### PR TITLE
feat: implement linearization

### DIFF
--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -123,7 +123,7 @@ class AdaptagramsGraph:
 
             self._add_edge(first_idx, second_idx, edge_len)
 
-    def _resolve(self, node):
+    def resolve(self, node):
         """Get whichever node is in layout (node or its reverse compliment)"""
         if self._node_in_layout(node):
             return node
@@ -141,8 +141,8 @@ class AdaptagramsGraph:
             edge.DetermineIfDrawn()
             if not edge.isDrawn():
                 continue
-            u = self._resolve(edge.startingNode)
-            v = self._resolve(edge.endingNode)
+            u = self.resolve(edge.startingNode)
+            v = self.resolve(edge.endingNode)
             if u in nodes and v in nodes and u is not v:
                 child[u] = v
                 has_parent.add(v)

--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -23,6 +23,7 @@ class AdaptagramsGraph:
         self.rs = adap.RectanglePtrs()
         self.es = adap.ColaEdges()
         self.edge_lengths = []
+        self._internal_edges = set()
 
         self.node_to_rects = {}
         self._fixed = set()
@@ -54,7 +55,9 @@ class AdaptagramsGraph:
         self.rs.push_back(r)
         return idx
 
-    def _add_edge(self, i, j, ideal_length):
+    def _add_edge(self, i, j, ideal_length, internal=False):
+        if internal:
+            self._internal_edges.add(len(self.edge_lengths))
         self.es.push_back(adap.ColaEdge(i, j))
         self.edge_lengths.append(float(ideal_length))
 
@@ -77,7 +80,7 @@ class AdaptagramsGraph:
                 idx = self._new_rect(seg_len)
                 chain.append(idx)
                 if i > 0:
-                    self._add_edge(prev_idx, idx, seg_len)
+                    self._add_edge(prev_idx, idx, seg_len, internal=True)
                 prev_idx = idx
 
             self.node_to_rects[node] = chain
@@ -222,6 +225,8 @@ class AdaptagramsGraph:
         """Makes non asm edges point forward"""
         cs = adap.CompoundConstraintPtrs()
         for k in range(len(self.edge_lengths)):
+            if k in self._internal_edges:
+                continue
             e = self.es[k]
             i, j = (e.first, e.second) if hasattr(e, "first") else (e[0], e[1])
             if i in self._fixed or j in self._fixed:

--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -226,22 +226,18 @@ class AdaptagramsGraph:
             i, j = (e.first, e.second) if hasattr(e, "first") else (e[0], e[1])
             if i in self._fixed or j in self._fixed:
                 continue
-            cs.push_back(adap.SeparationConstraint(adap.XDIM, i, j, 0.0))
+            cs.push_back(adap.SeparationConstraint(adap.XDIM, i, j, 0.5))
         return cs
 
     def build_fd_layout(self, ideal_length=1.0):
         """Builds and runs fd layout"""
-        #lock each assembly rect at its seeded (linear) position
-        self._locks = adap.ColaLocks()
-        for idx in self._fixed:
-            r = self.rs[idx]
-            self._locks.push_back(adap.Lock(idx, r.getCentreX(), r.getCentreY()))
-        self._pre = adap.PreIteration(self._locks)
+        self._constraints = self._forward_x_constraints()
+        self._fixed_rel = adap.FixedRelativeConstraint(
+            self.rs, adap.Unsigneds(list(self._fixed)), True)
+        self._constraints.push_back(self._fixed_rel)
 
         self._fd = adap.ConstrainedFDLayout(self.rs, self.es, ideal_length,
-                                            adap.Doubles(self.edge_lengths),
-                                            None, self._pre)
-        self._constraints = self._forward_x_constraints()
+                                            adap.Doubles(self.edge_lengths))
         self._fd.setConstraints(self._constraints)
         self._fd.setAvoidNodeOverlaps(True)
         return self._fd
@@ -251,8 +247,7 @@ class AdaptagramsGraph:
         Drop all our C++ refs so they can be garbage collected
         """
         self._fd = None
-        self._pre = None
-        self._locks = None
+        self._fixed_rel = None
         self._constraints = None
         self.rs = None
         self.es = None

--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -95,14 +95,22 @@ class AdaptagramsGraph:
             return rc
         return None
 
+    def _matches(self, node):
+        """True if node has an entry for the selected assembly + haplotype"""
+        for entry in node.m_nd_assembly + node.m_dup_assembly:
+            if entry["assembly_name"] == self._assembly and \
+                    (self._haplotype is None or entry["haplotype"] == self._haplotype):
+                return True
+        return False
+
     def _is_asm(self, node):
-        """True if node (or its rc) belongs to the selected assembly"""
+        """True if node (or its rc) belongs to the selected assembly+haplotype"""
         r = self.resolve(node)
-        return r is not None and self._assembly in r.m_assembly
+        return r is not None and self._matches(r)
 
     def _is_asm_name(self, name):
         node = self.pggraph.pgnodes.get(name)
-        return node is not None and self._assembly in node.m_assembly
+        return node is not None and self._matches(node)
 
     def _node_width(self, name):
         return self.pggraph.pgnodes[name].GetDrawnNodeLength()
@@ -188,11 +196,13 @@ class AdaptagramsGraph:
 
             arc_idx += 1
 
-    def seed_linear_layout(self, assembly, y=None, branch_gap=None):
+    def seed_linear_layout(self, assembly, haplotype=None):
         """
-        Initial placement of spine and bubbles
+        Initial placement of spine and bubbles.
+        haplotype filters to one haplotype of assembly; `None` = all.
         """
         self._assembly = assembly
+        self._haplotype = haplotype
         self._spine_y = 0.0
 
         out_adj, in_adj = build_adjacency(self.pggraph)

--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -133,25 +133,29 @@ class AdaptagramsGraph:
         return None
 
     def _assembly_topo_order(self, assembly):
-        """Linear walk down selected assembly, starting from head (node with indegree 0)"""
+        """Topological sort of selected assembly using Kahn's"""
         nodes = {n for n in self.node_to_rects if assembly in n.m_assembly}
-        child = {}
-        has_parent = set()
+        children = {n: set() for n in nodes}
+        indeg = {n: 0 for n in nodes}
         for edge in self.pggraph.pgedges.values():
             edge.DetermineIfDrawn()
             if not edge.isDrawn():
                 continue
             u = self.resolve(edge.startingNode)
             v = self.resolve(edge.endingNode)
-            if u in nodes and v in nodes and u is not v:
-                child[u] = v
-                has_parent.add(v)
+            if u in nodes and v in nodes and u is not v and v not in children[u]:
+                children[u].add(v)
+                indeg[v] += 1
 
-        head = next((n for n in nodes if n not in has_parent), None)
+        frontier = [n for n in nodes if indeg[n] == 0]
         order = []
-        while head is not None:
-            order.append(head)
-            head = child.get(head)
+        while frontier:
+            u = frontier.pop()
+            order.append(u)
+            for v in children[u]:
+                indeg[v] -= 1
+                if indeg[v] == 0:
+                    frontier.append(v)
         return order
 
     def seed_linear_layout(self, assembly, y=None, branch_gap=None, iters=20):

--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -1,17 +1,26 @@
+import math
+from collections import deque
+
 import adaptagrams as adap
