### PR TITLE
build: docker image, compose, and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "pangenome-api",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "api",
+  "workspaceFolder": "/app",
+  "overrideCommand": true, //just run the fastapi dev command when you want
+  "shutdownAction": "stopCompose",
+  "forwardPorts": [8000],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+__pycache__
+*.pyc
+.env
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 *.cnf*
 *.JSON*
 
+#walk files
+*.walk.gz
+
 # python cache
 __pycache__
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ cache/
 extract_svg/
 archived/
 node_modules/
+
+# environment variables
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ RUN apt-get update && apt-get install -y \
 #build gbz-base
 RUN git clone https://github.com/jltsiren/gbz-base.git /build/gbz-base
 WORKDIR /build/gbz-base
-RUN cargo build --release
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/build/gbz-base/target \
+    cargo build --release && \
+    cp target/release/gbz2db /usr/local/bin/gbz2db && \
+    cp target/release/query /usr/local/bin/query
 
 #actual runtime
 FROM python:3.11-slim-bookworm
@@ -27,8 +31,8 @@ RUN apt-get update && apt-get install -y \
     g++ \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build/gbz-base/target/release/gbz2db /usr/local/bin/gbz2db
-COPY --from=builder /build/gbz-base/target/release/query /usr/local/bin/query
+COPY --from=builder /usr/local/bin/gbz2db /usr/local/bin/gbz2db
+COPY --from=builder /usr/local/bin/query /usr/local/bin/query
 RUN chmod +x /usr/local/bin/gbz2db /usr/local/bin/query
 
 #install gfabase from their precompiled binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,11 @@ RUN git clone https://github.com/CAST-genomics/panCT.git /opt/panct/panCT \
     && cd /opt/panct/panCT && git checkout 03c406b
 
 #fix ogdf and wheel to specific versions to avoid mismatch which currently exists
-RUN pip install --no-cache-dir pathlib "fastapi[standard]" pysam numpy click typer "ogdf-python==0.3.4" "ogdf-wheel==2023.9"
+RUN pip install --no-cache-dir "fastapi[standard]" pysam numpy click typer "ogdf-python==0.3.4" "ogdf-wheel==2023.9"
 
-COPY . /app
+# this should be uncommented if the code is needed in the image, but with docker
+# compose it shouldn't be (but with docker build it is)
+# COPY . /app
 
 RUN git config --global tools.path /opt/panct \
     && git config --global data.path /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+#gbz base build step
+FROM rust:1.95-slim-bookworm AS builder
+
+#get git
+RUN apt-get update && apt-get install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+#build gbz-base
+RUN git clone https://github.com/jltsiren/gbz-base.git /build/gbz-base
+WORKDIR /build/gbz-base
+RUN cargo build --release
+
+#actual runtime
+FROM python:3.11-slim-bookworm
+
+#get git, curl, pysam system deps, and cppyy build tools
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    zlib1g-dev \
+    libbz2-dev \
+    liblzma-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    cmake \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/gbz-base/target/release/gbz2db /usr/local/bin/gbz2db
+COPY --from=builder /build/gbz-base/target/release/query /usr/local/bin/query
+RUN chmod +x /usr/local/bin/gbz2db /usr/local/bin/query
+
+#install gfabase from their precompiled binary
+RUN curl -L https://github.com/mlin/gfabase/releases/download/v0.6.0/gfabase-linux-x86-64 \
+    -o /usr/local/bin/gfabase && \
+    chmod +x /usr/local/bin/gfabase
+
+WORKDIR /app
+
+#install deps & panct
+RUN git clone https://github.com/CAST-genomics/panCT.git /opt/panct/panCT \
+    && cd /opt/panct/panCT && git checkout 03c406b
+
+#fix ogdf and wheel to specific versions to avoid mismatch which currently exists
+RUN pip install --no-cache-dir pathlib "fastapi[standard]" pysam numpy click typer "ogdf-python==0.3.4" "ogdf-wheel==2023.9"
+
+COPY . /app
+
+RUN git config --global tools.path /opt/panct \
+    && git config --global data.path /data
+
+EXPOSE 8000
+VOLUME ["/data"]
+
+CMD ["fastapi", "dev", "--host", "0.0.0.0", "main.py"]
+
+# instructions to run docker image:
+# build image (run from project root):
+#   docker build -t pangenome-api .
+# start container
+#   docker run -p 8000:8000 -v /data:/data -v "$(pwd)":/app pangenome-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,24 @@ RUN git clone https://github.com/CAST-genomics/panCT.git /opt/panct/panCT \
 #fix ogdf and wheel to specific versions to avoid mismatch which currently exists
 RUN pip install --no-cache-dir "fastapi[standard]" pysam numpy click typer "ogdf-python==0.3.4" "ogdf-wheel==2023.9"
 
+#install vg from precompiled static binary (instead of conda)
+RUN curl -L https://github.com/vgteam/vg/releases/download/v1.75.0/vg \
+    -o /usr/local/bin/vg && \
+    chmod +x /usr/local/bin/vg
+
+#install node.js from tarball (version 24.9.0)
+RUN curl -L https://nodejs.org/dist/v24.9.0/node-v24.9.0-linux-x64.tar.gz \
+    -o /tmp/node.tar.gz && \
+    tar -xzf /tmp/node.tar.gz -C /usr/local --strip-components=1 && \
+    rm /tmp/node.tar.gz
+
+#move node modules to root since . is mounted into /app
+COPY package.json package-lock.json /tmp/npm/
+RUN --mount=type=cache,target=/root/.npm \
+    cd /tmp/npm && npm ci && \
+    mv /tmp/npm/node_modules / && \
+    rm -rf /tmp/npm
+
 # this should be uncommented if the code is needed in the image, but with docker
 # compose it shouldn't be (but with docker build it is)
 # COPY . /app