+
+from bubble_finding import build_adjacency, find_all_bubbles
+
+NODE_SPACING = 30.0   #horizontal gap between consecutive nodes
+
 
 class AdaptagramsGraph:
     """
-    Builds adaptagrams (libcola) layout inputs from a PGGraph for linear alignment.
+    Builds adaptagrams layout inputs from a PGGraph for linear
+    alignment.
 
     Attributes
     ==========
     rs : adaptagrams.RectanglePtrs
-        All segment rectangles
+        All subnode rectangles
     es : adaptagrams.ColaEdges
-        All edges, including internal & external
+        FD spring edges: non-asm internal chains + external edges (excl. asm<->asm)
     edge_lengths : list[float]
-        Ideal length per edge in es, same order/len as es
+        Per-edge ideal-length weight, same order/len as es
     node_to_rects : dict[PGNode, list[int]]
         Mapping of node to its ordered rect indices
     """
@@ -19,11 +28,12 @@ class AdaptagramsGraph:
     def __init__(self, pggraph, rect_size=1.0):
         self.pggraph = pggraph
         self.rect_size = rect_size
+        self._base_ideal = pggraph.m_settings.get("NODESEGLEN", 20.0)
+        self._weight = NODE_SPACING / self._base_ideal
 
         self.rs = adap.RectanglePtrs()
         self.es = adap.ColaEdges()
         self.edge_lengths = []
-        self._internal_edges = set()
 
         self.node_to_rects = {}
         self._fixed = set()
@@ -33,7 +43,6 @@ class AdaptagramsGraph:
 
         self._mark_drawn()
         self._add_nodes()
-        self._add_edges()
 
     def _mark_drawn(self):
         for node in self.pggraph.pgnodes.values():
@@ -55,35 +64,20 @@ class AdaptagramsGraph:
         self.rs.push_back(r)
         return idx
 
-    def _add_edge(self, i, j, ideal_length, internal=False):
-        if internal:
-            self._internal_edges.add(len(self.edge_lengths))
+    def _add_edge(self, i, j):
         self.es.push_back(adap.ColaEdge(i, j))
-        self.edge_lengths.append(float(ideal_length))
+        self.edge_lengths.append(self._weight)
 
     def _add_nodes(self):
-        """
-        Adds every drawn node to the graph, including bandage subnodes
-        """
+        """One rect per subnode for every drawn node"""
         for node in self.pggraph.pgnodes.values():
             if not node.isDrawn() or self._this_or_rc_in_layout(node):
                 continue
-
             drawn_len = node.GetDrawnNodeLength()
             num_edges = node.GetNumOgdfGraphEdges(drawn_len)
-            seg_len = drawn_len / num_edges
-
-            #add rect for each subnode
-            chain = []
-            prev_idx = None
-            for i in range(num_edges + 1):
-                idx = self._new_rect(seg_len)
-                chain.append(idx)
-                if i > 0:
-                    self._add_edge(prev_idx, idx, seg_len, internal=True)
-                prev_idx = idx
-
-            self.node_to_rects[node] = chain
+            self.node_to_rects[node] = [
+                self._new_rect(2.0) for _ in range(num_edges + 1)
+            ]
 
     #simple accessors just to help readability a bit
     def _chain_last(self, node):
@@ -91,40 +85,6 @@ class AdaptagramsGraph:
 
     def _chain_first(self, node):
         return self.node_to_rects[node][0]
-
-    def _add_edges(self):
-        edge_len = self.pggraph.m_settings["EDGELEN"]
-        for edge in self.pggraph.pgedges.values():
-            edge.DetermineIfDrawn()
-            if not edge.isDrawn():
-                continue
-
-            start = edge.startingNode
-            end = edge.endingNode
-
-            #pretty much the same logic as AddEdgeToOGDFGraph in bandage_graph.py
-            if self._node_in_layout(start):
-                first_idx = self._chain_last(start)
-            elif start.getReverseComplement() is not None and \
-                    self._node_in_layout(start.getReverseComplement()):
-                first_idx = self._chain_first(start.getReverseComplement())
-            else:
-                continue
-
-            if self._node_in_layout(end):
-                second_idx = self._chain_first(end)
-            elif end.getReverseComplement() is not None and \
-                    self._node_in_layout(end.getReverseComplement()):
-                second_idx = self._chain_last(end.getReverseComplement())
-            else:
-                continue
-
-            #skip single-segment self connecting nodes
-            drawn_len = start.GetDrawnNodeLength()
-            if start == end and start.GetNumOgdfGraphEdges(drawn_len) == 1:
-                continue
-
-            self._add_edge(first_idx, second_idx, edge_len)
 
     def resolve(self, node):
         """Get whichever node is in layout (node or its reverse compliment)"""
@@ -135,116 +95,269 @@ class AdaptagramsGraph:
             return rc
         return None
 
-    def _assembly_topo_order(self, assembly):
-        """Topological sort of selected assembly using Kahn's"""
-        nodes = {n for n in self.node_to_rects if assembly in n.m_assembly}
-        children = {n: set() for n in nodes}
-        indeg = {n: 0 for n in nodes}
+    def _is_asm(self, node):
+        """True if node (or its rc) belongs to the selected assembly"""
+        r = self.resolve(node)
+        return r is not None and self._assembly in r.m_assembly
+
+    def _is_asm_name(self, name):
+        node = self.pggraph.pgnodes.get(name)
+        return node is not None and self._assembly in node.m_assembly
+
+    def _node_width(self, name):
+        return self.pggraph.pgnodes[name].GetDrawnNodeLength()
+
+    def _place_chain(self, name, x, y):
+        """Place a node's subnode rects starting at (x, y), spanning drawn length"""
+        node = self.pggraph.pgnodes[name]
+        chain = self.node_to_rects[node]
+        n = len(chain)
+        if n == 1:
+            self.rs[chain[0]].moveCentreX(x)
+            self.rs[chain[0]].moveCentreY(y)
+            return
+        seg = node.GetDrawnNodeLength() / (n - 1)
+        for i, idx in enumerate(chain):
+            self.rs[idx].moveCentreX(x + i * seg)
+            self.rs[idx].moveCentreY(y)
+
+    def _place_bubble_interior(self, bubble, out_adj, in_adj, placed,
+                               bubble_by_source, junction_x, start_parity=0):
+        """
+        Seed non-asm interior nodes of a bubble.
+        """
+        interior_set = set(bubble.interior)
+
+        in_cnt = {
+            n: sum(1 for p in in_adj.get(n, []) if p in interior_set)
+            for n in interior_set
+        }
+        q = deque(n for n in interior_set if in_cnt[n] == 0)
+        topo = []
+        seen = set()
+        while q:
+            n = q.popleft()
+            if n in seen:
+                continue
+            seen.add(n)
+            topo.append(n)
+            for nb in out_adj.get(n, []):
+                if nb in interior_set and nb not in seen:
+                    in_cnt[nb] -= 1
+                    if in_cnt[nb] == 0:
+                        q.append(nb)
+        for n in interior_set:
+            if n not in seen:
+                topo.append(n)
+
+        direct_nonasm = [n for n in topo if not self._is_asm_name(n) and n not in placed]
+        n = len(direct_nonasm)
+        R = NODE_SPACING * max(1.0, n / (2 * math.pi))
+        above = (start_parity % 2 == 0)
+
+        arc_idx = 0
+        sub_count = 0
+        for iname in topo:
+            if iname in placed:
+                continue
+            sub = bubble_by_source.get(iname)
+            has_sub = sub is not None and sub is not bubble
+
+            if self._is_asm_name(iname):
+                if has_sub:
+                    self._place_bubble_interior(
+                        sub, out_adj, in_adj, placed, bubble_by_source,
+                        junction_x=junction_x,
+                        start_parity=(start_parity + sub_count + 1) % 2)
+                    sub_count += 1
+                continue
+
+            theta = 2 * math.pi * (arc_idx + 1) / (n + 1)
+            x0 = junction_x + R * math.sin(theta)
+            y0 = R * (1 - math.cos(theta)) * (1 if above else -1)
+
+            self._place_chain(iname, x0, y0)
+            placed.add(iname)
+
+            if has_sub:
+                self._place_bubble_interior(
+                    sub, out_adj, in_adj, placed, bubble_by_source,
+                    junction_x=x0 + self._node_width(iname),
+                    start_parity=(start_parity + sub_count + 1) % 2)
+                sub_count += 1
+
+            arc_idx += 1
+
+    def seed_linear_layout(self, assembly, y=None, branch_gap=None):
+        """
+        Initial placement of spine and bubbles
+        """
+        self._assembly = assembly
+        self._spine_y = 0.0
+
+        out_adj, in_adj = build_adjacency(self.pggraph)
+
+        #topo ordering
+        asm_set = {n for n in out_adj if self._is_asm_name(n)}
+        in_count = {
+            n: sum(1 for p in in_adj.get(n, []) if p in asm_set)
+            for n in asm_set
+        }
+        queue = deque(n for n in asm_set if in_count[n] == 0)
+        asm_order = []
+        while queue:
+            n = queue.popleft()
+            asm_order.append(n)
+            for nb in out_adj.get(n, []):
+                if nb in asm_set:
+                    in_count[nb] -= 1
+                    if in_count[nb] == 0:
+                        queue.append(nb)
+        self._asm_order = asm_order
+
+        bubbles = find_all_bubbles(self.pggraph, out_adj, in_adj)
+        bubble_by_source = {b.source: b for b in bubbles}
+
+        placed = set()
+        spine_x = 0.0
+        for name in asm_order:
+            if name in placed:
+                continue
+            self._place_chain(name, spine_x, 0.0)
+            spine_x += self._node_width(name)
+            placed.add(name)
+
+            bubble = bubble_by_source.get(name)
+            if bubble is None:
+                continue
+            self._place_bubble_interior(
+                bubble, out_adj, in_adj, placed, bubble_by_source,
+                junction_x=spine_x)
+
+        # asm rect indices, for the spine y-alignment constraint
+        self._fixed = set()
+        for name in asm_set:
+            node = self.pggraph.pgnodes.get(name)
+            if node in self.node_to_rects:
+                self._fixed.update(self.node_to_rects[node])
+
+        self._build_springs()
+
+    def _edge_rects(self, edge):
+        start, end = edge.startingNode, edge.endingNode
+        if self._node_in_layout(start):
+            i = self._chain_last(start)
+        elif start.getReverseComplement() is not None and \
+                self._node_in_layout(start.getReverseComplement()):
+            i = self._chain_first(start.getReverseComplement())
+        else:
+            return None
+        if self._node_in_layout(end):
+            j = self._chain_first(end)
+        elif end.getReverseComplement() is not None and \
+                self._node_in_layout(end.getReverseComplement()):
+            j = self._chain_last(end.getReverseComplement())
+        else:
+            return None
+        return i, j
+
+    def _build_springs(self):
+        #internal chains: non-asm nodes only
+        for node, chain in self.node_to_rects.items():
+            if self._is_asm(node):
+                continue
+            for a, b in zip(chain, chain[1:]):
+                self._add_edge(a, b)
+
+        #external edges between nodes
         for edge in self.pggraph.pgedges.values():
             edge.DetermineIfDrawn()
             if not edge.isDrawn():
                 continue
-            u = self.resolve(edge.startingNode)
-            v = self.resolve(edge.endingNode)
-            if u in nodes and v in nodes and u is not v and v not in children[u]:
-                children[u].add(v)
-                indeg[v] += 1
+            rects = self._edge_rects(edge)
+            if rects is None:
+                continue
+            i, j = rects
 
-        frontier = [n for n in nodes if indeg[n] == 0]
-        order = []
-        while frontier:
-            u = frontier.pop()
-            order.append(u)
-            for v in children[u]:
-                indeg[v] -= 1
-                if indeg[v] == 0:
-                    frontier.append(v)
-        return order
+            #skip single-segment self connecting nodes (avoids a self-edge)
+            start = edge.startingNode
+            drawn_len = start.GetDrawnNodeLength()
+            if start == edge.endingNode and start.GetNumOgdfGraphEdges(drawn_len) == 1:
+                continue
 
-    def seed_linear_layout(self, assembly, y=None, branch_gap=None):
-        """Seed initial rect positions for fd, including assembly & non-assembly branches"""
-        if y is None:
-            y = self.rect_size / 2.0
-        if branch_gap is None:
-            branch_gap = self.pggraph.m_settings["EDGELEN"]
+            if self._is_asm(start) and self._is_asm(edge.endingNode):
+                continue
 
-        self._fixed = set()
-        x = 0.0
-        for node in self._assembly_topo_order(assembly):
-            chain = self.node_to_rects[node]
-            drawn_len = node.GetDrawnNodeLength()
-            #same per-edge length as _add_nodes so node spans its true drawn length
-            seg_len = drawn_len / node.GetNumOgdfGraphEdges(drawn_len)
-            for i, idx in enumerate(chain):
-                self.rs[idx].moveCentreX(x + i * seg_len)
-                self.rs[idx].moveCentreY(y)
-                self._fixed.add(idx)
-            x += (len(chain) - 1) * seg_len
-
-        self._seed_branches(self._fixed, y, branch_gap)
-
-    def _rect_adjacency(self):
-        """Adjacency matrix over all rects in graph"""
-        adj = {i: [] for i in range(len(self._rect_objs))}
-        for k in range(len(self.edge_lengths)):
-            e = self.es[k]
-            a, b = (e.first, e.second) if hasattr(e, "first") else (e[0], e[1])
-            adj[a].append(b)
-            adj[b].append(a)
-        return adj
-
-    def _seed_branches(self, fixed, base_y, gap):
-        adj = self._rect_adjacency()
-        seen = set(fixed)
-        x = {i: self.rs[i].getCentreX() for i in fixed}
-
-        def walk(cur, prev, level):
-            y = base_y + level * gap
-            while cur is not None and cur not in seen:
-                seen.add(cur)
-                x[cur] = x[prev] + gap
-                self.rs[cur].moveCentreX(x[cur])
-                self.rs[cur].moveCentreY(y)
-                nbrs = [w for w in adj[cur] if w not in seen]
-                prev, cur = cur, (nbrs[0] if nbrs else None)
-                #rest are subbubbles
-                for w in nbrs[1:]:
-                    walk(w, prev, level + 1)
-
-        #first layer neighbors are starts of bubbles
-        for f in list(fixed):
-            for w in adj[f]:
-                walk(w, f, 1)
+            self._add_edge(i, j)
 
     def get_segment_coordinates(self, node):
         """Gets rect centers for every rect in node"""
         return [(self.rs[idx].getCentreX(), self.rs[idx].getCentreY())
                 for idx in self.node_to_rects[node]]
 