@@ -57,12 +75,3 @@ RUN git config --global tools.path /opt/panct \
     && git config --global data.path /data
 
 EXPOSE 8000
-
-# instructions to run docker image:
-# build and start image:
-#   docker compose up --build
-# if image has already been built & doesn't need to be re-built, can simply run:
-#   docker compose up
-
-# to stop the docker image:
-#   docker compose down

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,12 +55,12 @@ RUN git config --global tools.path /opt/panct \
     && git config --global data.path /data
 
 EXPOSE 8000
-VOLUME ["/data"]
-
-CMD ["fastapi", "dev", "--host", "0.0.0.0", "main.py"]
 
 # instructions to run docker image:
-# build image (run from project root):
-#   docker build -t pangenome-api .
-# start container
-#   docker run -p 8000:8000 -v /data:/data -v "$(pwd)":/app pangenome-api
+# build and start image:
+#   docker compose up --build
+# if image has already been built & doesn't need to be re-built, can simply run:
+#   docker compose up
+
+# to stop the docker image:
+#   docker compose down

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,32 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp target/release/gbz2db /usr/local/bin/gbz2db && \
     cp target/release/query /usr/local/bin/query
 
+# compile adaptagrams & generate swig bindings
+# note: needs to be the same python version as runtime
+FROM python:3.11-slim-bookworm AS adaptagrams-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    build-essential \
+    swig \
+    autoconf \
+    automake \
+    libtool \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir setuptools
+
+RUN git clone https://github.com/mjwybrow/adaptagrams.git /build/adaptagrams \
+    && cd /build/adaptagrams && git checkout 840ebcff
+
+WORKDIR /build/adaptagrams/cola
+RUN mkdir -p m4 \
+    && autoreconf --install --verbose \
+    && ./configure \
+    && make -j"$(nproc)" \
+    && make -f Makefile-swig-python
+    
 #actual runtime
 FROM python:3.11-slim-bookworm
 
@@ -67,6 +93,10 @@ RUN --mount=type=cache,target=/root/.npm \
     mv /tmp/npm/node_modules / && \
     rm -rf /tmp/npm
 
+# binary + bindings, and add adaptagrams to pythonpath so import finds it
+COPY --from=adaptagrams-builder /build/adaptagrams/cola/adaptagrams.py /opt/adaptagrams/
+COPY --from=adaptagrams-builder /build/adaptagrams/cola/_adaptagrams*.so /opt/adaptagrams/
+ENV PYTHONPATH=/opt/adaptagrams
 # this should be uncommented if the code is needed in the image, but with docker
 # compose it shouldn't be (but with docker build it is)
 # COPY . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ name: pangenome
 services:
   api:
     build: .
+    platform: linux/amd64
     command: ["fastapi", "dev", "--host", "0.0.0.0", "main.py"]
     ports:
       - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
       - PYTHONUNBUFFERED=1
     volumes:
       - .:/app
-      - ./data:/data
+      - ../data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+name: pangenome
 services:
   api:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       - PYTHONUNBUFFERED=1
     volumes:
       - .:/app
-      - ../data:/data
+      - ${DATA_DIR:-../data}:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   api:
     build: .
+    command: ["fastapi", "dev", "--host", "0.0.0.0", "main.py"]
     ports:
       - "8000:8000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  api:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - PYTHONUNBUFFERED=1
+    volumes:
+      - .:/app
+      - ./data:/data


### PR DESCRIPTION
# Dockerfile and compose
Implements a docker image (in `Dockerfile`) that contains all necessary dependencies, up to seqtubemap.

## First time build
Run
```bash
docker compose up --build
```
This will build the docker image (may take a bit), mount necessary volumes, and run `fastapi dev --host "0.0.0.0" main.py`. The server should be accessible immediately, assuming repository structure is correct (data directory containing `.gfa`, `.gbz`, `.tbi`, etc. files should be *parallel* to the repository - this was to prevent the data files existing in the docker build cache)

## Starting without rebuilding
Simply omit the `--build` tag
```bash
docker compose up
```
This starts up the docker image, but does not rebuild. Rebuilding shouldn't be necessary unless something in the dockerfile is changed.

Optionally you could run it with the `-d` flag, which runs the docker image in the detached state. This lets you continue to use whatever shell you ran it in. I typically do not do this and instead just open a new shell, since the debug log is not shown in the detached state.

## Stopping the image
Run
```bash
docker compose down
```

# Specifying different data directory
Currently, data directory defaults to `../data`. To specify a different path, create a file `.env`. In it, add
```
DATA_DIR=[path to data]
```
(where the brackets are omitted and "path to data" is the actual relative (or absolute) path to your data directory)

Here's what it would look like for the default:
```
DATA_DIR=../data
```

# Devcontainer
I also added a devcontainer, so you don't need to locally install all the dependencies (ASSUMING you are developing in VSCode). All that's necessary for this is to have the devcontainers extension (see [their official instructions on using devcontainers](https://code.visualstudio.com/docs/devcontainers/containers)). Then, when you open the repo in VSCode, it will prompt you to reopen in the devcontainer (in the bottom righthand corner). If you click reopen, it will let you use VSCode as if your machine was the docker image.

It is worth noting that many of the dependencies are x86-64 binaries, so if using arm64 silicon, you may need to enable a docker setting which performs emulation. I pinned the platform to `linux/amd64` in the compose file, so the emulation should be on by default, but just worth noting.