-    def _forward_x_constraints(self):
-        """Makes non asm edges point forward"""
-        cs = adap.CompoundConstraintPtrs()
-        for k in range(len(self.edge_lengths)):
-            if k in self._internal_edges:
-                continue
-            e = self.es[k]
-            i, j = (e.first, e.second) if hasattr(e, "first") else (e[0], e[1])
-            if i in self._fixed or j in self._fixed:
-                continue
-            cs.push_back(adap.SeparationConstraint(adap.XDIM, i, j, 0.5))
+    def _spine_alignment(self):
+        """Pin every assembly rect onto one horizontal line"""
+        ac = adap.AlignmentConstraint(adap.YDIM, self._spine_y)
+        for idx in self._fixed:
+            ac.addShape(idx, 0.0)
+        ac.fixPos(self._spine_y)
+        return ac
+
+    def _spine_x_chain(self):
+        """
+        Rigid front-to-back x ordering of assembly rects
+        """
+        cs = []
+        prev = None
+        for name in self._asm_order:
+            chain = self.node_to_rects[self.pggraph.pgnodes[name]]
+            for k, idx in enumerate(chain):
+                if prev is not None:
+                    gap = NODE_SPACING if k > 0 else 0.0
+                    cs.append(adap.SeparationConstraint(adap.XDIM, prev, idx, gap, True))
+                prev = idx
         return cs
 
-    def build_fd_layout(self, ideal_length=1.0):
-        """Builds and runs fd layout"""
-        self._constraints = self._forward_x_constraints()
-        self._fixed_rel = adap.FixedRelativeConstraint(
-            self.rs, adap.Unsigneds(list(self._fixed)), True)
-        self._constraints.push_back(self._fixed_rel)
+    def _branch_y_separations(self):
+        """
+        Pin each non-asm subnode exactly NODE_SPACING off the spine along every
+        asm<->non-asm edge.
+        """
+        cs = []
+        for edge in self.pggraph.pgedges.values():
+            edge.DetermineIfDrawn()
+            if not edge.isDrawn():
+                continue
+            rects = self._edge_rects(edge)
+            if rects is None:
+                continue
+            i, j = rects
+            u_asm = self._is_asm(edge.startingNode)
+            v_asm = self._is_asm(edge.endingNode)
+            if u_asm == v_asm:
+                continue
+            asm_idx, nonasm_idx = (i, j) if u_asm else (j, i)
+            if self.rs[nonasm_idx].getCentreY() >= self._spine_y:
+                cs.append(adap.SeparationConstraint(adap.YDIM, asm_idx, nonasm_idx, NODE_SPACING, True))
+            else:
+                cs.append(adap.SeparationConstraint(adap.YDIM, nonasm_idx, asm_idx, NODE_SPACING, True))
+        return cs
+
+    def build_fd_layout(self, ideal_length=None):
+        """Builds fd layout with the linear-alignment constraints"""
+        if ideal_length is None:
+            ideal_length = self._base_ideal / 1.5
+
+        self._constraints = adap.CompoundConstraintPtrs()
+        self._constraints.push_back(self._spine_alignment())
+        for c in self._spine_x_chain():
+            self._constraints.push_back(c)
+        for c in self._branch_y_separations():
+            self._constraints.push_back(c)
 
         self._fd = adap.ConstrainedFDLayout(self.rs, self.es, ideal_length,
                                             adap.Doubles(self.edge_lengths))
         self._fd.setConstraints(self._constraints)
-        self._fd.setAvoidNodeOverlaps(True)
         return self._fd
 
     def close(self):
@@ -252,7 +365,6 @@ class AdaptagramsGraph:
         Drop all our C++ refs so they can be garbage collected
         """
         self._fd = None
-        self._fixed_rel = None
         self._constraints = None
         self.rs = None
         self.es = None

--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -62,13 +62,13 @@ class AdaptagramsGraph:
         """
         Adds every drawn node to the graph, including bandage subnodes
         """
+        seg_len = self.pggraph.m_settings["NODESEGLEN"]
         for node in self.pggraph.pgnodes.values():
             if not node.isDrawn() or self._this_or_rc_in_layout(node):
                 continue
 
             drawn_len = node.GetDrawnNodeLength()
             num_edges = node.GetNumOgdfGraphEdges(drawn_len)
-            len_per_edge = drawn_len / num_edges
 
             #add rect for each subnode
             chain = []
@@ -77,7 +77,7 @@ class AdaptagramsGraph:
                 idx = self._new_rect()
                 chain.append(idx)
                 if i > 0:
-                    self._add_edge(prev_idx, idx, len_per_edge)
+                    self._add_edge(prev_idx, idx, seg_len)
                 prev_idx = idx
 
             self.node_to_rects[node] = chain
@@ -163,19 +163,18 @@ class AdaptagramsGraph:
         if y is None:
             y = self.rect_size / 2.0
         if branch_gap is None:
-            branch_gap = self.rect_size
+            branch_gap = self.pggraph.m_settings["EDGELEN"]
 
+        seg_len = self.pggraph.m_settings["NODESEGLEN"]
         fixed = set()
         x = 0.0
         for node in self._assembly_topo_order(assembly):
             chain = self.node_to_rects[node]
-            drawn_len = node.GetDrawnNodeLength()
-            step = drawn_len / (len(chain) - 1) if len(chain) > 1 else 0.0
             for i, idx in enumerate(chain):
-                self.rs[idx].moveCentreX(x + i * step)
+                self.rs[idx].moveCentreX(x + i * seg_len)
                 self.rs[idx].moveCentreY(y)
                 fixed.add(idx)
-            x += drawn_len
+            x += (len(chain) - 1) * seg_len
 
         self._seed_branches(fixed, y, branch_gap, iters)
 

--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -47,9 +47,8 @@ class AdaptagramsGraph:
         rc = node.getReverseComplement()
         return self._node_in_layout(node) or (rc is not None and self._node_in_layout(rc))
 
-    def _new_rect(self):
-        #a rect_size x rect_size rect (spanning from 0 to rect_size)
-        r = adap.Rectangle(0.0, self.rect_size, 0.0, self.rect_size)
+    def _new_rect(self, width):
+        r = adap.Rectangle(0.0, width, 0.0, self.rect_size)
         idx = len(self._rect_objs)
         self._rect_objs.append(r)
         self.rs.push_back(r)
@@ -75,7 +74,7 @@ class AdaptagramsGraph:
             chain = []
             prev_idx = None
             for i in range(num_edges + 1):
-                idx = self._new_rect()
+                idx = self._new_rect(seg_len)
                 chain.append(idx)
                 if i > 0:
                     self._add_edge(prev_idx, idx, seg_len)

--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -25,6 +25,7 @@ class AdaptagramsGraph:
         self.edge_lengths = []
 
         self.node_to_rects = {}
+        self._fixed = set()
 
         #need to store rect pointers so they don't get garbage collected mid-layout
         self._rect_objs = []
@@ -166,17 +167,17 @@ class AdaptagramsGraph:
             branch_gap = self.pggraph.m_settings["EDGELEN"]
 
         seg_len = self.pggraph.m_settings["NODESEGLEN"]
-        fixed = set()
+        self._fixed = set()
         x = 0.0
         for node in self._assembly_topo_order(assembly):
             chain = self.node_to_rects[node]
             for i, idx in enumerate(chain):
                 self.rs[idx].moveCentreX(x + i * seg_len)
                 self.rs[idx].moveCentreY(y)
-                fixed.add(idx)
+                self._fixed.add(idx)
             x += (len(chain) - 1) * seg_len
 
-        self._seed_branches(fixed, y, branch_gap, iters)
+        self._seed_branches(self._fixed, y, branch_gap, iters)
 
     def _rect_adjacency(self):
         """Adjacency matrix over all rects in graph"""
@@ -226,8 +227,19 @@ class AdaptagramsGraph:
                 for idx in self.node_to_rects[node]]
 
     def build_fd_layout(self, ideal_length=1.0):
+        """Builds and runs fd layout"""
+        #lock each assembly rect at its seeded (linear) position
+        self._locks = adap.ColaLocks()
+        for idx in self._fixed:
+            r = self.rs[idx]
+            self._locks.push_back(adap.Lock(idx, r.getCentreX(), r.getCentreY()))
+        self._pre = adap.PreIteration(self._locks)
+
         self._fd = adap.ConstrainedFDLayout(self.rs, self.es, ideal_length,
-                                            adap.Doubles(self.edge_lengths))
+                                            adap.Doubles(self.edge_lengths),
+                                            None, self._pre)
+        self._fd.setAvoidNodeOverlaps(True)
+        self._fd.run()
         return self._fd
 
     def close(self):
@@ -235,6 +247,8 @@ class AdaptagramsGraph:
         Drop all our C++ refs so they can be garbage collected
         """
         self._fd = None
+        self._pre = None
+        self._locks = None
         self.rs = None
         self.es = None
         self.node_to_rects.clear()

--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -218,6 +218,17 @@ class AdaptagramsGraph:
         return [(self.rs[idx].getCentreX(), self.rs[idx].getCentreY())
                 for idx in self.node_to_rects[node]]
 
+    def _forward_x_constraints(self):
+        """Makes non asm edges point forward"""
+        cs = adap.CompoundConstraintPtrs()
+        for k in range(len(self.edge_lengths)):
+            e = self.es[k]
+            i, j = (e.first, e.second) if hasattr(e, "first") else (e[0], e[1])
+            if i in self._fixed or j in self._fixed:
+                continue
+            cs.push_back(adap.SeparationConstraint(adap.XDIM, i, j, 0.0))
+        return cs
+
     def build_fd_layout(self, ideal_length=1.0):
         """Builds and runs fd layout"""
         #lock each assembly rect at its seeded (linear) position
@@ -230,6 +241,8 @@ class AdaptagramsGraph:
         self._fd = adap.ConstrainedFDLayout(self.rs, self.es, ideal_length,
                                             adap.Doubles(self.edge_lengths),
                                             None, self._pre)
+        self._constraints = self._forward_x_constraints()
+        self._fd.setConstraints(self._constraints)
         self._fd.setAvoidNodeOverlaps(True)
         return self._fd
 
@@ -240,6 +253,7 @@ class AdaptagramsGraph:
         self._fd = None
         self._pre = None
         self._locks = None
+        self._constraints = None
         self.rs = None
         self.es = None
         self.node_to_rects.clear()

--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -63,13 +63,13 @@ class AdaptagramsGraph:
         """
         Adds every drawn node to the graph, including bandage subnodes
         """
-        seg_len = self.pggraph.m_settings["NODESEGLEN"]
         for node in self.pggraph.pgnodes.values():
             if not node.isDrawn() or self._this_or_rc_in_layout(node):
                 continue
 
             drawn_len = node.GetDrawnNodeLength()
             num_edges = node.GetNumOgdfGraphEdges(drawn_len)
+            seg_len = drawn_len / num_edges
 
             #add rect for each subnode
             chain = []
@@ -159,25 +159,27 @@ class AdaptagramsGraph:
                     frontier.append(v)
         return order
 
-    def seed_linear_layout(self, assembly, y=None, branch_gap=None, iters=20):
+    def seed_linear_layout(self, assembly, y=None, branch_gap=None):
         """Seed initial rect positions for fd, including assembly & non-assembly branches"""
         if y is None:
             y = self.rect_size / 2.0
         if branch_gap is None:
             branch_gap = self.pggraph.m_settings["EDGELEN"]
 
-        seg_len = self.pggraph.m_settings["NODESEGLEN"]
         self._fixed = set()
         x = 0.0
         for node in self._assembly_topo_order(assembly):
             chain = self.node_to_rects[node]
+            drawn_len = node.GetDrawnNodeLength()
+            #same per-edge length as _add_nodes so node spans its true drawn length
+            seg_len = drawn_len / node.GetNumOgdfGraphEdges(drawn_len)
             for i, idx in enumerate(chain):
                 self.rs[idx].moveCentreX(x + i * seg_len)
                 self.rs[idx].moveCentreY(y)
                 self._fixed.add(idx)
             x += (len(chain) - 1) * seg_len
 
-        self._seed_branches(self._fixed, y, branch_gap, iters)
+        self._seed_branches(self._fixed, y, branch_gap)
 
     def _rect_adjacency(self):
         """Adjacency matrix over all rects in graph"""
@@ -189,37 +191,28 @@ class AdaptagramsGraph:
             adj[b].append(a)
         return adj
 
-    def _seed_branches(self, fixed, base_y, gap, iters):
-        """Best attempt at semi-optimal seeding for fd. Each rect position becomes mean
-        of its neighbors over `iters` iterations. Kind of like KNN clustering algorithm"""
+    def _seed_branches(self, fixed, base_y, gap):
         adj = self._rect_adjacency()
-        x = {i: self.rs[i].getCentreX() for i in range(len(self._rect_objs))}
+        seen = set(fixed)
+        x = {i: self.rs[i].getCentreX() for i in fixed}
 
-        #bfs from backbone and set x to backbone x - save depth
-        depth = {i: 0 for i in fixed}
-        frontier = list(fixed)
-        while frontier:
-            nxt = []
-            for u in frontier:
-                for v in adj[u]:
-                    if v not in depth:
-                        depth[v] = depth[u] + 1
-                        x[v] = x[u]
-                        nxt.append(v)
-            frontier = nxt
+        def walk(cur, prev, level):
+            y = base_y + level * gap
+            while cur is not None and cur not in seen:
+                seen.add(cur)
+                x[cur] = x[prev] + gap
+                self.rs[cur].moveCentreX(x[cur])
+                self.rs[cur].moveCentreY(y)
+                nbrs = [w for w in adj[cur] if w not in seen]
+                prev, cur = cur, (nbrs[0] if nbrs else None)
+                #rest are subbubbles
+                for w in nbrs[1:]:
+                    walk(w, prev, level + 1)
 
-        #pull free rects to mean x of neighbors
-        free = [i for i in depth if i not in fixed]
-        for _ in range(iters):
-            for i in free:
-                nb = adj[i]
-                if nb:
-                    x[i] = sum(x[j] for j in nb) / len(nb)
-
-        #update positions
-        for i in free:
-            self.rs[i].moveCentreX(x[i])
-            self.rs[i].moveCentreY(base_y + depth[i] * gap)
+        #first layer neighbors are starts of bubbles
+        for f in list(fixed):
+            for w in adj[f]:
+                walk(w, f, 1)
 
     def get_segment_coordinates(self, node):
         """Gets rect centers for every rect in node"""
@@ -239,7 +232,6 @@ class AdaptagramsGraph:
                                             adap.Doubles(self.edge_lengths),
                                             None, self._pre)
         self._fd.setAvoidNodeOverlaps(True)
-        self._fd.run()
         return self._fd
 
     def close(self):

--- a/adaptagrams_converter.py
+++ b/adaptagrams_converter.py
@@ -1,0 +1,244 @@
+import adaptagrams as adap
+
+class AdaptagramsGraph:
+    """
+    Builds adaptagrams (libcola) layout inputs from a PGGraph for linear alignment.
+
+    Attributes
+    ==========
+    rs : adaptagrams.RectanglePtrs
+        All segment rectangles
+    es : adaptagrams.ColaEdges
+        All edges, including internal & external
+    edge_lengths : list[float]
+        Ideal length per edge in es, same order/len as es
+    node_to_rects : dict[PGNode, list[int]]
+        Mapping of node to its ordered rect indices
+    """
+
+    def __init__(self, pggraph, rect_size=1.0):
+        self.pggraph = pggraph
+        self.rect_size = rect_size
+
+        self.rs = adap.RectanglePtrs()
+        self.es = adap.ColaEdges()
+        self.edge_lengths = []
+
+        self.node_to_rects = {}
+
+        #need to store rect pointers so they don't get garbage collected mid-layout
+        self._rect_objs = []
+
+        self._mark_drawn()
+        self._add_nodes()
+        self._add_edges()
+
+    def _mark_drawn(self):
+        for node in self.pggraph.pgnodes.values():
+            #all positive nodes are drawn
+            if node.isPositiveNode():
+                node.setAsDrawn()
+
+    def _node_in_layout(self, node):
+        return node in self.node_to_rects
+
+    def _this_or_rc_in_layout(self, node):
+        rc = node.getReverseComplement()
+        return self._node_in_layout(node) or (rc is not None and self._node_in_layout(rc))
+
+    def _new_rect(self):
+        #a rect_size x rect_size rect (spanning from 0 to rect_size)
+        r = adap.Rectangle(0.0, self.rect_size, 0.0, self.rect_size)
+        idx = len(self._rect_objs)
+        self._rect_objs.append(r)
+        self.rs.push_back(r)
+        return idx
+
+    def _add_edge(self, i, j, ideal_length):
+        self.es.push_back(adap.ColaEdge(i, j))
+        self.edge_lengths.append(float(ideal_length))
+
+    def _add_nodes(self):
+        """
+        Adds every drawn node to the graph, including bandage subnodes
+        """
+        for node in self.pggraph.pgnodes.values():
+            if not node.isDrawn() or self._this_or_rc_in_layout(node):
+                continue
+
+            drawn_len = node.GetDrawnNodeLength()
+            num_edges = node.GetNumOgdfGraphEdges(drawn_len)
+            len_per_edge = drawn_len / num_edges
+
+            #add rect for each subnode
+            chain = []
+            prev_idx = None
+            for i in range(num_edges + 1):
+                idx = self._new_rect()
+                chain.append(idx)
+                if i > 0:
+                    self._add_edge(prev_idx, idx, len_per_edge)
+                prev_idx = idx
+
+            self.node_to_rects[node] = chain
+
+    #simple accessors just to help readability a bit
+    def _chain_last(self, node):
+        return self.node_to_rects[node][-1]
+
+    def _chain_first(self, node):
+        return self.node_to_rects[node][0]
+
+    def _add_edges(self):
+        edge_len = self.pggraph.m_settings["EDGELEN"]
+        for edge in self.pggraph.pgedges.values():
+            edge.DetermineIfDrawn()
+            if not edge.isDrawn():
+                continue
+
+            start = edge.startingNode
+            end = edge.endingNode
+
+            #pretty much the same logic as AddEdgeToOGDFGraph in bandage_graph.py
+            if self._node_in_layout(start):
+                first_idx = self._chain_last(start)
+            elif start.getReverseComplement() is not None and \
+                    self._node_in_layout(start.getReverseComplement()):
+                first_idx = self._chain_first(start.getReverseComplement())
+            else:
+                continue
+
+            if self._node_in_layout(end):
+                second_idx = self._chain_first(end)
+            elif end.getReverseComplement() is not None and \
+                    self._node_in_layout(end.getReverseComplement()):
+                second_idx = self._chain_last(end.getReverseComplement())
+            else:
+                continue
+
+            #skip single-segment self connecting nodes
+            drawn_len = start.GetDrawnNodeLength()
+            if start == end and start.GetNumOgdfGraphEdges(drawn_len) == 1:
+                continue
+
+            self._add_edge(first_idx, second_idx, edge_len)
+
+    def _resolve(self, node):
+        """Get whichever node is in layout (node or its reverse compliment)"""
+        if self._node_in_layout(node):
+            return node
+        rc = node.getReverseComplement()
+        if rc is not None and self._node_in_layout(rc):
+            return rc
+        return None
+
+    def _assembly_topo_order(self, assembly):
+        """Linear walk down selected assembly, starting from head (node with indegree 0)"""
+        nodes = {n for n in self.node_to_rects if assembly in n.m_assembly}
+        child = {}
+        has_parent = set()
+        for edge in self.pggraph.pgedges.values():
+            edge.DetermineIfDrawn()
+            if not edge.isDrawn():
+                continue
+            u = self._resolve(edge.startingNode)
+            v = self._resolve(edge.endingNode)
+            if u in nodes and v in nodes and u is not v:
+                child[u] = v
+                has_parent.add(v)
+
+        head = next((n for n in nodes if n not in has_parent), None)
+        order = []
+        while head is not None:
+            order.append(head)
+            head = child.get(head)
+        return order
+
+    def seed_linear_layout(self, assembly, y=None, branch_gap=None, iters=20):
+        """Seed initial rect positions for fd, including assembly & non-assembly branches"""
+        if y is None:
+            y = self.rect_size / 2.0
+        if branch_gap is None:
+            branch_gap = self.rect_size
+
+        fixed = set()
+        x = 0.0
+        for node in self._assembly_topo_order(assembly):
+            chain = self.node_to_rects[node]
+            drawn_len = node.GetDrawnNodeLength()
+            step = drawn_len / (len(chain) - 1) if len(chain) > 1 else 0.0
+            for i, idx in enumerate(chain):
+                self.rs[idx].moveCentreX(x + i * step)
+                self.rs[idx].moveCentreY(y)
+                fixed.add(idx)
+            x += drawn_len
+
+        self._seed_branches(fixed, y, branch_gap, iters)
+
+    def _rect_adjacency(self):
+        """Adjacency matrix over all rects in graph"""
+        adj = {i: [] for i in range(len(self._rect_objs))}
+        for k in range(len(self.edge_lengths)):
+            e = self.es[k]
+            a, b = (e.first, e.second) if hasattr(e, "first") else (e[0], e[1])
+            adj[a].append(b)
+            adj[b].append(a)
+        return adj
+
+    def _seed_branches(self, fixed, base_y, gap, iters):
+        """Best attempt at semi-optimal seeding for fd. Each rect position becomes mean
+        of its neighbors over `iters` iterations. Kind of like KNN clustering algorithm"""
+        adj = self._rect_adjacency()
+        x = {i: self.rs[i].getCentreX() for i in range(len(self._rect_objs))}
+
+        #bfs from backbone and set x to backbone x - save depth
+        depth = {i: 0 for i in fixed}
+        frontier = list(fixed)
+        while frontier:
+            nxt = []
+            for u in frontier:
+                for v in adj[u]:
+                    if v not in depth:
+                        depth[v] = depth[u] + 1
+                        x[v] = x[u]
+                        nxt.append(v)
+            frontier = nxt
+
+        #pull free rects to mean x of neighbors
+        free = [i for i in depth if i not in fixed]
+        for _ in range(iters):
+            for i in free:
+                nb = adj[i]
+                if nb:
+                    x[i] = sum(x[j] for j in nb) / len(nb)
+
+        #update positions
+        for i in free:
+            self.rs[i].moveCentreX(x[i])
+            self.rs[i].moveCentreY(base_y + depth[i] * gap)
+
+    def get_segment_coordinates(self, node):
+        """Gets rect centers for every rect in node"""
+        return [(self.rs[idx].getCentreX(), self.rs[idx].getCentreY())
+                for idx in self.node_to_rects[node]]
+
+    def build_fd_layout(self, ideal_length=1.0):
+        self._fd = adap.ConstrainedFDLayout(self.rs, self.es, ideal_length,
+                                            adap.Doubles(self.edge_lengths))
+        return self._fd
+
+    def close(self):
+        """
+        Drop all our C++ refs so they can be garbage collected
+        """
+        self._fd = None
+        self.rs = None
+        self.es = None
+        self.node_to_rects.clear()
+        self._rect_objs.clear()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()

--- a/bubble_finding.py
+++ b/bubble_finding.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Bubble:
+    """A bubble (branching region): source, sink, and interior node names."""
+    source: str
+    sink: str
+    interior: frozenset
+
+
+def build_adjacency(pg) -> tuple[dict, dict]:
+    """
+    Build out_adj and in_adj from a PGGraph object.
+    Only positive nodes and positive edges are considered.
+    """
+    out_adj = {n: [] for n in pg.pgnodes if pg.pgnodes[n].isPositiveNode()}
+    in_adj = {n: [] for n in pg.pgnodes if pg.pgnodes[n].isPositiveNode()}
+
+    for edge in pg.pgedges.values():
+        if not edge.isPositiveEdge():
+            continue
+        s = edge.getStartingNode().nodeName
+        t = edge.getEndingNode().nodeName
+        if s in out_adj and t in in_adj:
+            if t not in out_adj[s]:
+                out_adj[s].append(t)
+            if s not in in_adj[t]:
+                in_adj[t].append(s)
+
+    return out_adj, in_adj
+
+
+def _reachable_from(source: str, out_adj: dict, node_set: set) -> set:
+    """BFS: all nodes reachable from *source* restricted to *node_set*."""
+    visited = set()
+    q = deque([source])
+    while q:
+        n = q.popleft()
+        if n in visited or n not in node_set:
+            continue
+        visited.add(n)
+        for nb in out_adj.get(n, []):
+            if nb not in visited:
+                q.append(nb)
+    return visited
+
+
+def _find_sink(
+    source: str,
+    out_adj: dict,
+    in_adj: dict,
+    node_set: set,
+) -> Optional[tuple[str, frozenset]]:
+    """
+    Wavefront search from *source* within *node_set*.
+
+    When the wavefront collapses to a single node, (sink, interior) is returned.
+    Otherwise, None is returned.
+    """
+    if len(out_adj.get(source, [])) < 2:
+        return None
+
+    reachable = _reachable_from(source, out_adj, node_set)
+
+    #get number of predecessors
+    in_deg = {
+        n: sum(1 for p in in_adj.get(n, []) if p in reachable)
+        for n in reachable
+    }
+
+    visited = {source}
+    interior = set()
+
+    wavefront = set()
+    visit_count = {}
+
+    for nb in out_adj.get(source, []):
+        if nb in reachable:
+            wavefront.add(nb)
+            visit_count[nb] = visit_count.get(nb, 0) + 1
+
+    while True:
+        if not wavefront:
+            return None
+
+        #sink case
+        if len(wavefront) == 1:
+            sink = next(iter(wavefront))
+            if visit_count.get(sink, 0) == in_deg[sink]:
+                return sink, frozenset(interior)
+            return None
+
+        node = next(
+            (n for n in wavefront if visit_count.get(n, 0) == in_deg[n]),
+            None,
+        )
+        if node is None:
+            raise ValueError(
+                f"Cycle detected in reachable subgraph from {source!r}; "
+                "pangenome graph is expected to be acyclic."
+            )
+
+        wavefront.remove(node)
+        visited.add(node)
+        interior.add(node)
+
+        for nb in out_adj.get(node, []):
+            if nb in reachable and nb not in visited:
+                wavefront.add(nb)
+                visit_count[nb] = visit_count.get(nb, 0) + 1
+
+
+def find_bubble_from_source(
+    source: str,
+    out_adj: dict,
+    in_adj: dict,
+    node_set: set = None,
+) -> Optional[Bubble]:
+    """Find the bubble whose source is *source*, or None."""
+    if node_set is None:
+        node_set = set(out_adj.keys()) | set(in_adj.keys())
+
+    result = _find_sink(source, out_adj, in_adj, node_set)
+    if result is None:
+        return None
+
+    sink, interior = result
+    return Bubble(source=source, sink=sink, interior=interior)
+
+
+def find_all_bubbles(
+    pg=None,
+    out_adj: dict = None,
+    in_adj: dict = None,
+) -> list[Bubble]:
+    """
+    Find all bubbles in the graph.
+
+    Pass either a PGGraph object (*pg*) or pre-built adjacency dicts.
+    Returns a list of Bubble objects (one per branching source).
+    """
+    if out_adj is None or in_adj is None:
+        if pg is None:
+            raise ValueError("Provide either a PGGraph (pg=) or both out_adj and in_adj.")
+        out_adj, in_adj = build_adjacency(pg)
+
+    bubbles = []
+    for node in out_adj:
+        if len(out_adj[node]) < 2:
+            continue
+        bubble = find_bubble_from_source(node, out_adj, in_adj)
+        if bubble is not None:
+            bubbles.append(bubble)
+
+    return bubbles

--- a/main.py
+++ b/main.py
@@ -499,7 +499,7 @@ async def bandage(
     edgelen: float = Query(5, description="Length of edges between nodes"),
     nodelenpermb: float = Query(1000, description="Formula:\n`drawnNodeLength = nodelenpermb * node_length_in_bp / 1,000,000`"),
     linear: bool = Query(False, description="If true, linearize the selected assembly via AdaptagramsGraph instead of the default OGDF layout"),
-    assembly: str = Query("GRCh38", description="Assembly to linearize when `linear` is true (must match a node assembly token, e.g. `GRCh38`)")
+    assembly: str = Query("GRCh38", description="Assembly and haplotype to linearize when `linear` is true (in `assembly#haplotype` format - e.g. `GRCh38#0`)")
 ):
     """
     ## Parameters
@@ -515,7 +515,7 @@ async def bandage(
     - `edgelen`: float — Edge length between nodes
     - `nodelenpermb`: float — Drawn node length scaling factor
     - `linear`: bool — Whether output should be linearized wrt an assembly
-    - `assembly`: str — Assembly to linearize against
+    - `assembly`: str — Assembly to linearize against, provided in `sample_name#haplotype` format.
 
     ## Returns
 
@@ -579,8 +579,12 @@ async def bandage(
     pggraph = bandage_graph.PGGraph(str(postprocess_gfa_output), settings)
     pggraph.BuildOGDFGraph()
     if linear:
+        #more input validation may be required but tbd
+        parts = assembly.split('#')
+        sample = parts[0]
+        haplotype = parts[1] if len(parts) > 1 else None
         ag = adaptagrams_converter.AdaptagramsGraph(pggraph)
-        ag.seed_linear_layout(assembly)
+        ag.seed_linear_layout(assembly=sample, haplotype=haplotype)
         ag.build_fd_layout().run()
     else:
         pggraph.LayoutGraph()
@@ -635,6 +639,7 @@ async def bandage(
     data["edge"] = edges
     
     #free up refs
-    ag.close()
+    if linear:
+        ag.close()
 
     return JSONResponse(content=data)

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ import tempfile
 import json
 import pysam
 import re
+import adaptagrams_converter
 
 logging.basicConfig(level=logging.INFO)
 api_log = logging.getLogger("app")
@@ -578,7 +579,6 @@ async def bandage(
     pggraph = bandage_graph.PGGraph(str(postprocess_gfa_output), settings)
     pggraph.BuildOGDFGraph()
     if linear:
-        import adaptagrams_converter
         ag = adaptagrams_converter.AdaptagramsGraph(pggraph)
         ag.seed_linear_layout(assembly)
         ag.build_fd_layout()  # TEMP: skip .run() — return seeded positions only

--- a/main.py
+++ b/main.py
@@ -499,7 +499,7 @@ async def bandage(
     edgelen: float = Query(5, description="Length of edges between nodes"),
     nodelenpermb: float = Query(1000, description="Formula:\n`drawnNodeLength = nodelenpermb * node_length_in_bp / 1,000,000`"),
     linear: bool = Query(False, description="If true, linearize the selected assembly via AdaptagramsGraph instead of the default OGDF layout"),
-    assembly: str = Query("GRCh38", description="Assembly and haplotype to linearize when `linear` is true (in `assembly#haplotype` format - e.g. `GRCh38#0`)")
+    assembly: str = Query("GRCh38#0", description="Assembly and haplotype to linearize when `linear` is true (in `assembly#haplotype` format - e.g. `GRCh38#0`)")
 ):
     """
     ## Parameters

--- a/main.py
+++ b/main.py
@@ -581,7 +581,7 @@ async def bandage(
     if linear:
         ag = adaptagrams_converter.AdaptagramsGraph(pggraph)
         ag.seed_linear_layout(assembly)
-        ag.build_fd_layout()
+        ag.build_fd_layout().run()
     else:
         pggraph.LayoutGraph()
     assembly_range = adjustAssemblyRangeList(pggraph.pgassemblies) # {assembly_id1: {"sequence_id": seq_id, "region": 1000-2000}, assembly_id2: ...}

--- a/main.py
+++ b/main.py
@@ -634,4 +634,7 @@ async def bandage(
     data["assembly"] = assembly_range
     data["edge"] = edges
     
+    #free up refs
+    ag.close()
+
     return JSONResponse(content=data)

--- a/main.py
+++ b/main.py
@@ -496,7 +496,9 @@ async def bandage(
     minnodelen: float = Query(5, description="Minimum node length to draw.\nIf the drawn node length is smaller than this, it defaults to minnodelen."),
     nodeseglen: float = Query(20, description="Node length for each OGDF node"),
     edgelen: float = Query(5, description="Length of edges between nodes"),
-    nodelenpermb: float = Query(1000, description="Formula:\n`drawnNodeLength = nodelenpermb * node_length_in_bp / 1,000,000`")
+    nodelenpermb: float = Query(1000, description="Formula:\n`drawnNodeLength = nodelenpermb * node_length_in_bp / 1,000,000`"),
+    linear: bool = Query(False, description="If true, linearize the selected assembly via AdaptagramsGraph instead of the default OGDF layout"),
+    assembly: str = Query("GRCh38", description="Assembly to linearize when `linear` is true (must match a node assembly token, e.g. `GRCh38`)")
 ):
     """
     ## Parameters
@@ -511,6 +513,8 @@ async def bandage(
     - `nodeseglen`: float — Node length for every OGDF node
     - `edgelen`: float — Edge length between nodes
     - `nodelenpermb`: float — Drawn node length scaling factor
+    - `linear`: bool — Whether output should be linearized wrt an assembly
+    - `assembly`: str — Assembly to linearize against
 
     ## Returns
 
@@ -573,7 +577,13 @@ async def bandage(
     
     pggraph = bandage_graph.PGGraph(str(postprocess_gfa_output), settings)
     pggraph.BuildOGDFGraph()
-    pggraph.LayoutGraph()
+    if linear:
+        import adaptagrams_converter
+        ag = adaptagrams_converter.AdaptagramsGraph(pggraph)
+        ag.seed_linear_layout(assembly)
+        ag.build_fd_layout()  # TEMP: skip .run() — return seeded positions only
+    else:
+        pggraph.LayoutGraph()
     assembly_range = adjustAssemblyRangeList(pggraph.pgassemblies) # {assembly_id1: {"sequence_id": seq_id, "region": 1000-2000}, assembly_id2: ...}
     # TODO adjust take in non duplicated coordinates if it's not from the right contig. Can look into real cases before this adjustment
     
@@ -601,10 +611,14 @@ async def bandage(
             node_info["assembly_metadata"] = pgnodes.m_assembly_metadata
             node_info["default_range"] = pgnodes.m_range
             sequence[pgnodes.nodeName] = pgnodes.nodeSequence
-            odgf_coordinates = []
-            for ogdf_node in pgnodes.GetOgdfNode().m_ogdfNodes:
-                coordinates = {"x": pggraph.m_graphAttributes.x(ogdf_node), "y": pggraph.m_graphAttributes.y(ogdf_node)}
-                odgf_coordinates.append(coordinates)
+            if linear:
+                resolved = ag.resolve(pgnodes)
+                odgf_coordinates = [{"x": x, "y": y} for x, y in ag.get_segment_coordinates(resolved)] if resolved else []
+            else:
+                odgf_coordinates = []
+                for ogdf_node in pgnodes.GetOgdfNode().m_ogdfNodes:
+                    coordinates = {"x": pggraph.m_graphAttributes.x(ogdf_node), "y": pggraph.m_graphAttributes.y(ogdf_node)}
+                    odgf_coordinates.append(coordinates)
             node_info["ogdf_coordinates"] = odgf_coordinates
             node[pgnodes.nodeName] = node_info
 

--- a/main.py
+++ b/main.py
@@ -581,7 +581,7 @@ async def bandage(
     if linear:
         ag = adaptagrams_converter.AdaptagramsGraph(pggraph)
         ag.seed_linear_layout(assembly)
-        ag.build_fd_layout()  # TEMP: skip .run() — return seeded positions only
+        ag.build_fd_layout()
     else:
         pggraph.LayoutGraph()
     assembly_range = adjustAssemblyRangeList(pggraph.pgassemblies) # {assembly_id1: {"sequence_id": seq_id, "region": 1000-2000}, assembly_id2: ...}


### PR DESCRIPTION
# Overview
Implements an `AdaptagramsGraph` class, which converts a `PGGraph` into a usable format for the Adaptagrams library. Updates `/json` endpoint to include a `linear` and `assembly` parameter.

## Changes
`adaptagrams_converter.py` (new)
- Core linearization engine
- Wraps PGGraph & builds adaptagrams graph with Rectangles & ColaEdges
- Seeds initial linear layout with a topo-sort
- Runs actual algorithm (stress majorization) to create linear layout

`bubble_finding.py` (new)
- Helper script to find bubbles in graph
- Used exclusively in `adaptagrams_converter` to help with initial seeding

`main.py`
- Adds new query params
   - `linear: bool`
   - `assembly: str`
- When `linear = True`, builds an `AdaptagramsGraph` from the existing `PGGraph`, and runs FD layout using the resulting graph object.
- Also closes the graph to free up memory afterwards