### PR TITLE
Diagnose /seqtubemap latency, and propose an additive band format

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,71 @@
+# PangenomeAPI — Context
+
+The backend of the Pangenome Browser. It extracts a region of a human pangenome
+graph and returns it in the form its one consumer — [`pgb`](https://github.com/CAST-genomics/pgb) —
+needs: graph structure for the 3D view, and a **sequence tube map** for looking
+inside a single **node**.
+
+This glossary is shared with `pgb`'s [`CONTEXT.md`](https://github.com/CAST-genomics/pgb/blob/main/CONTEXT.md)
+and the two must not diverge. Where a word here differs from what the upstream
+tools (GFA, `vg`, `tubemap.js`) spell it, that spelling is listed under _Avoid_:
+it stays correct *inside* the tool's own file format, and stops at this codebase's
+boundary.
+
+## Language
+
+**pangenome graph**:
+A graph whose vertices are stretches of DNA and whose paths are the assembled
+haplotypes of many individuals. Two are served: **minigraph-cactus** and
+**minigraph**, each in a **v1** and a **v2** build.
+
+**node**:
+A vertex of the coarse graph `pgb` draws in 3D — one haplotypic stretch of DNA,
+addressed by an oriented id such as `141452+`. This is what the `minigraphnode`
+parameter names.
+_Avoid_: using bare "node" for the finer vertices inside a tube map — those are
+**segments**. The two granularities appear in the same URL, which is exactly why
+the distinction is written down. **minigraph node** is the deliberate alias to
+reach for wherever a tube map is also in scope.
+
+**segment**:
+A vertex *inside* a **sequence tube map** — one stretch of sequence in the
+minigraph-cactus subgraph that a **node** collapses. Typically tiny; most are
+single-base variants.
+_Avoid_: node (this codebase's meaning), and `vg`'s "node". A GFA `S` line is a
+segment in the GFA, which is the one place the word already agrees.
+
+**strand**:
+One haplotype's route through a **sequence tube map**, named
+`sample#haplotype#contig` and coloured by its shipped PCLAI RGB.
+_Avoid_: track, path, walk. This one concept has five spellings across the
+pipeline — a GFA `W` line calls it a walk, a GFA `P` line and `vg` JSON call it a
+path, `tubemap.js` and the emitted `trackID`/`trackName` attributes call it a
+track, and the biology calls it a haplotype. Each is correct in its own format;
+none of them is what this codebase calls it.
+
+**band**:
+The atomic drawable of a **sequence tube map**: one **strand** crossing one
+x-interval. A strand is made of many bands, so a band count counts shapes, not
+haplotypes.
+_Avoid_: ribbon, which reads as the whole strand.
+
+**sequence tube map**:
+A base-resolution picture of what is inside one **node** — its **segments** laid
+along an axis with every **strand** threaded through them.
+
+**subgraph**:
+The slice of a **pangenome graph** covering one requested region. The unit this
+API extracts, transforms and serves; never the whole graph.
+
+**region**:
+A `chrom`, `start`, `end` triple in GRCh38 coordinates. The address of every
+request.
+
+**assembly**:
+One sequenced individual's genome. Contributes two **strands** per chromosome to
+the graph — one per haplotype.
+
+**GRCh38**:
+The linear reference the graphs are built against and every **region** is
+expressed in. Present in the graph as **strands** of its own, and treated
+specially wherever strands are merged.

--- a/docs/adr/0001-additive-band-format.md
+++ b/docs/adr/0001-additive-band-format.md
@@ -1,0 +1,140 @@
+---
+status: accepted
+date: 2026-08-27
+measured: 2026-08-27
+---
+
+# `/seqtubemap` gains a band format alongside the SVG, and the band data becomes canonical
+
+The endpoint renders a **sequence tube map** by booting a headless browser, building a
+jsdom document and serializing it to XML — so that its one consumer, `pgb`, can parse the
+XML back into the numbers the layout already held. Measurement says that emulation is
+**93.7% of the memory** and roughly half the bytes. We are adding `?format=bands`, which
+returns those numbers directly, and inverting which of the two is the source of truth: the
+band data becomes canonical and the SVG becomes a rendering of it.
+
+The format is **additive**. The existing URL keeps returning SVG, so the API and `pgb` never
+have to deploy in lockstep, and the SVG remains the oracle the band payload is checked
+against.
+
+## The measurements
+
+Four, all taken 2026-08-27 and reproducible from [`perf/`](../../perf/). The full write-up
+is [`docs/perf/seqtubemap-latency.md`](../perf/seqtubemap-latency.md).
+
+**The DOM is the memory, not the layout.** `perf/rss-split.mjs` marks retained heap either
+side of `tubemap.js`'s `create()`, then tears the document down and marks again. What the
+DOM releases is what the DOM was holding:
+
+| fixture | `create()` retained | DOM share | layout share |
+| --- | ---: | ---: | ---: |
+| spine 150 × 464 strands | 567.6 MB | **530.7 MB (93.5%)** | 36.9 MB |
+| spine 400 × 464 strands | 1522.7 MB | **1427.5 MB (93.7%)** | 95.2 MB |
+
+The layout is ~15× smaller than the document built to hold it, and holds no DOM references.
+This is why large nodes cannot be fetched at all: roughly 43% of catalogued nodes fail, and
+the ceiling is the DOM.
+
+**Between 41% and 47% of every response is redundancy.** Byte census over the five golden
+documents in `pgb`'s `src/tubemap/__tests__/fixtures/`:
+
+| | 90 bp | 600 bp | node 5520 (13.56 MB) |
+| --- | ---: | ---: | ---: |
+| `d=` — the geometry | 15.0% | 28.1% | 29.9% |
+| `style=` — one of ~464 rgb triples | 16.4% | 14.5% | 14.2% |
+| `trackName=` — one of ~464 names | 11.4% | 10.3% | 10.1% |
+| `color=` — *the same rgb as `style`, written twice* | 8.6% | 7.6% | 7.5% |
+| `class="track{id}"` — the same integer as `trackID` | 5.4% | 4.8% | 4.8% |
+| `<title></title>` — empty, 40,716 of them | 5.0% | 4.4% | 4.3% |
+| **redundant** | **46.9%** | **41.5%** | **40.8% (5.53 MB)** |
+
+Everything but `d=` is either a per-strand constant re-serialized on every band, or carries
+nothing at all. The geometry — the only genuinely per-band content — is under a third of the
+payload.
+
+**There are zero `<text>` and zero `<line>` elements in production output.** No labels, no
+legend, no axis. The document is bands and segment boxes and nothing else, which is what
+makes "derive the SVG from the band data" lossless rather than a compromise.
+
+**The geometry never needed a DOM.** At `seqtubemap/tubemap.js:3599` the `d` attribute is
+bound as `(d) => d.path` — already a complete `"M … C … Z"` string, computed before any
+element exists. jsdom's entire contribution is to hold that string and hand it back.
+
+## What is served
+
+`?format=bands` returns a JSON header and a binary body in one response:
+
+- **header** — the viewBox, and the ~464-row strand table: `trackID`, rgb, `trackName`,
+  `pclaiX/pclaiY/pclaiScore`. Transmitted once instead of once per band.
+- **body** — `Float32 × 6 + Uint16` per band. `pgb` builds `InstancedBufferGeometry` from
+  typed arrays, so this is a copy into the GPU buffer with no parse step at all.
+- **segment boxes** — id, outline, sequence, which `parseSegmentBoxes.ts` reads today.
+
+At the 10 kb region that is roughly **1.5 MB against the SVG's 10.07 MB**, with the client's
+regex pass deleted rather than shrunk.
+
+## How it lands
+
+Four increments, each shippable alone.
+
+**A** — the two endpoints are `async def` (`main.py:470`, `:527`) and neither awaits
+anything; every pipeline stage is a blocking `subprocess.run`, so one slow request stalls
+every concurrent one. FastAPI runs a plain `def` endpoint in a threadpool. Deleting the word
+`async` twice is the fix, and it fixes `/json` at the same time.
+
+**B** — capture the d3 data joins instead of appending, derive the SVG from the band data,
+and delete `jsdom` and `canvas` from `package.json`. **B is held byte-compatible with
+`pgb`'s existing parser as a deliberate constraint, not a coincidence** —
+`parseBands.ts` requires `style="fill: rgb(R, G, B); fill-opacity: 1;" trackID="N"
+trackName="…"` contiguous and in that order, and counts `<rect>` + `<path>` in `g.track`.
+Dropping `color=`, `class=`, and the empty `<title>` children changes none of that. So B is
+a server-only change against an unchanged client, and `pgb` becomes its conformance test: a
+bad B shows up as an error card rather than as a diff nobody ran.
+
+**C** — the path builder emits floats rather than strings, the binary body appears, and
+`pgb`'s parser changes for the first time.
+
+**D** — delete the `vg convert` / `vg view -j` round trip. Gated on measuring
+`subgraph_extract` on the live server; if upstream extraction dominates, this is noise.
+
+## Considered and rejected
+
+**Mutating the existing URL in place** — hoisting the per-strand constants out of every band
+without adding a format. Cheaper to write and strictly worse to ship: the two repos would
+have to deploy in lockstep, and it buys a byte reduction without touching the DOM that
+causes the ceiling.
+
+**Replacing SVG outright.** Loses the oracle at exactly the moment it is needed, and there
+is no reason to force the client to move before it is ready.
+
+**Two sinks over one layout** — the SVG sink and a band collector side by side. Keeps jsdom
+alive forever for a route nobody calls, and makes drift a matter of discipline. Deriving one
+from the other makes drift impossible by construction.
+
+**JSON rather than a binary body.** Roughly 3–4 MB where binary is 1.5 MB, and it keeps a
+full parse on the client that typed arrays remove entirely.
+
+**Carrying `pathnumoption` onto the band route.** `pathnumoption=compressed`
+(`main.py:212–226`) keys on the entire walk across the region, so one SNP prevents any
+collapse — measured byte-identical to `normal` at 1000 bp. Fixing it would merge strands,
+which is a change to the *data* and out of scope. It stays as-is on the SVG route and does
+not exist on the band route; carrying a parameter that has never changed an output into a
+new format is how dead code becomes permanent.
+
+## Consequences
+
+- **`pgb`'s ADR 0002 loses its largest accepted cost.** That decision accepted being
+  *"coupled to an upstream at the level of drawing primitives"* — reading `d` attributes
+  against a path grammar and rebuilding the picture from inferred numbers. Once the server
+  publishes the numbers, the inference is gone. ADR 0002 is amended rather than left
+  contradicted.
+- **The band data is canonical.** Where the two encodings disagree, the SVG is wrong.
+- **Correctness is `parseBands`-equivalence, not byte-identity** — except in B, where
+  byte-compatibility is the constraint that lets the repos move independently.
+- **Golden fixtures**: `pgb` already commits five real documents spanning 0.29 MB to 13.56
+  MB. The matching *inputs* do not exist outside the live server and must be obtained; see
+  [`docs/perf/deploy-request.md`](../perf/deploy-request.md).
+- **`seqtubemap/tubemap.js` is declared a fork.** It is an unmarked 4,000-line vendored copy
+  of `vgteam/sequence-tube-map`, carrying upstream's eslint header and no provenance. B
+  removes its DOM sink, so the re-sync option is gone in fact; the header comment makes it
+  gone on paper too.

--- a/docs/perf/deploy-request.md
+++ b/docs/perf/deploy-request.md
@@ -1,48 +1,58 @@
-# Deploy request — stage timing on the live API
+# The ask for Cici — one deploy, two things to send back
 
-A ready-to-send message asking whoever operates `pangenome-api.ucsd.edu` to deploy the
-timing branch and return three log lines.
+Two things are needed from the live server before the `/seqtubemap` work can be verified,
+and both come from the same deploy, so they go in one message rather than two.
 
-**Why this exists:** the `[stage-timing]` instrumentation is new code on
-`perf/seqtubemap-diagnosis`. The live server cannot produce these numbers as it stands, so
-the ask is "deploy this branch, hit three URLs, send a grep" — not "run something for me".
+1. **Stage timings for three fresh regions** — the last unmeasured number in the effort.
+2. **The pipeline intermediates for five regions** — the missing half of the golden
+   fixtures.
 
-**Why not measure locally:** this machine is arm64 and `docker-compose.yml` pins
-`platform: linux/amd64`, so a local container runs under x86 emulation. That inflates the
-native binaries (`vg`, `gbz-base`) unevenly — exactly the stages being measured. Local
-Docker is fine for developing the fix, not for timing it. See
-[`seqtubemap-plan.md`](./seqtubemap-plan.md) Step 0.
+**Why this can't be done locally.** This machine is arm64 and `docker-compose.yml` pins
+`platform: linux/amd64`, so a local container runs under x86 emulation — which inflates the
+native binaries (`vg`, `gbz-base`) unevenly, and those are exactly the stages being
+measured. Local Docker is fine for *developing* the fix, not for timing it. Separately, the
+three `.walk.gz` files are team-generated derivatives rather than public HPRC downloads, and
+the server won't boot without all three.
 
-Tone below is pitched as a peer asking a colleague. Adjust to fit.
+**Status.** PR [#12](https://github.com/CAST-genomics/PangenomeAPI/pull/12) carries the
+`[stage-timing]` instrumentation. It is logging only — no behaviour change — and the diff is
+reviewable in a minute (`git show ab3e5b0 -- main.py`). The message below is a comment on
+that PR, or a Slack message pointing at it; it is written as a peer asking a colleague, so
+adjust the tone to taste.
 
 ---
 
-**Subject: Small ask — deploy a logging-only branch to pangenome-api and send me three log lines?**
+**Subject: Two things off one deploy — stage timings + five fixture dumps**
 
-Hi —
+Hi Cici —
 
-I've been digging into why `/seqtubemap` is so slow, and I've got it narrowed down but I'm
-stuck on one measurement I can't take from outside. Could I ask ~10 minutes of your time?
+I've been digging into why `/seqtubemap` is slow and I've got it down to one unmeasured
+number plus one missing artifact. Both come off the same deploy, so I've bundled them.
+Maybe 15 minutes of your time.
 
-**What I've found so far:** a 10 kb region takes **120 seconds** and returns a **10 MB
-SVG**. I've confirmed the SVG-rendering step is only ~1–2 s of that, so roughly **34
-seconds is somewhere upstream** — in the gbz-base query, the GFA rewrite, `vg convert`, or
-`vg view -j`. I can't tell which from outside the server, and that one fact determines where
-the fix goes.
+**What I've found.** A 10 kb region takes **120 seconds** and returns a **10 MB** SVG. Two
+measurements say where most of that goes:
 
-**The ask:** I've pushed a branch that adds timing instrumentation around each pipeline
-stage:
+- **93.7% of the render's memory is the jsdom document**, not the layout — measured by
+  tearing the DOM down and watching what's released, at two fixture sizes. That's why big
+  nodes can't be fetched at all; the ceiling is the DOM.
+- **41–47% of every response carries no information** — measured across five real documents
+  from 0.29 MB to 13.6 MB. Per-strand constants re-serialized on every band, `color=`
+  duplicating the rgb already in `style=`, `class=` duplicating `trackID`, and 40,716 empty
+  `<title>` elements in one document.
 
-```
-perf/seqtubemap-diagnosis    (CAST-genomics/PangenomeAPI)
-```
+The plan is in
+[`docs/adr/0001-additive-band-format.md`](https://github.com/CAST-genomics/PangenomeAPI/blob/perf/seqtubemap-diagnosis/docs/adr/0001-additive-band-format.md).
+Short version: `/seqtubemap` gains `?format=bands` that returns the numbers directly. It's
+**additive** — the existing URL keeps returning SVG, unchanged, so nothing has to deploy in
+lockstep. There's also a two-word fix I'd like to land first, separately: both endpoints are
+`async def` and neither awaits anything, so one slow request currently stalls every
+concurrent one. Deleting the word `async` twice makes FastAPI run them in a threadpool. That
+one helps `/json` as much as `/seqtubemap`.
 
-It's **logging only** — a context manager that records elapsed time, plus one log line per
-request. No change to any output, response, or pipeline behaviour. The relevant commit is
-`ab3e5b0`.
-
-If you could deploy it and hit these three regions (deliberately chosen as ones nobody's
-queried, so they don't hit the cached subgraph path):
+**Ask 1 — deploy PR #12 and send me a grep.** It's logging only; it adds one line per
+request. Then hit three URLs, each against a **fresh region** so `cached=False` — the cached
+path skips the stage I most suspect:
 
 ```
 https://pangenome-api.ucsd.edu:8000/seqtubemap?chrom=chr8&start=78900000&end=78900090&version=v2&pathnumoption=normal&nodewidthoption=compressed
@@ -50,55 +60,50 @@ https://pangenome-api.ucsd.edu:8000/seqtubemap?chrom=chr8&start=78910000&end=789
 https://pangenome-api.ucsd.edu:8000/seqtubemap?chrom=chr8&start=78920000&end=78930000&version=v2&pathnumoption=normal&nodewidthoption=compressed
 ```
 
-…then send me the output of:
+Then:
 
 ```sh
 grep '\[stage-timing\]' <logfile>
 ```
 
-Three lines, looking roughly like:
+Fair warning: the 10 kb one will hold the API for around two minutes. That's the
+event-loop bug above, not something the instrumentation introduced — but pick a quiet
+moment.
 
-```
-[stage-timing] chr8:78920000-78930000 span=10000bp v2 path=normal width=compressed
-cached=False total=118.442s subgraph_extract=94.1s gfa_process=12.3s gfa_to_vg=4.8s
-vg_to_json=6.1s generate_svg=1.2s json_mb=42.7 svg_mb=9.6
-```
+Three lines is all I need. They tell me whether the time is in the `gbz-base` query, the GFA
+rewrite, or the `vg` hop, and that decides whether one of the four planned changes is worth
+doing at all.
 
-That's everything I need — I can take it from there.
+**Ask 2 — the intermediates for five regions.** `pgb` has five committed golden tube maps,
+but only the *outputs*. To test the server end-to-end I need what produced them: the
+`postprocess_gfa_subgraph` (or the vg JSON, either works) for:
 
-**One heads-up:** the third request may take up to ~2 minutes, and while it runs the API is
-unresponsive to everything else. That's not the instrumentation; it's an existing bug I
-found (the endpoint is `async` but does blocking work, so one slow request stalls the event
-loop). Worth running at a quiet time.
+| region | size |
+| --- | ---: |
+| `chr8:78,771,162-78,771,252` | 0.29 MB |
+| `chr1:25,331,046-25,331,646` | 3.37 MB |
+| `chr8:10,079,054-10,080,461` | 3.97 MB |
+| `chr1:25,301,271-25,309,238` (node 5514) | 12.92 MB |
+| `chr1:25,331,646-25,335,796` (node 5520) | 13.56 MB |
 
-Happy to walk through any of this, or do the deploy myself if you'd rather give me access.
+Any way you can get them to me is fine. With those, `pgb`'s existing fixtures become a real
+end-to-end test and I can verify the rework against known-good output rather than against
+my own synthetic data.
 
-Thanks!
+Happy to jump on a call and do the deploy together if that's easier than doing it
+asynchronously.
+
+Thanks —
+Doug
 
 ---
 
-## Notes on sending
+## When the timings come back
 
-**The "logging only" claim is what gets this approved quickly, and it is accurate.** The
-change wraps existing calls in `with` blocks and adds one `log.info`. If they want to
-verify: `git show ab3e5b0 -- main.py` is a 65-line diff readable in a minute.
-
-**Keep the access offer.** If the answer is yes, this favour stops being needed every time —
-and inheriting this project, that access is worth having regardless.
-
-**The three regions are chosen to be uncached.** `preprocess_gfa_subgraph` is the one
-artifact the code caches, and a previously-queried region skips the most expensive upstream
-step — which is why the original measurements showed 1,000 bp returning faster than 300 bp.
-If these regions turn out to have been queried before, any three unqueried ones work; what
-matters is that the log line reports `cached=False`.
-
-## What to do with the reply
-
-1. Paste the three lines into [`seqtubemap-latency.md`](./seqtubemap-latency.md), replacing
-   the inferred split in §2 and closing §6.
-2. Update the published artifact **by passing its URL** — publishing without it forks the
-   link into a second artifact.
-3. Re-rank the roadmap in [`seqtubemap-plan.md`](./seqtubemap-plan.md) Step 3 if the numbers
-   disagree with the current ordering. In particular: if `subgraph_extract` dominates,
-   deleting the `vg` round trip wins less than its effort suggests, and the work moves to
-   how the `gbz-base` query is issued.
+- Fill in §2 and close §6 of [`seqtubemap-latency.md`](./seqtubemap-latency.md), where the
+  ~34 s upstream figure is currently marked as inferred by subtraction rather than measured.
+- Re-rank increment **D** in [`seqtubemap-plan.md`](./seqtubemap-plan.md) — it's the only
+  one gated on this. A-C are correct regardless of where the upstream time goes.
+- Update the rendered report **by passing its URL**
+  (`https://claude.ai/code/artifact/71539dd1-fb13-44d0-8468-a3a96e726114`); publishing
+  without it forks the link into a second artifact.

--- a/docs/perf/deploy-request.md
+++ b/docs/perf/deploy-request.md
@@ -1,0 +1,104 @@
+# Deploy request — stage timing on the live API
+
+A ready-to-send message asking whoever operates `pangenome-api.ucsd.edu` to deploy the
+timing branch and return three log lines.
+
+**Why this exists:** the `[stage-timing]` instrumentation is new code on
+`perf/seqtubemap-diagnosis`. The live server cannot produce these numbers as it stands, so
+the ask is "deploy this branch, hit three URLs, send a grep" — not "run something for me".
+
+**Why not measure locally:** this machine is arm64 and `docker-compose.yml` pins
+`platform: linux/amd64`, so a local container runs under x86 emulation. That inflates the
+native binaries (`vg`, `gbz-base`) unevenly — exactly the stages being measured. Local
+Docker is fine for developing the fix, not for timing it. See
+[`seqtubemap-plan.md`](./seqtubemap-plan.md) Step 0.
+
+Tone below is pitched as a peer asking a colleague. Adjust to fit.
+
+---
+
+**Subject: Small ask — deploy a logging-only branch to pangenome-api and send me three log lines?**
+
+Hi —
+
+I've been digging into why `/seqtubemap` is so slow, and I've got it narrowed down but I'm
+stuck on one measurement I can't take from outside. Could I ask ~10 minutes of your time?
+
+**What I've found so far:** a 10 kb region takes **120 seconds** and returns a **10 MB
+SVG**. I've confirmed the SVG-rendering step is only ~1–2 s of that, so roughly **34
+seconds is somewhere upstream** — in the gbz-base query, the GFA rewrite, `vg convert`, or
+`vg view -j`. I can't tell which from outside the server, and that one fact determines where
+the fix goes.
+
+**The ask:** I've pushed a branch that adds timing instrumentation around each pipeline
+stage:
+
+```
+perf/seqtubemap-diagnosis    (CAST-genomics/PangenomeAPI)
+```
+
+It's **logging only** — a context manager that records elapsed time, plus one log line per
+request. No change to any output, response, or pipeline behaviour. The relevant commit is
+`ab3e5b0`.
+
+If you could deploy it and hit these three regions (deliberately chosen as ones nobody's
+queried, so they don't hit the cached subgraph path):
+
+```
+https://pangenome-api.ucsd.edu:8000/seqtubemap?chrom=chr8&start=78900000&end=78900090&version=v2&pathnumoption=normal&nodewidthoption=compressed
+https://pangenome-api.ucsd.edu:8000/seqtubemap?chrom=chr8&start=78910000&end=78913000&version=v2&pathnumoption=normal&nodewidthoption=compressed
+https://pangenome-api.ucsd.edu:8000/seqtubemap?chrom=chr8&start=78920000&end=78930000&version=v2&pathnumoption=normal&nodewidthoption=compressed
+```
+
+…then send me the output of:
+
+```sh
+grep '\[stage-timing\]' <logfile>
+```
+
+Three lines, looking roughly like:
+
+```
+[stage-timing] chr8:78920000-78930000 span=10000bp v2 path=normal width=compressed
+cached=False total=118.442s subgraph_extract=94.1s gfa_process=12.3s gfa_to_vg=4.8s
+vg_to_json=6.1s generate_svg=1.2s json_mb=42.7 svg_mb=9.6
+```
+
+That's everything I need — I can take it from there.
+
+**One heads-up:** the third request may take up to ~2 minutes, and while it runs the API is
+unresponsive to everything else. That's not the instrumentation; it's an existing bug I
+found (the endpoint is `async` but does blocking work, so one slow request stalls the event
+loop). Worth running at a quiet time.
+
+Happy to walk through any of this, or do the deploy myself if you'd rather give me access.
+
+Thanks!
+
+---
+
+## Notes on sending
+
+**The "logging only" claim is what gets this approved quickly, and it is accurate.** The
+change wraps existing calls in `with` blocks and adds one `log.info`. If they want to
+verify: `git show ab3e5b0 -- main.py` is a 65-line diff readable in a minute.
+
+**Keep the access offer.** If the answer is yes, this favour stops being needed every time —
+and inheriting this project, that access is worth having regardless.
+
+**The three regions are chosen to be uncached.** `preprocess_gfa_subgraph` is the one
+artifact the code caches, and a previously-queried region skips the most expensive upstream
+step — which is why the original measurements showed 1,000 bp returning faster than 300 bp.
+If these regions turn out to have been queried before, any three unqueried ones work; what
+matters is that the log line reports `cached=False`.
+
+## What to do with the reply
+
+1. Paste the three lines into [`seqtubemap-latency.md`](./seqtubemap-latency.md), replacing
+   the inferred split in §2 and closing §6.
+2. Update the published artifact **by passing its URL** — publishing without it forks the
+   link into a second artifact.
+3. Re-rank the roadmap in [`seqtubemap-plan.md`](./seqtubemap-plan.md) Step 3 if the numbers
+   disagree with the current ordering. In particular: if `subgraph_extract` dominates,
+   deleting the `vg` round trip wins less than its effort suggests, and the work moves to
+   how the `gbz-base` query is issued.

--- a/docs/perf/seqtubemap-latency.html
+++ b/docs/perf/seqtubemap-latency.html
@@ -1,0 +1,454 @@
+<title>The 120-Second Tube Map</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Serif:wght@500;600&display=swap">
+
+<style>
+  :root {
+    --ground:   #F4F6F5;
+    --surface:  #FFFFFF;
+    --ink:      #141B1A;
+    --muted:    #5C6A66;
+    --faint:    #8B9793;
+    --rule:     #DCE2DF;
+    --accent:   #0F6E62;
+    --accent-w: #E3EFEC;
+    --critical: #A8321E;
+    --crit-w:   #F7E7E3;
+    --warn:     #B07A16;
+    --warn-w:   #F6EEDC;
+    --ok:       #3F7A4E;
+
+    --sans: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+    --serif: "IBM Plex Serif", Georgia, serif;
+    --mono: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+    --measure: 68ch;
+    --s1: 0.4rem; --s2: 0.75rem; --s3: 1.15rem;
+    --s4: 1.9rem; --s5: 3rem; --s6: 4.5rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --ground:   #0F1513;
+      --surface:  #171F1C;
+      --ink:      #E7ECE9;
+      --muted:    #9AA8A3;
+      --faint:    #6E7C77;
+      --rule:     #28332F;
+      --accent:   #57C3B1;
+      --accent-w: #14302B;
+      --critical: #E0725C;
+      --crit-w:   #331914;
+      --warn:     #D9A748;
+      --warn-w:   #302512;
+      --ok:       #72B384;
+    }
+  }
+  :root[data-theme="dark"] {
+    --ground:   #0F1513;
+    --surface:  #171F1C;
+    --ink:      #E7ECE9;
+    --muted:    #9AA8A3;
+    --faint:    #6E7C77;
+    --rule:     #28332F;
+    --accent:   #57C3B1;
+    --accent-w: #14302B;
+    --critical: #E0725C;
+    --crit-w:   #331914;
+    --warn:     #D9A748;
+    --warn-w:   #302512;
+    --ok:       #72B384;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 16.5px;
+    line-height: 1.62;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 78rem;
+    margin: 0 auto;
+    padding: var(--s5) var(--s4) var(--s6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--s5);
+  }
+
+  .col { max-width: var(--measure); }
+
+  /* ---- masthead ---- */
+  .mast { display: flex; flex-direction: column; gap: var(--s3); }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 500;
+  }
+  h1 {
+    font-family: var(--serif);
+    font-weight: 600;
+    font-size: clamp(2.1rem, 5.5vw, 3.4rem);
+    line-height: 1.06;
+    letter-spacing: -0.02em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  .standfirst {
+    font-size: 1.12rem;
+    color: var(--muted);
+    max-width: var(--measure);
+    margin: 0;
+  }
+  .standfirst strong { color: var(--ink); font-weight: 600; }
+
+  /* ---- headline stat row ---- */
+  .stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    gap: 1px;
+    background: var(--rule);
+    border: 1px solid var(--rule);
+  }
+  .stat { background: var(--surface); padding: var(--s3) var(--s3) var(--s2); }
+  .stat .n {
+    font-family: var(--mono);
+    font-size: 1.85rem;
+    font-weight: 600;
+    letter-spacing: -0.03em;
+    font-variant-numeric: tabular-nums;
+    display: block;
+    line-height: 1.1;
+  }
+  .stat .n.crit { color: var(--critical); }
+  .stat .l {
+    font-size: 0.8rem;
+    color: var(--muted);
+    display: block;
+    margin-top: var(--s1);
+  }
+
+  /* ---- sections ---- */
+  section { display: flex; flex-direction: column; gap: var(--s3); }
+  h2 {
+    font-family: var(--serif);
+    font-size: 1.55rem;
+    font-weight: 600;
+    letter-spacing: -0.012em;
+    margin: 0;
+    text-wrap: balance;
+  }
+  h2 .num {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--faint);
+    margin-right: 0.7em;
+    letter-spacing: 0.06em;
+  }
+  h3 {
+    font-family: var(--sans);
+    font-size: 1.02rem;
+    font-weight: 600;
+    margin: 0;
+  }
+  p { margin: 0; max-width: var(--measure); }
+  .sec-rule { border: 0; border-top: 1px solid var(--rule); margin: 0; }
+
+  code, .m {
+    font-family: var(--mono);
+    font-size: 0.87em;
+    background: var(--accent-w);
+    color: var(--accent);
+    padding: 0.12em 0.36em;
+    border-radius: 2px;
+  }
+
+  /* ---- tables ---- */
+  .scroll { overflow-x: auto; border: 1px solid var(--rule); background: var(--surface); }
+  table { border-collapse: collapse; width: 100%; font-size: 0.9rem; min-width: 34rem; }
+  th, td { padding: 0.62rem 0.9rem; text-align: right; white-space: nowrap; }
+  th:first-child, td:first-child { text-align: left; }
+  thead th {
+    font-family: var(--mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 500;
+    border-bottom: 1px solid var(--rule);
+  }
+  tbody td { font-family: var(--mono); font-variant-numeric: tabular-nums; border-bottom: 1px solid var(--rule); }
+  tbody tr:last-child td { border-bottom: 0; }
+  tbody tr.peak td { background: var(--crit-w); }
+  tbody tr.peak td:first-child { font-weight: 600; }
+  td.bad { color: var(--critical); font-weight: 600; }
+  .const { color: var(--faint); }
+
+  /* ---- findings ---- */
+  .findings { display: flex; flex-direction: column; gap: var(--s3); }
+  .finding {
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-left: 3px solid var(--accent);
+    padding: var(--s3) var(--s3) var(--s3) 1.35rem;
+    display: flex;
+    flex-direction: column;
+    gap: var(--s2);
+  }
+  .finding.is-crit { border-left-color: var(--critical); }
+  .finding.is-warn { border-left-color: var(--warn); }
+  .finding.is-out  { border-left-color: var(--faint); }
+  .fhead { display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--s2); }
+  .chip {
+    font-family: var(--mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    padding: 0.2em 0.5em;
+    border-radius: 2px;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+  .chip.measured { background: var(--crit-w);   color: var(--critical); }
+  .chip.inferred { background: var(--warn-w);   color: var(--warn); }
+  .chip.ruled    { background: var(--rule);     color: var(--muted); }
+  .finding p { font-size: 0.95rem; color: var(--muted); }
+  .finding p strong { color: var(--ink); font-weight: 600; }
+  .ref { font-family: var(--mono); font-size: 0.78rem; color: var(--faint); }
+
+  /* ---- evidence block ---- */
+  pre {
+    margin: 0;
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    padding: var(--s3);
+    overflow-x: auto;
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    line-height: 1.55;
+    color: var(--ink);
+  }
+  pre .dim { color: var(--faint); }
+  pre .hit { color: var(--critical); font-weight: 600; }
+
+  /* ---- lane diagram ---- */
+  figure { margin: 0; display: flex; flex-direction: column; gap: var(--s2); }
+  figcaption { font-size: 0.85rem; color: var(--muted); max-width: var(--measure); }
+  .lanes { width: 100%; height: auto; display: block; background: var(--surface); border: 1px solid var(--rule); }
+  /* var() does not resolve in SVG presentation attributes — style via CSS. */
+  .lanes .panel  { fill: var(--ground); stroke: var(--rule); }
+  .lanes .lane   { stroke: var(--accent); stroke-width: 1.4; opacity: 0.55; }
+  .lanes .merged { stroke: var(--accent); stroke-width: 4; }
+  .lanes .arrow  { stroke: var(--faint); stroke-width: 1.2; fill: none; }
+  .lanes .lbl    { fill: var(--muted); font-family: var(--mono); font-size: 11px; }
+  .lanes .sub    { fill: var(--faint); font-family: var(--mono); font-size: 10px; }
+
+  ul { margin: 0; padding-left: 1.1rem; max-width: var(--measure); display: flex; flex-direction: column; gap: var(--s1); }
+  li { color: var(--muted); }
+  li strong { color: var(--ink); font-weight: 600; }
+
+  footer {
+    border-top: 1px solid var(--rule);
+    padding-top: var(--s3);
+    font-size: 0.85rem;
+    color: var(--faint);
+    max-width: var(--measure);
+  }
+  a { color: var(--accent); }
+  a:focus-visible, summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+</style>
+
+<div class="wrap">
+
+  <header class="mast">
+    <span class="eyebrow">PangenomeAPI · performance diagnosis · 27 Aug 2026</span>
+    <h1>The 120-Second Tube Map</h1>
+    <p class="standfirst">The <code>/seqtubemap</code> endpoint takes <strong>two minutes</strong> to return a <strong>10 MB SVG</strong> for a 10 kb region — and while it does, it takes the entire API down. Measured against the live service at <span class="m">pangenome-api.ucsd.edu</span>, plus a local stage-timing harness.</p>
+  </header>
+
+  <div class="stats">
+    <div class="stat"><span class="n crit">120.4s</span><span class="l">to render 10 kb</span></div>
+    <div class="stat"><span class="n crit">10.1 MB</span><span class="l">SVG returned</span></div>
+    <div class="stat"><span class="n">464</span><span class="l">stacked lanes, every region</span></div>
+    <div class="stat"><span class="n">722 ms</span><span class="l">fixed boot cost per request</span></div>
+  </div>
+
+  <hr class="sec-rule">
+
+  <section>
+    <h2><span class="num">01</span>What the live API actually does</h2>
+    <p>Five sequential requests against <code>chr8</code> from position <span class="m">78,771,162</span>, growing the region each time. Everything else held constant: <code>version=v2</code>, <code>pathnumoption=normal</code>, <code>nodewidthoption=compressed</code>.</p>
+
+    <div class="scroll">
+      <table>
+        <thead>
+          <tr><th>Region</th><th>TTFB</th><th>Bytes</th><th>Tracks</th><th>Elements</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>90 bp</td><td>1.46 s</td><td>177,593</td><td class="const">464</td><td>1,201</td></tr>
+          <tr><td>300 bp</td><td>7.87 s</td><td>606,428</td><td class="const">464</td><td>3,641</td></tr>
+          <tr><td>1,000 bp</td><td>1.89 s</td><td>1,300,847</td><td class="const">464</td><td>7,553</td></tr>
+          <tr><td>3,000 bp</td><td class="bad">35.33 s</td><td>3,152,494</td><td class="const">464</td><td>18,073</td></tr>
+          <tr class="peak"><td>10,000 bp</td><td class="bad">120.40 s</td><td>10,071,688</td><td class="const">464</td><td>57,225</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p>Two readings matter here. <strong>Track count never moves</strong> — 464 at every region size, because that is the haplotype count, and it multiplies everything downstream. And <strong>time is wildly nonlinear and noisy</strong>: 1,000 bp came back faster than 300 bp. That inversion is the one piece of caching in the system leaking through — <code>preprocess_gfa_subgraph</code> is the only artifact checked with <code>.exists()</code>, so a previously-touched region skips the most expensive upstream step.</p>
+  </section>
+
+  <hr class="sec-rule">
+
+  <section>
+    <h2><span class="num">02</span>Where the time is not</h2>
+    <p>A local harness runs the Node half of the pipeline in isolation, mirroring <code>generate-svg.mjs</code> stage for stage. On a synthetic graph of <strong>36,106 elements</strong> — twice the size of the real 3,000 bp response — the entire Node stage completes in <strong>1.44 seconds</strong>:</p>
+
+    <pre><span class="dim">[stage]</span> import:jsdom+canvas    437.6ms  <span class="dim">rss=154MB</span>
+<span class="dim">[stage]</span> jsdom:construct-dom    109.0ms  <span class="dim">rss=179MB</span>
+<span class="dim">[stage]</span> import:tubemap.js      175.6ms  <span class="dim">rss=208MB</span>
+<span class="dim">[stage]</span> io:read-input            0.4ms
+<span class="dim">[stage]</span> parse:JSON.parse         4.5ms
+<span class="dim">[stage]</span> convert:vgExtractNodes   0.1ms
+<span class="dim">[stage]</span> convert:vgExtractTracks  0.7ms
+<span class="dim">[stage]</span> render:create()        647.2ms  <span class="dim">rss=468MB</span>
+<span class="dim">[stage]</span> serialize:outerHTML     48.4ms
+<span class="dim">[stage]</span> io:write-svg             9.8ms
+                       <span class="hit">total 1441.7ms</span></pre>
+
+    <p>The server spent <strong>35.3 s</strong> producing a smaller graph than this. So the SVG generation stage is roughly <strong>1–2 seconds of it</strong>, and something on the order of <strong>34 seconds sits upstream</strong> — in <code>gbz-base</code> subgraph extraction, <code>SeqTubeGfaProcessor</code>, <code>vg convert</code>, and <code>vg view -j</code>. That split is inferred, not directly measured; §06 says how to close it.</p>
+    <p>Note the first three lines. <strong>722 ms of that total is fixed cost</strong> — booting JSDOM, node-canvas, and importing 130 KB of <code>tubemap.js</code> — paid on every single request no matter how small the region.</p>
+  </section>
+
+  <hr class="sec-rule">
+
+  <section>
+    <h2><span class="num">03</span>Findings</h2>
+    <div class="findings">
+
+      <article class="finding is-crit">
+        <div class="fhead"><h3>One slow request takes down the whole API</h3><span class="chip measured">Measured</span></div>
+        <p><code>seqtubemap</code> is declared <code>async def</code>, but every call inside it is blocking: four synchronous <code>subprocess.run</code> invocations plus the gbz extraction. That blocks the FastAPI event loop outright. This was confirmed by accident — four unrelated requests issued while the 120 s call was in flight <strong>all failed with no HTTP status at all</strong>, then succeeded immediately once it finished. Concurrent requests don't queue, they die.</p>
+        <p class="ref">main.py:452 · blocking calls at :250, :273, :293</p>
+      </article>
+
+      <article class="finding is-crit">
+        <div class="fhead"><h3>Path aggregation is implemented, but effectively never fires</h3><span class="chip measured">Measured</span></div>
+        <p>The <code>pathnumoption=compressed</code> option groups haplotypes into <code>path_summary</code> keyed on <code>walk_update</code> — <strong>the entire node traversal across the whole region, as one string</strong>. Two haplotypes collapse only if their walks are byte-identical end to end, so a single SNP anywhere in the window keeps them apart. At 1,000 bp, <code>compressed</code> and <code>normal</code> returned <strong>byte-identical 1,300,847-byte responses</strong>: nothing collapsed.</p>
+        <p>This is aggregation at the wrong granularity. Collapsing tracks that agree <em>between branch points</em>, rather than across the entire walk, is what would actually merge those 464 lanes — and is closer to what a tube map is meant to draw.</p>
+        <p class="ref">main.py:212–226</p>
+      </article>
+
+      <article class="finding is-warn">
+        <div class="fhead"><h3>Most of the payload is repeated strings, not geometry</h3><span class="chip measured">Measured</span></div>
+        <p>In the real 90 bp response: <strong><code>style=</code> is 14% of bytes</strong> (<code>fill: rgb(211, 211, 211); fill-opacity: 1;</code> written out hundreds of times) and <strong><code>trackName=</code> is 13%</strong> — each track's full name, e.g. <code>NA20806#1#CM102444.1#0[80060344-80060632]</code>, duplicated per element. Actual path geometry <code>d=</code> is only 8%. There are 599 <code>&lt;title&gt;</code> elements for tooltips against 517 <code>&lt;rect&gt;</code>s.</p>
+      </article>
+
+      <article class="finding is-warn">
+        <div class="fhead"><h3>A browser is emulated server-side to emit XML</h3><span class="chip measured">Measured</span></div>
+        <p>To run the browser visualization component on the server, <code>generate-svg.mjs</code> stands up a full JSDOM document with <code>pretendToBeVisual: true</code>, plus a node-canvas instance whose only job is backing a monkey-patched <code>getComputedTextLength</code> for text measurement — then discards all of it and takes <code>.outerHTML</code> as a string. Nothing is rasterized; the cost is DOM emulation, and it is the <strong>722 ms fixed floor</strong> on every request.</p>
+        <p>The caveat: the layout math in <code>create()</code> is real work that has to happen somewhere. What is gratuitous is routing it through a DOM — not that it happens.</p>
+        <p class="ref">seqtubemap/generate-svg.mjs</p>
+      </article>
+
+      <article class="finding is-out">
+        <div class="fhead"><h3>Result caching is not the fix</h3><span class="chip ruled">Ruled out</span></div>
+        <p>The code deletes every intermediate <em>and the finished SVG</em> after each response, so identical repeat requests recompute from scratch — 3.18 s then 3.01 s for the same region. That looked like an easy win, but scientists poke arbitrary nodes across a loaded graph and rarely repeat a specific retrieval, so a cache would almost never hit. <strong>Ruled out on access-pattern grounds.</strong></p>
+        <p class="ref">main.py:485</p>
+      </article>
+
+    </div>
+  </section>
+
+  <hr class="sec-rule">
+
+  <section>
+    <h2><span class="num">04</span>Why 464 lanes is the multiplier</h2>
+    <figure>
+      <svg class="lanes" viewBox="0 0 720 190" role="img" aria-label="Diagram: 464 haplotype lanes rendered separately versus collapsed by shared segment">
+        <text class="lbl" x="16" y="20">pathnumoption=normal — 464 lanes, 7,080px tall</text>
+        <text class="lbl" x="410" y="20">collapsed per segment</text>
+        <rect class="panel" x="16" y="32" width="330" height="140"/>
+        <g class="lane">
+          <line x1="30" y1="40" x2="332" y2="40"/><line x1="30" y1="46" x2="332" y2="46"/>
+          <line x1="30" y1="52" x2="332" y2="52"/><line x1="30" y1="58" x2="332" y2="58"/>
+          <line x1="30" y1="64" x2="332" y2="64"/><line x1="30" y1="70" x2="332" y2="70"/>
+          <line x1="30" y1="76" x2="332" y2="76"/><line x1="30" y1="82" x2="332" y2="82"/>
+          <line x1="30" y1="88" x2="332" y2="88"/><line x1="30" y1="94" x2="332" y2="94"/>
+          <line x1="30" y1="100" x2="332" y2="100"/><line x1="30" y1="106" x2="332" y2="106"/>
+          <line x1="30" y1="112" x2="332" y2="112"/><line x1="30" y1="118" x2="332" y2="118"/>
+          <line x1="30" y1="124" x2="332" y2="124"/><line x1="30" y1="130" x2="332" y2="130"/>
+          <line x1="30" y1="136" x2="332" y2="136"/><line x1="30" y1="142" x2="332" y2="142"/>
+          <line x1="30" y1="148" x2="332" y2="148"/><line x1="30" y1="154" x2="332" y2="154"/>
+          <line x1="30" y1="160" x2="332" y2="160"/><line x1="30" y1="166" x2="332" y2="166"/>
+        </g>
+        <text class="sub" x="176" y="186" text-anchor="middle">…×464</text>
+
+        <path class="arrow" d="M360 100 L392 100"/>
+        <path class="arrow" d="M386 95 L392 100 L386 105"/>
+
+        <rect class="panel" x="404" y="32" width="300" height="140"/>
+        <g class="merged">
+          <line x1="420" y1="70" x2="688" y2="70"/>
+          <line x1="420" y1="94" x2="688" y2="94"/>
+          <line x1="420" y1="118" x2="688" y2="118"/>
+        </g>
+        <text class="sub" x="554" y="186" text-anchor="middle">shared segments merge</text>
+      </svg>
+      <figcaption>Every haplotype gets its own ~15 px row regardless of whether it differs from its neighbours anywhere in the window. At 90 bp that produces a 7,080 px-tall image; at 10 kb it produces 57,225 elements.</figcaption>
+    </figure>
+
+    <p>A local sweep holding tracks at 464 while growing the graph shows how steeply the byte count and memory follow — and where it stops working entirely:</p>
+
+    <div class="scroll">
+      <table>
+        <thead><tr><th>Spine nodes</th><th>create()</th><th>SVG</th><th>Elements</th><th>Peak RSS</th></tr></thead>
+        <tbody>
+          <tr><td>40</td><td>656 ms</td><td>4.92 MB</td><td>38,167</td><td>514 MB</td></tr>
+          <tr><td>150</td><td>1,975 ms</td><td>15.49 MB</td><td>119,053</td><td>1,222 MB</td></tr>
+          <tr><td>600</td><td>7,662 ms</td><td>57.32 MB</td><td>441,121</td><td>3,879 MB</td></tr>
+          <tr class="peak"><td>2,400</td><td class="bad">OOM</td><td class="bad">—</td><td class="bad">—</td><td class="bad">6 GB heap exhausted</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p>These are synthetic graphs and diverge more than real haplotypes do, so treat the absolute numbers as an upper bound. The shape is the point: <strong>memory, not CPU, is what ends the run.</strong></p>
+  </section>
+
+  <hr class="sec-rule">
+
+  <section>
+    <h2><span class="num">05</span>The harness</h2>
+    <p>Four files in <code>perf/</code>, no genomics toolchain required — they exercise the JSON→SVG boundary directly, so none of <code>data.path</code>, <code>tools.path</code>, or the HPRC graph files need to be provisioned.</p>
+    <ul>
+      <li><strong><code>gen-vg-json.mjs</code></strong> — deterministic synthetic vg JSON: reference spine, bubbles, haplotypes. Tunable <code>spineNodes</code>, <code>haplotypes</code>, <code>bubbleRate</code>, <code>altFreq</code>, <code>seqLen</code>, <code>seed</code>.</li>
+      <li><strong><code>stage-timer.mjs</code></strong> — mirrors <code>generate-svg.mjs</code> stage for stage, timing each and measuring output composition. Runs as its own process, because <code>tubemap.js</code> holds module-level layout state. Emits progress to stderr so a crash still names the stage that died.</li>
+      <li><strong><code>bench.mjs</code></strong> — sweeps one graph dimension at a time; <code>--input=real.json</code> takes a real fixture.</li>
+      <li><strong><code>cross.mjs</code></strong> — the tracks × nodes cross term, which is the case that matters.</li>
+    </ul>
+    <pre>node perf/stage-timer.mjs &lt;input.json&gt; &lt;out.svg&gt; &lt;start&gt; &lt;end&gt; &lt;nodeWidthOption&gt;
+node perf/bench.mjs --axis=spine
+SPINES=40,150,600 HAPS=464 ALT=0.08 node perf/cross.mjs</pre>
+    <p><code>perf/fixtures/</code> is gitignored — the sweeps generate hundreds of MB.</p>
+  </section>
+
+  <hr class="sec-rule">
+
+  <section>
+    <h2><span class="num">06</span>The one gap</h2>
+    <p>The ~34 s upstream figure is <strong>inferred by subtraction</strong>, not measured. Everything else in this report is a direct observation. Closing it is small: add tagged timers around the four pipeline calls in <code>seqtubemap</code> — <code>SubgraphMC</code>, <code>SeqTubeGfaProcessor</code>, <code>ConvertGfaToVg</code>, <code>ConvertVgToJson</code>, <code>GenerateSeqTubeMapSvg</code> — and log the split per request. That turns the largest remaining unknown into a number and tells you whether the first real fix belongs in <code>gbz-base</code> extraction or in the <code>vg</code> conversion hop.</p>
+  </section>
+
+  <footer>
+    Measured 27 Aug 2026 against <span class="m">pangenome-api.ucsd.edu:8000</span> and locally on Node v26.7.0 / darwin 25.5.0. Live-API timings are single samples on a shared service and carry real variance; the local harness is deterministic and repeatable.
+  </footer>
+
+</div>

--- a/docs/perf/seqtubemap-latency.md
+++ b/docs/perf/seqtubemap-latency.md
@@ -183,6 +183,11 @@ SPINES=40,150,600 HAPS=464 ALT=0.08 node perf/cross.mjs
 The ~34 s upstream figure in §2 is **inferred by subtraction**. Everything else in this
 document is a direct observation.
 
+> **Still true as of §9.** Sections 7-9 added three more direct measurements and closed the
+> layout-vs-DOM question, but none of them touches the upstream stage. This remains the one
+> number in the document that nobody has watched a clock for, and it is the only thing
+> gating increment **D** in [ADR 0001](../adr/0001-additive-band-format.md).
+
 Server-side stage timers are now in place (`stage_timing()` in `main.py`, wrapping all five
 pipeline calls). Each request emits one greppable line:
 
@@ -206,6 +211,111 @@ Capture a spread — 90 bp, 3 kb, 10 kb — each against a **fresh region** so `
 because the cached path skips the stage most likely to dominate. That result either confirms
 the ~34 s upstream inference or overturns it, and tells you whether the first real fix
 belongs in `gbz-base` extraction or the `vg` conversion hop.
+
+## 7. Where the memory goes — the DOM, not the layout
+
+Measured 2026-08-27 with `perf/rss-split.mjs`, which marks retained heap (a forced full GC
+before every mark) at each boundary of a render, then tears the document down and marks
+again. What is released by emptying the DOM is what the DOM was holding; what survives is
+`tubemap.js`'s module-level layout state.
+
+| fixture | `create()` retained | **DOM share** | layout share |
+| --- | ---: | ---: | ---: |
+| spine 150 x 464 strands | 567.6 MB | **530.7 MB (93.5%)** | 36.9 MB |
+| spine 400 x 464 strands | 1522.7 MB | **1427.5 MB (93.7%)** | 95.2 MB |
+
+Two sizes, two points four decimal places apart. The layout is roughly **15x smaller** than
+the document built to hold it, and holds no DOM references — emptying the document releases
+essentially all of it.
+
+This closes a question section 3 could not answer. `render:create()` was measured as one
+stage covering both the layout computation and the jsdom construction, and the ranking of
+every proposed fix depended on which of the two it was. It is the DOM. Consequently the
+unfetchable-node ceiling — roughly 43% of catalogued nodes, per `pgb`'s ADR 0001 — is a DOM
+ceiling, and removing the DOM should raise it by about an order of magnitude.
+
+Reproduce with:
+
+```sh
+node perf/gen-vg-json.mjs perf/fixtures/split-400.json \
+  --spineNodes=400 --haplotypes=464 --bubbleRate=0.3 --altFreq=0.08 --seqLen=20 --seed=7
+node --expose-gc --max-old-space-size=8192 perf/rss-split.mjs \
+  perf/fixtures/split-400.json 0 8000 compressed
+```
+
+`--expose-gc` is mandatory; without it the harness refuses to run, because retained-memory
+numbers taken without a forced collection are garbage-in-flight rather than retention.
+
+## 8. Where the bytes go — five real documents
+
+Sections 1-3 measured byte composition on one 90 bp response. `pgb` commits five real golden
+documents in `src/tubemap/__tests__/fixtures/`, spanning 0.29 MB to 13.56 MB and 369 to 464
+strands, including the two at the fetch ceiling. The composition is stable across all of
+them.
+
+| | 90 bp | 600 bp | chr8 1.4 kb | node 5514 | node 5520 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| size | 0.29 MB | 3.37 MB | 3.97 MB | 12.92 MB | 13.56 MB |
+| strands | 464 | 369 | 463 | 378 | 464 |
+| `d=` — the geometry | 15.0% | 28.1% | 25.6% | 28.4% | 29.9% |
+| `style=` — 1 of ~464 rgb triples | 16.4% | 14.5% | 13.9% | 14.4% | 14.2% |
+| `trackName=` — 1 of ~464 names | 11.4% | 10.3% | 14.5% | 10.1% | 10.1% |
+| `color=` — *the same rgb as `style`* | 8.6% | 7.6% | 7.3% | 7.3% | 7.5% |
+| `class="track{id}"` — same int as `trackID` | 5.4% | 4.8% | 4.7% | 4.8% | 4.8% |
+| `<title></title>` — empty | 5.0% | 4.4% | 4.2% | 4.3% | 4.3% |
+| **redundant total** | **46.9%** | **41.5%** | **44.6%** | **40.9%** | **40.8%** |
+
+Read that bottom row as: **between 41% and 47% of every response carries no information.**
+Each row above it is either a per-strand constant re-serialized once per band, or — in the
+case of `color=` and `class=` — a second copy of a value already present in the same
+element, or, in the case of `<title></title>`, nothing whatsoever. Node 5520 alone carries
+**40,716 empty `<title>` elements**, which is also 40,716 jsdom nodes feeding directly into
+section 7.
+
+The geometry, the only genuinely per-band content in the document, is under a third of it.
+
+Two further facts from the same pass:
+
+- **Zero `<text>` and zero `<line>` elements**, in every one of the five. No labels, no
+  legend, no axis. The production document is bands and segment boxes and nothing else.
+- **The strand count is not always 464** — 369, 378, 463, 464 across the set. It is a
+  property of the region, not a constant.
+
+## 9. The geometry never needed a browser
+
+At `seqtubemap/tubemap.js:3599`:
+
+```js
+.data(flattenedGroups).enter().append("path")
+  .attr("d", (d) => d.path)        // already a complete "M ... C ... Z" string
+  .style("fill", (d) => d.color)
+  .attr("trackID", (d) => d.id)
+  .attr("trackName", (d) => d.name)
+  .append("svg:title")             // an empty <title> on every band
+```
+
+`d.path` is a finished string before any element exists. jsdom's entire contribution to this
+pipeline is to hold that string and hand it back through `outerHTML`. `tubemap.js`'s total
+DOM surface is five `d3.` calls, `document.getElementById`, and `getComputedTextLength`.
+
+Meanwhile `pgb` never renders the result. `src/tubemap/parseBands.ts` regexes it —
+*"deliberately regex over raw response text, never `DOMParser`"* — back into six floats per
+band. The round trip is: layout computes numbers, jsdom holds them as XML, the wire carries
+the XML, and the client parses the XML back into numbers.
+
+What the client actually reads is three things:
+
+| | consumed by `pgb` |
+| --- | --- |
+| document | viewBox — dimensions and centre |
+| bands | geometry, `trackID`, rgb, `trackName`, `pclaiX/Y/Score` |
+| segment boxes | `id`, outline, `sequence` |
+
+Everything else in the payload is ignored, which is the same set section 8 measures as
+redundant.
+
+The decision this evidence produced is
+[ADR 0001](../adr/0001-additive-band-format.md).
 
 ---
 

--- a/docs/perf/seqtubemap-latency.md
+++ b/docs/perf/seqtubemap-latency.md
@@ -1,0 +1,213 @@
+# `/seqtubemap` latency and payload size
+
+Performance diagnosis of the sequence tube map endpoint. Measured 2026-08-27 against the
+live service at `pangenome-api.ucsd.edu:8000`, plus a local stage-timing harness
+(Node v26.7.0, darwin 25.5.0).
+
+- Rendered version: <https://claude.ai/code/artifact/71539dd1-fb13-44d0-8468-a3a96e726114>
+- Source of the rendered version: [`seqtubemap-latency.html`](./seqtubemap-latency.html)
+- Harness: [`perf/`](../../perf/)
+
+**Headline:** a 10 kb region takes **120 seconds** and returns a **10 MB SVG** — and while
+it does, it takes the entire API down for every other caller.
+
+---
+
+## 1. What the live API actually does
+
+Five sequential requests against `chr8` from position 78,771,162, growing the region each
+time. Everything else held constant: `version=v2`, `pathnumoption=normal`,
+`nodewidthoption=compressed`.
+
+| Region | TTFB | Bytes | Tracks | Elements |
+| --- | ---: | ---: | ---: | ---: |
+| 90 bp | 1.46 s | 177,593 | 464 | 1,201 |
+| 300 bp | 7.87 s | 606,428 | 464 | 3,641 |
+| 1,000 bp | 1.89 s | 1,300,847 | 464 | 7,553 |
+| 3,000 bp | 35.33 s | 3,152,494 | 464 | 18,073 |
+| **10,000 bp** | **120.40 s** | **10,071,688** | 464 | 57,225 |
+
+Two readings matter.
+
+**Track count never moves** — 464 at every region size, because that is the haplotype
+count, and it multiplies everything downstream.
+
+**Time is wildly nonlinear and noisy**: 1,000 bp came back faster than 300 bp. That
+inversion is the one piece of caching in the system leaking through —
+`preprocess_gfa_subgraph` is the only artifact checked with `.exists()`, so a
+previously-touched region skips the most expensive upstream step.
+
+## 2. Where the time is not
+
+A local harness runs the Node half of the pipeline in isolation, mirroring
+`generate-svg.mjs` stage for stage. On a synthetic graph of **36,106 elements** — twice
+the size of the real 3,000 bp response — the entire Node stage completes in **1.44 s**:
+
+```
+[stage] import:jsdom+canvas    437.6ms  rss=154MB
+[stage] jsdom:construct-dom    109.0ms  rss=179MB
+[stage] import:tubemap.js      175.6ms  rss=208MB
+[stage] io:read-input            0.4ms
+[stage] parse:JSON.parse         4.5ms
+[stage] convert:vgExtractNodes   0.1ms
+[stage] convert:vgExtractTracks  0.7ms
+[stage] render:create()        647.2ms  rss=468MB
+[stage] serialize:outerHTML     48.4ms
+[stage] io:write-svg             9.8ms
+                       total 1441.7ms
+```
+
+The server spent **35.3 s** producing a *smaller* graph than this. So the SVG generation
+stage is roughly **1–2 seconds of it**, and on the order of **34 seconds sits upstream** —
+in `gbz-base` subgraph extraction, `SeqTubeGfaProcessor`, `vg convert`, and `vg view -j`.
+
+> This split is **inferred by subtraction, not directly measured.** See §6.
+
+Note the first three lines: **722 ms is fixed cost** — booting JSDOM, node-canvas, and
+importing 130 KB of `tubemap.js` — paid on every request no matter how small the region.
+
+## 3. Findings
+
+### One slow request takes down the whole API — *measured*
+
+`seqtubemap` is declared `async def`, but every call inside it is blocking: four
+synchronous `subprocess.run` invocations plus the gbz extraction. That blocks the FastAPI
+event loop outright.
+
+Confirmed by accident: four unrelated requests issued while the 120 s call was in flight
+**all failed with no HTTP status at all**, then succeeded immediately once it finished.
+Concurrent requests don't queue, they die.
+
+*`main.py:452`; blocking calls at `:250`, `:273`, `:293`*
+
+### Path aggregation is implemented, but effectively never fires — *measured*
+
+`pathnumoption=compressed` groups haplotypes into `path_summary` keyed on `walk_update` —
+**the entire node traversal across the whole region, as one string**. Two haplotypes
+collapse only if their walks are byte-identical end to end, so a single SNP anywhere in the
+window keeps them apart.
+
+At 1,000 bp, `compressed` and `normal` returned **byte-identical 1,300,847-byte
+responses**: nothing collapsed.
+
+This is aggregation at the wrong granularity. Collapsing tracks that agree *between branch
+points*, rather than across the entire walk, is what would actually merge those 464 lanes —
+and is closer to what a tube map is meant to draw.
+
+*`main.py:212–226`*
+
+### Most of the payload is repeated strings, not geometry — *measured*
+
+In the real 90 bp response:
+
+| Component | Bytes | Share |
+| --- | ---: | ---: |
+| `style=` attributes | 25,163 | 14% |
+| `trackName=` attributes | 24,632 | 13% |
+| `d=` path geometry | 14,522 | 8% |
+
+`style=` is `fill: rgb(211, 211, 211); fill-opacity: 1;` written out hundreds of times.
+`trackName=` is each track's full name — e.g. `NA20806#1#CM102444.1#0[80060344-80060632]` —
+duplicated per element. Element counts: 599 `<title>`, 517 `<rect>`, 82 `<path>`, 2 `<g>`,
+1 `<svg>`.
+
+### A browser is emulated server-side to emit XML — *measured*
+
+To run the browser visualization component on the server, `generate-svg.mjs` stands up a
+full JSDOM document with `pretendToBeVisual: true`, plus a node-canvas instance whose only
+job is backing a monkey-patched `getComputedTextLength` for text measurement — then
+discards all of it and takes `.outerHTML` as a string.
+
+Nothing is rasterized; the cost is DOM emulation, and it is the **722 ms fixed floor** on
+every request.
+
+Caveat: the layout math in `create()` is real work that has to happen somewhere. What is
+gratuitous is routing it through a DOM — not that it happens.
+
+*`seqtubemap/generate-svg.mjs`*
+
+### Result caching is not the fix — *ruled out*
+
+The code deletes every intermediate *and the finished SVG* after each response, so
+identical repeat requests recompute from scratch — 3.18 s then 3.01 s for the same region.
+
+That looks like an easy win, but scientists poke arbitrary nodes across a loaded graph and
+rarely repeat a specific retrieval, so a cache would almost never hit. **Ruled out on
+access-pattern grounds** — recorded here because the deletion looks like obvious dead
+weight to anyone reading the code cold.
+
+*`main.py:485`*
+
+## 4. Why 464 lanes is the multiplier
+
+Every haplotype gets its own ~15 px row regardless of whether it differs from its
+neighbours anywhere in the window. At 90 bp that produces a **7,080 px-tall** image; at
+10 kb it produces 57,225 elements.
+
+A local sweep holding tracks at 464 while growing the graph:
+
+| Spine nodes | `create()` | SVG | Elements | Peak RSS |
+| ---: | ---: | ---: | ---: | ---: |
+| 40 | 656 ms | 4.92 MB | 38,167 | 514 MB |
+| 150 | 1,975 ms | 15.49 MB | 119,053 | 1,222 MB |
+| 600 | 7,662 ms | 57.32 MB | 441,121 | 3,879 MB |
+| **2,400** | **OOM** | — | — | **6 GB heap exhausted** |
+
+These are synthetic graphs and diverge more than real haplotypes do, so treat the absolute
+numbers as an upper bound. The shape is the point: **memory, not CPU, is what ends the
+run.**
+
+## 5. The harness
+
+Four files in [`perf/`](../../perf/). No genomics toolchain required — they exercise the
+JSON→SVG boundary directly, so none of `data.path`, `tools.path`, or the HPRC graph files
+need to be provisioned.
+
+| File | Purpose |
+| --- | --- |
+| `gen-vg-json.mjs` | Deterministic synthetic vg JSON: reference spine, bubbles, haplotypes. Tunable `spineNodes`, `haplotypes`, `bubbleRate`, `altFreq`, `seqLen`, `seed`. |
+| `stage-timer.mjs` | Mirrors `generate-svg.mjs` stage for stage, timing each and measuring output composition. Runs as its own process because `tubemap.js` holds module-level layout state. Emits progress to stderr so a crash still names the stage that died. |
+| `bench.mjs` | Sweeps one graph dimension at a time; `--input=real.json` takes a real fixture. |
+| `cross.mjs` | The tracks × nodes cross term, which is the case that matters. |
+
+```sh
+node perf/stage-timer.mjs <input.json> <out.svg> <start> <end> <nodeWidthOption>
+node perf/bench.mjs --axis=spine
+SPINES=40,150,600 HAPS=464 ALT=0.08 node perf/cross.mjs
+```
+
+`perf/fixtures/` is gitignored — the sweeps generate hundreds of MB.
+
+## 6. The one gap, and how to close it
+
+The ~34 s upstream figure in §2 is **inferred by subtraction**. Everything else in this
+document is a direct observation.
+
+Server-side stage timers are now in place (`stage_timing()` in `main.py`, wrapping all five
+pipeline calls). Each request emits one greppable line:
+
+```
+[stage-timing] chr8:78771162-78781162 span=10000bp v2 path=normal width=compressed
+cached=False total=118.442s subgraph_extract=94.1s gfa_process=12.3s gfa_to_vg=4.8s
+vg_to_json=6.1s generate_svg=1.2s json_mb=42.7 svg_mb=9.6
+```
+
+*(Illustrative values — the real ones are what we're after.)*
+
+```sh
+grep '\[stage-timing\]' <logfile>
+```
+
+`cached=` reports whether `preprocess_gfa_subgraph` already existed, which is what caused
+the 1000 bp-faster-than-300 bp inversion above; without it the numbers are uninterpretable.
+`json_mb`/`svg_mb` are captured before the background delete task fires.
+
+Capture a spread — 90 bp, 3 kb, 10 kb — each against a **fresh region** so `cached=False`,
+because the cached path skips the stage most likely to dominate. That result either confirms
+the ~34 s upstream inference or overturns it, and tells you whether the first real fix
+belongs in `gbz-base` extraction or the `vg` conversion hop.
+
+---
+
+*Live-API timings are single samples on a shared service and carry real variance. The local
+harness is deterministic and repeatable.*

--- a/docs/perf/seqtubemap-plan.md
+++ b/docs/perf/seqtubemap-plan.md
@@ -17,10 +17,15 @@ Written 2026-08-27, at the end of the diagnosis phase.
 
 | | |
 | --- | --- |
-| Branch | `perf/seqtubemap-diagnosis` at `ab3e5b0`, local only, `main` untouched |
-| Diagnosis | Complete, with one open gap (see Step 1) |
+| Branch | `perf/seqtubemap-diagnosis`, PR [#12](https://github.com/CAST-genomics/PangenomeAPI/pull/12) open |
+| Diagnosis | Complete. One gap remains: the upstream stage (see Step 0) |
+| Grilling | Complete, 2026-08-27. Produced [`CONTEXT.md`](../../CONTEXT.md) and [ADR 0001](../adr/0001-additive-band-format.md) |
 | Built | Local harness (`perf/`), server-side stage timers (`main.py`) |
 | Changed in production behaviour | Nothing yet |
+
+**The shape of the work is now settled.** Steps 1 and 2 below are done; what remains is
+Step 0 (a deploy, not a decision) and Step 3 (the build). The increments are A-D under
+*The roadmap* and they come from ADR 0001, not from this document.
 
 ## Decisions already made — do not reopen
 
@@ -38,7 +43,29 @@ real defect worth its own issue — it just isn't the performance strategy.)
 
 **The target is systemic plumbing inefficiency**, not hot loops and not data volume. The
 working thesis is that the server is a set of separately-authored pieces joined by temp
-files and subprocesses, and that the cost lives in the joins.
+files and subprocesses, and that the cost lives in the joins. Measurement bore this out: the
+single largest cost is a headless browser emulated to serialize XML that the client parses
+straight back into numbers.
+
+Added by the grilling session, 2026-08-27. Each of these is recorded with its reasoning in
+[ADR 0001](../adr/0001-additive-band-format.md):
+
+**The band format is additive, never a replacement.** `?format=bands` appears beside the
+existing SVG URL, which keeps working. The two repos never deploy in lockstep, and the SVG
+stays as the oracle the band payload is checked against.
+
+**The band data is canonical; the SVG is derived from it.** Not two sinks over one layout —
+one path, so drift is impossible by construction rather than by discipline.
+
+**`pgb` is the sole consumer**, and the `parseBands` grammar is an internal encoding between
+two repos on one team rather than a public contract.
+
+**Correctness is `parseBands`-equivalence**, not byte-identity — except in increment B,
+where byte-compatibility is a deliberate constraint so the client need not move at all.
+
+**`pathnumoption` does not exist on the band route.** It is measurably dead
+(`main.py:212-226`, byte-identical output to `normal`), and fixing it would merge strands,
+which is a data change and out of scope.
 
 ## Known-good baseline
 
@@ -75,9 +102,17 @@ whole plan.
 > This does not block Step 1. Start the deploy, then begin grilling; fold the numbers in
 > when they arrive.
 
-## Step 1 — Sharpen the idea
+## Step 1 — Sharpen the idea ✅ *done 2026-08-27*
 
 **Skill:** `/grill-with-docs` — the stateful interview.
+
+**Outcome:** six rounds. Produced [`CONTEXT.md`](../../CONTEXT.md) — which `CLAUDE.md` had
+been promising all along — and [ADR 0001](../adr/0001-additive-band-format.md). Two
+measurements were taken mid-interview to settle questions rather than guess at them: the
+layout-vs-DOM split (§7 of the findings) and the five-fixture byte census (§8).
+
+The one-sentence statement of the change, per the exit criteria: **`/seqtubemap` publishes
+the numbers it already has, instead of emulating a browser to hide them in XML.**
 
 Precede it with **`/compact`**, not `/clear`. The diagnosis context matters to the
 grilling — particularly the ruled-out paths above — but the raw sweep output does not, and
@@ -108,7 +143,14 @@ from the GFA, skipping `vg convert` and `vg view -j` entirely?* That is a questi
 answered by throwaway code against a real GFA, not by argument. Bridge with **`/handoff`**
 out and back, and reference the prototype branch from the resulting issue.
 
-## Step 2 — Decide the build shape
+## Step 2 — Decide the build shape ✅ *done 2026-08-27*
+
+**Answer: multi-session.** Four separable increments with real ordering between them, so
+**`/to-spec`** then **`/to-tickets`**, filing into `CAST-genomics/PangenomeAPI` per
+[`docs/agents/issue-tracker.md`](../agents/issue-tracker.md), each ticket declaring its
+blocking edges. A-D below are the increments those tickets cover.
+
+*Original guidance, retained:*
 
 **Skill:** still inside the Step 1 window. Do not compact between Steps 1 and 2.
 
@@ -134,30 +176,82 @@ self-contained, so the previous one's context is disposable.
 
 ### The roadmap, in order
 
-Ranked on evidence as of 2026-08-27. **Step 0's numbers may reorder this** — in particular,
-if `subgraph_extract` dominates, items 1–2 win less than their effort suggests and the real
-work moves into how the `gbz-base` query is issued.
+Superseded 2026-08-27 by the grilling session. The previous ranking led with *delete the
+`vg` round trip*, on the reasoning that it was the most obviously silly thing in the
+pipeline. Two measurements re-ranked it: the DOM is **93.7%** of the memory, and **41-47%**
+of every response carries no information. The ceiling has a name now, so the work that
+raises it goes first and `vg` drops to last. Full reasoning in
+[ADR 0001](../adr/0001-additive-band-format.md).
 
-1. **Delete the `vg` round trip.** `GFA → protobuf → JSON` exists only to change format
-   between two processes this project controls, and inflates the payload **13×** (3.9 B per
-   node visit as a GFA walk, 51.0 B as vg JSON, identical information). The target schema is
-   trivial — `node[]` of `{id, sequence}`, `path[]` of `{name, mapping[].position}` — and
-   the GFA already contains it. Removes two subprocess spawns and two temp files.
-2. **Stop round-tripping through disk.** With `vg` gone, the remaining stages can pass bytes
-   rather than filenames. The SVG is currently written to disk purely so `FileResponse` can
-   read it back.
-3. **Unblock the event loop.** `seqtubemap` is `async def` with four blocking
-   `subprocess.run` calls inside it. This wins no latency but stops one slow request from
-   killing every concurrent one — currently a hard outage, observed.
-4. **Kill the per-request Node boot.** 722 ms measured, paid on every request, to start a
-   process that immediately rebuilds the same JSDOM document.
-5. **Only then** revisit the layout substrate — running the tube map layout without
-   emulating a browser, or moving it to the client. Real, but 1–4 are cheaper and may make
-   it unnecessary.
+Ranked by **what it wins**, against the goals in priority order: (1) no request blocks
+another, (2) the unfetchable-node ceiling rises, (3) wall-clock. Bytes are a consequence of
+these, never a target in themselves.
 
-Not on this list but worth its own issue: **`pathnumoption=compressed` never fires**
-(`main.py:212–226`) — it keys on the entire walk across the region, so one SNP prevents any
-collapse. A correctness defect, not a performance item.
+| | change | wins | risk |
+| --- | --- | --- | --- |
+| **#12** | stage timing *(PR open)* | measurement | none — no behaviour change |
+| **A** | `async def` → `def` ×2; lazy `TabixFile` | goal 1 | very low |
+| **B** | capture the d3 joins; derive SVG from band data; **delete jsdom + canvas** | goal 2 | low — see below |
+| **C** | floats not strings; binary body; `?format=bands` | goals 2, 3 | medium |
+| **D** | delete the `vg` round trip | goal 3 | gated on Step 0 |
+
+**A — unblock the event loop.** `main.py:470` and `:527` are both `async def`, and neither
+awaits anything: every pipeline stage is a blocking `subprocess.run`. FastAPI runs a plain
+`def` endpoint in a threadpool automatically, so **deleting the word `async` twice is the
+fix.** Ship it with the lazy `TabixFile` opens (`main.py:71`, `:73`, `:81`), which currently
+prevent the app from booting unless all three `.walk.gz` derivatives are present even for a
+request that touches none of them. Both are server-wide, so this improves `/json` too —
+which also makes it the easiest PR in the programme for Cici to say yes to.
+
+**B — delete the browser.** Capture the d3 data joins rather than appending to a document,
+emit the SVG from the captured band data, and drop `jsdom` and `canvas` from
+`package.json` — two of five dependencies, present solely to feed `tubemap.js`.
+
+The reason B is *low* risk and not medium: it is held **byte-compatible with `pgb`'s
+existing parser by design**. `parseBands.ts` requires `style="fill: rgb(R, G, B);
+fill-opacity: 1;" trackID="N" trackName="…"` contiguous and in that order, and its
+conformance gate counts `<rect>` + `<path>` in `g.track`. Dropping `color=`, `class=`, and
+the empty `<title>` children changes neither. So B is a **server-only change against an
+unchanged client**, and `pgb` becomes its conformance test — a bad B surfaces as an error
+card in the frontend rather than as a diff nobody ran.
+
+B ships band data carrying *path strings*, not six floats, and that is deliberate: it takes
+the entire ceiling win without touching a line of geometry code, and leaves C as a pure
+encoding change with B's own output as its oracle.
+
+**C — the format.** The path builder emits floats; the response becomes a JSON header (the
+viewBox and the ~464-row strand table) plus a binary body of `Float32 × 6 + Uint16` per band.
+Roughly **1.5 MB against today's 10.07 MB** at the 10 kb region, with `pgb`'s regex pass
+deleted rather than shrunk — typed arrays copy straight into the GPU buffer. This is the
+increment where `pgb` changes, and where `pgb`'s ADR 0002 gets amended.
+
+**D — delete the `vg` round trip.** Unchanged in substance from the original item 1:
+`GFA → protobuf → JSON` exists only to change format between two processes this project
+controls, inflates the payload **13×** (3.9 B per segment visit as a GFA walk, 51.0 B as vg
+JSON), and costs two subprocess spawns and two temp files. It sits *upstream* of layout, so
+the band format does not touch it. **Do not start it until Step 0 reports** — if
+`subgraph_extract` dominates, this is noise.
+
+Also worth its own issue, and not a performance item: **`pathnumoption=compressed` never
+fires** (`main.py:212-226`). It keys on the entire walk across the region, so a single SNP
+prevents any collapse — measured byte-identical to `normal` at 1000 bp. It is a correctness
+defect, and ADR 0001 records why it is not carried onto the band route.
+
+### Two things to do alongside
+
+**Declare the fork.** `seqtubemap/tubemap.js` is an unmarked 4,000-line vendored copy of
+`vgteam/sequence-tube-map`, carrying upstream's eslint header and no provenance, version, or
+README note. B removes its DOM sink, so the re-sync option is gone in fact; a header comment
+naming upstream and the commit makes it gone on paper. This is the single most
+duct-taped-feeling artifact in the repo and one comment fixes the feeling as well as the
+fact.
+
+**Get golden inputs.** `pgb` commits five real documents in
+`src/tubemap/__tests__/fixtures/` — 0.29 MB to 13.56 MB, 369 to 464 strands, including the
+two at the fetch ceiling. Those pin the *expected* side. The matching **inputs** exist only
+on the live server, so the intermediates for those five regions are part of the ask in
+[`deploy-request.md`](./deploy-request.md). Once they land, the fixtures become end-to-end
+and B has a real oracle.
 
 ## Step 4 — Verify
 
@@ -170,7 +264,14 @@ re-run the local harness to confirm the Node stage did not regress:
 node perf/bench.mjs --axis=spine
 SPINES=40,150,600 HAPS=464 ALT=0.08 node perf/cross.mjs
 python3 perf/gfa-rewrite-bench.py
+node --expose-gc --max-old-space-size=8192 perf/rss-split.mjs \\
+  perf/fixtures/split-400.json 0 8000 compressed
 ```
+
+`rss-split.mjs` is the one that matters after B: it should report the DOM share at or near
+**zero**, because there should no longer be a DOM. Its `--expose-gc` requirement is not
+optional — retained-memory numbers taken without a forced collection measure garbage rather
+than retention.
 
 Update `seqtubemap-latency.md` with after-numbers beside the before-numbers. Update the
 artifact by passing its URL — publishing without it forks the link into a second artifact.
@@ -194,9 +295,13 @@ artifact by passing its URL — publishing without it forks the link into a seco
 
 ## Open questions
 
-- Does `subgraph_extract` dominate? (Step 0 answers this.)
-- Is the SVG-over-HTTP contract with pgb fixed, or can the response shape change? This
-  gates roadmap item 5 entirely and is a pgb question, not an API one.
-- Does anything downstream depend on the intermediate `.gfa` / `.vg` / `.json` files
-  existing on disk, or are they purely internal? They are deleted after every response,
-  which suggests purely internal — worth confirming before removing them.
+- **Does `subgraph_extract` dominate?** Step 0 answers this. It is the last unmeasured
+  number in the whole effort, and it gates increment D alone — every other increment is
+  correct regardless of where the upstream time goes.
+- **Does anything depend on the intermediate `.gfa` / `.vg` / `.json` files existing on
+  disk?** They are deleted after every response, which suggests purely internal — worth
+  confirming with Cici before removing them.
+
+*Closed by the grilling session:* whether the SVG contract can change (yes — `pgb` is the
+sole consumer and the two repos are one team), and whether `create()`'s cost is layout or
+DOM (DOM, 93.7%).

--- a/docs/perf/seqtubemap-plan.md
+++ b/docs/perf/seqtubemap-plan.md
@@ -1,0 +1,202 @@
+# `/seqtubemap` performance work — order of events
+
+A working plan for the `/seqtubemap` latency effort: what happens in what order, which
+skill drives each step, and what has already been decided so it doesn't get re-litigated.
+
+Companion documents:
+
+- [`seqtubemap-latency.md`](./seqtubemap-latency.md) — the measured findings this plan acts on
+- [`perf/`](../../perf/) — the harness
+- Rendered report: <https://claude.ai/code/artifact/71539dd1-fb13-44d0-8468-a3a96e726114>
+
+Written 2026-08-27, at the end of the diagnosis phase.
+
+---
+
+## Where things stand
+
+| | |
+| --- | --- |
+| Branch | `perf/seqtubemap-diagnosis` at `ab3e5b0`, local only, `main` untouched |
+| Diagnosis | Complete, with one open gap (see Step 1) |
+| Built | Local harness (`perf/`), server-side stage timers (`main.py`) |
+| Changed in production behaviour | Nothing yet |
+
+## Decisions already made — do not reopen
+
+These were considered and closed during diagnosis. Reopening them costs a grilling round
+each.
+
+**Result caching is ruled out.** Retrievals are near-random — a scientist loads a graph and
+pokes arbitrary nodes with no intent to repeat a specific one. A cache would almost never
+hit. This is settled on access-pattern grounds, not technical ones.
+
+**Haplotype collapsing is out of scope.** The 464 strands are fixed input, not a variable to
+optimise. Any proposal that reduces cost by merging or dropping haplotypes is off the table
+regardless of how much time it would save. (The `pathnumoption=compressed` bug is still a
+real defect worth its own issue — it just isn't the performance strategy.)
+
+**The target is systemic plumbing inefficiency**, not hot loops and not data volume. The
+working thesis is that the server is a set of separately-authored pieces joined by temp
+files and subprocesses, and that the cost lives in the joins.
+
+## Known-good baseline
+
+Verification at the end measures against these. All from the live API, 2026-08-27,
+`chr8:78,771,162+`, `version=v2`, `pathnumoption=normal`.
+
+| Region | TTFB | Payload |
+| --- | ---: | ---: |
+| 90 bp | 1.46 s | 178 KB |
+| 3,000 bp | 35.33 s | 3.2 MB |
+| 10,000 bp | 120.40 s | 10.1 MB |
+
+---
+
+## Step 0 — Push, and start the timers
+
+**Skill:** none. Plain git and a deploy.
+
+Push `perf/seqtubemap-diagnosis` and get the `[stage-timing]` instrumentation onto the
+server. Capture three requests — roughly 90 bp, 3 kb, 10 kb — each against a **fresh
+region** so `cached=False`, because the cached path skips the stage most likely to dominate.
+
+```sh
+grep '\[stage-timing\]' <logfile>
+```
+
+**Why first:** the ~34 s upstream figure is inferred by subtraction. Everything downstream
+of here is ranked on that inference. One deploy converts it to fact and may reorder the
+whole plan.
+
+**Exit criteria:** you can name which of `subgraph_extract`, `gfa_process`, `gfa_to_vg`,
+`vg_to_json`, `generate_svg` owns the majority of a slow request.
+
+> This does not block Step 1. Start the deploy, then begin grilling; fold the numbers in
+> when they arrive.
+
+## Step 1 — Sharpen the idea
+
+**Skill:** `/grill-with-docs` — the stateful interview.
+
+Precede it with **`/compact`**, not `/clear`. The diagnosis context matters to the
+grilling — particularly the ruled-out paths above — but the raw sweep output does not, and
+it is all recoverable from `seqtubemap-latency.md`.
+
+Use `grill-with-docs` rather than `grill-me` for a specific reason: **`CLAUDE.md` points at
+a `CONTEXT.md` that does not exist.** This project's domain vocabulary lives in other
+people's heads. The interview produces that glossary as a side effect, plus ADRs for
+hard-to-reverse calls. For an inherited codebase that paper trail is worth as much as the
+refactor.
+
+**Expect to settle:** how far the rework goes (targeted excisions vs. restructuring the
+pipeline), what must not change (output fidelity, the 464 strands, the SVG contract pgb
+depends on), and what "fast enough" means as a number.
+
+**Exit criteria:** you can state the change in one sentence, and `CONTEXT.md` exists.
+
+### If the shape is already settled
+
+Skip to **`/request-refactor-plan`** instead. It interviews you about the increments rather
+than the idea, and files the result as a GitHub issue broken into tiny safe commits. Use
+grilling when still hunting; use refactor-plan when done hunting.
+
+### If a question needs a runnable answer
+
+Detour through **`/prototype`**. The likely candidate: *can the vg JSON be emitted directly
+from the GFA, skipping `vg convert` and `vg view -j` entirely?* That is a question best
+answered by throwaway code against a real GFA, not by argument. Bridge with **`/handoff`**
+out and back, and reference the prototype branch from the resulting issue.
+
+## Step 2 — Decide the build shape
+
+**Skill:** still inside the Step 1 window. Do not compact between Steps 1 and 2.
+
+- **Multi-session build** → **`/to-spec`**, then **`/to-tickets`**. Tickets land as GitHub
+  issues in `CAST-genomics/PangenomeAPI` per `docs/agents/issue-tracker.md`, each declaring
+  its blocking edges.
+- **Single session** → straight to **`/implement`** in the same window.
+
+Given the roadmap below has at least four separable items with real ordering between them,
+multi-session is the likely answer.
+
+**Context hygiene:** Steps 1–2 must stay in **one unbroken context window**. Compact only
+at the Step 0/1 boundary and after `/to-tickets` — never in between, or the spec loses the
+thinking that produced it.
+
+## Step 3 — Build
+
+**Skill:** **`/implement`**, once per ticket, **`/clear`ing between each**. Each ticket is
+self-contained, so the previous one's context is disposable.
+
+`/implement` drives **`/tdd`** internally for each red-green slice and closes by running
+**`/code-review`** (Standards + Spec) against the diff before committing.
+
+### The roadmap, in order
+
+Ranked on evidence as of 2026-08-27. **Step 0's numbers may reorder this** — in particular,
+if `subgraph_extract` dominates, items 1–2 win less than their effort suggests and the real
+work moves into how the `gbz-base` query is issued.
+
+1. **Delete the `vg` round trip.** `GFA → protobuf → JSON` exists only to change format
+   between two processes this project controls, and inflates the payload **13×** (3.9 B per
+   node visit as a GFA walk, 51.0 B as vg JSON, identical information). The target schema is
+   trivial — `node[]` of `{id, sequence}`, `path[]` of `{name, mapping[].position}` — and
+   the GFA already contains it. Removes two subprocess spawns and two temp files.
+2. **Stop round-tripping through disk.** With `vg` gone, the remaining stages can pass bytes
+   rather than filenames. The SVG is currently written to disk purely so `FileResponse` can
+   read it back.
+3. **Unblock the event loop.** `seqtubemap` is `async def` with four blocking
+   `subprocess.run` calls inside it. This wins no latency but stops one slow request from
+   killing every concurrent one — currently a hard outage, observed.
+4. **Kill the per-request Node boot.** 722 ms measured, paid on every request, to start a
+   process that immediately rebuilds the same JSDOM document.
+5. **Only then** revisit the layout substrate — running the tube map layout without
+   emulating a browser, or moving it to the client. Real, but 1–4 are cheaper and may make
+   it unnecessary.
+
+Not on this list but worth its own issue: **`pathnumoption=compressed` never fires**
+(`main.py:212–226`) — it keys on the entire walk across the region, so one SNP prevents any
+collapse. A correctness defect, not a performance item.
+
+## Step 4 — Verify
+
+**Skill:** none, plus **`/code-review`** if reviewing the whole branch against `main`.
+
+Re-run the live probe against the baseline table above, same regions, same parameters. Then
+re-run the local harness to confirm the Node stage did not regress:
+
+```sh
+node perf/bench.mjs --axis=spine
+SPINES=40,150,600 HAPS=464 ALT=0.08 node perf/cross.mjs
+python3 perf/gfa-rewrite-bench.py
+```
+
+Update `seqtubemap-latency.md` with after-numbers beside the before-numbers. Update the
+artifact by passing its URL — publishing without it forks the link into a second artifact.
+
+---
+
+## Skill quick reference for this effort
+
+| Situation | Skill |
+| --- | --- |
+| Shape of the work still open | `/grill-with-docs` |
+| Shape settled, need safe increments | `/request-refactor-plan` |
+| A design question needs runnable proof | `/prototype` (+ `/handoff` both ways) |
+| Interview thread → buildable plan | `/to-spec` |
+| Plan → tickets with blocking edges | `/to-tickets` |
+| Build one ticket | `/implement` (drives `/tdd`, closes with `/code-review`) |
+| Review a branch against a fixed point | `/code-review` |
+| Something breaks during the rework | `/diagnosing-bugs` |
+| The duct-tape survey beyond seqtubemap | `/improve-codebase-architecture` |
+| A message didn't land | `/wait-what` |
+
+## Open questions
+
+- Does `subgraph_extract` dominate? (Step 0 answers this.)
+- Is the SVG-over-HTTP contract with pgb fixed, or can the response shape change? This
+  gates roadmap item 5 entirely and is a pgb question, not an API one.
+- Does anything downstream depend on the intermediate `.gfa` / `.vg` / `.json` files
+  existing on disk, or are they purely internal? They are deleted after every response,
+  which suggests purely internal — worth confirming before removing them.

--- a/docs/seqtubemap-roadmap.md
+++ b/docs/seqtubemap-roadmap.md
@@ -1,0 +1,315 @@
+# `/seqtubemap` rework — the roadmap
+
+The execution sequence for the `/seqtubemap` plumbing work: fourteen tickets, what each
+delivers, what gates it, and what has to be true before it is called done.
+
+This is the **build** document. Its companions:
+
+| | |
+| --- | --- |
+| [`CONTEXT.md`](../CONTEXT.md) | the vocabulary — **strand**, **segment**, **band**, **node** |
+| [`docs/adr/0001`](./adr/0001-additive-band-format.md) | the decision, and the alternatives that were rejected |
+| [`docs/perf/seqtubemap-latency.md`](./perf/seqtubemap-latency.md) | the measurements, §1-9 |
+| [`docs/perf/seqtubemap-plan.md`](./perf/seqtubemap-plan.md) | which skill drives each phase |
+| [`docs/perf/deploy-request.md`](./perf/deploy-request.md) | the ask that unblocks [#16](https://github.com/CAST-genomics/PangenomeAPI/issues/16) |
+| [#13](https://github.com/CAST-genomics/PangenomeAPI/issues/13) | the spec these tickets decompose |
+
+Written 2026-08-27, at the end of the grilling and ticketing phase.
+
+---
+
+## The one-sentence version
+
+**`/seqtubemap` publishes the numbers it already has, instead of emulating a browser to
+hide them in XML.**
+
+## Why
+
+A researcher clicks a **minigraph node** to look inside it. Roughly 43% of the time nothing
+appears. When it works, a 10 kb region takes 120 seconds and delivers 10 MB — and the
+frontend gives up at 90, so for a large node the feature is simply unavailable, with no way
+to tell in advance which nodes will work.
+
+And the failure is not contained. Both endpoints are `async def` while every stage blocks,
+so one slow tube map request stalls **every** other request to the server, including the
+`/json` the 3D graph depends on.
+
+One cause sits under all three symptoms. The server computes the geometry, then boots a
+headless browser, builds a jsdom document, and serializes it to XML — so that `pgb`, the
+only consumer, can parse the XML back into the numbers the layout already held in memory.
+
+| measured | |
+| --- | ---: |
+| of the render's retained memory is the jsdom document | **93.7%** |
+| of every response carries no information | **41-47%** |
+| empty `<title>` elements in one 13.56 MB document | **40,716** |
+| fixed per-request cost to boot Node and jsdom | **722 ms** |
+
+## The dependency graph
+
+```
+#14 test runner + CI ──┬── #17 endpoint seam ──── #20 threadpool
+                       │
+                       ├── #18 golden test ──┬── #21 capture ── #22 delete jsdom
+                       │                     │                        │
+                       │                     │                        └── #23 floats ── #24 ?format=bands ── #25 contract test
+                       │                     │
+                       │                     └── #26 delete vg ── #27 no disk
+                       │
+                       └── #19 lazy tabix
+
+#15 declare the fork ──────── #21
+#16 timings + fixtures ────── #26          (ready-for-human)
+```
+
+**The frontier is [#14](https://github.com/CAST-genomics/PangenomeAPI/issues/14),
+[#15](https://github.com/CAST-genomics/PangenomeAPI/issues/15),
+[#16](https://github.com/CAST-genomics/PangenomeAPI/issues/16)** — three independent starts.
+Edges are GitHub's native issue dependencies, so a ticket whose blockers are all closed is
+grabbable without consulting this document.
+
+---
+
+## Phase 0 — Foundation
+
+Nothing can be asserted until something can run assertions. **This repository has no tests
+and no CI**: no test files, no runner configuration, no workflows. Every seam below is a new
+seam.
+
+### [#14](https://github.com/CAST-genomics/PangenomeAPI/issues/14) — Test runner and CI
+
+A Python runner, a Node runner, a workflow running both on every pull request, and one smoke
+test per runner proving the setup works end to end. CI also carries the `vg` binary, because
+the endpoint seam needs it until [#26](https://github.com/CAST-genomics/PangenomeAPI/issues/26)
+removes it; tests needing `vg` skip with a stated reason when it is absent, so the suite
+stays runnable on a machine that has none.
+
+Prefactoring. Make the change easy, then make the easy change.
+
+### [#15](https://github.com/CAST-genomics/PangenomeAPI/issues/15) — Declare the fork
+
+`seqtubemap/tubemap.js` is an unmarked ~4,000-line vendored copy of
+`vgteam/sequence-tube-map`, carrying upstream's eslint header and no provenance, version, or
+note. [#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22) removes its DOM sink, so
+the re-sync option is gone in fact; a header comment makes it gone on paper. Land it before
+anyone edits the file.
+
+### [#16](https://github.com/CAST-genomics/PangenomeAPI/issues/16) — Timings and fixtures *(human)*
+
+Two artifacts off one deploy: stage timings for three uncached regions, and the pipeline
+intermediates for the five regions `pgb` already holds golden outputs for. The full request
+is in [`deploy-request.md`](./perf/deploy-request.md).
+
+Start it now — it is a conversation with a colleague, and it gates
+[#26](https://github.com/CAST-genomics/PangenomeAPI/issues/26) only.
+
+---
+
+## The two seams
+
+Everything below tests at one of two places. The ideal is one; two is the honest count,
+because the work spans two runtimes and one increment is invisible below HTTP.
+
+**Seam 1 — the Node stage CLI.** Graph JSON in, document out, across a process boundary that
+already exists. Increments **B** and **C** live entirely here. No Python, no `vg`, no graph
+data, so it runs anywhere. `perf/` is the prior art for driving it.
+Established by [#18](https://github.com/CAST-genomics/PangenomeAPI/issues/18).
+
+**Seam 2 — the HTTP endpoint**, via the framework's test client. Increment **A** lives here
+and nowhere else: *a slow request no longer stalls a concurrent one* is a statement about the
+event loop that cannot be observed lower down. **D** also lands here.
+Established by [#17](https://github.com/CAST-genomics/PangenomeAPI/issues/17).
+
+Seam 2 runs with **no graph data at all**, by exploiting an existing production branch: the
+pipeline already skips extraction when the subgraph is present, so a golden subgraph
+pre-placed at that path stands in for a multi-gigabyte `.gbz`. An existing code path, not a
+test hook.
+
+**What makes a good test here.** Assert what a consumer can observe: the bytes of a response,
+the floats a parser recovers, whether a second request completes while a first is in flight.
+Never assert on intermediate data structures, internal function names, or the presence of
+temp files — every one of those is something an increment is *expected* to change. The
+strongest available assertion is **parser-equivalence**: run the client's own parser over
+before and after, and diff the recovered arrays.
+
+---
+
+## Increment A — stop one request taking the server down
+
+Highest priority, smallest diff, and it improves `/json` for free — which also makes it the
+easiest thing in the programme for a reviewer to say yes to.
+
+### [#17](https://github.com/CAST-genomics/PangenomeAPI/issues/17) — Endpoint seam
+
+The tracer bullet for Seam 2: request a small region with no graph data present, get a real
+document back, assert it contains bands and segment boxes rather than merely that bytes
+arrived.
+
+### [#20](https://github.com/CAST-genomics/PangenomeAPI/issues/20) — Threadpool
+
+**The fix is deleting the word `async` twice** (`main.py:470`, `:527`). Neither endpoint
+awaits anything; FastAPI runs a plain `def` endpoint in a threadpool automatically. The
+ticket exists for the *test* — issue a slow request and a fast one concurrently, assert the
+fast one does not wait.
+
+### [#19](https://github.com/CAST-genomics/PangenomeAPI/issues/19) — Lazy tabix opens
+
+Three module-scope `pysam.TabixFile` opens (`main.py:71`, `:73`, `:81`) mean the app cannot
+boot unless all three `.walk.gz` derivatives are present, even for a request touching none of
+them. They are team-generated files, not public downloads — this is the first wall anyone
+hits trying to run the server.
+
+---
+
+## Increment B — delete the browser
+
+Where the ceiling moves. This is the increment that makes large nodes *fetchable*, not merely
+faster.
+
+### [#21](https://github.com/CAST-genomics/PangenomeAPI/issues/21) — Capture
+
+The expand half. At `tubemap.js:3599` the geometry is bound as `(d) => d.path` — **already a
+finished string, before any element exists**. jsdom's entire contribution is to hold it and
+hand it back. Make that data reachable; keep building the document exactly as before.
+
+Deliberately not demoable on its own. Its acceptance criterion is *the golden test passes with
+no re-baselining* — the only meaningful thing to assert about a change that changes nothing.
+
+### [#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22) — Delete jsdom
+
+The contract half, and the payoff: **~15× on the ceiling, −722 ms fixed, −16.6% bytes**, and
+`jsdom` and `canvas` — two of five dependencies — gone.
+
+**Held byte-compatible with `pgb`'s existing parser as a deliberate constraint.**
+`parseBands.ts` requires `style="fill: rgb(R, G, B); fill-opacity: 1;" trackID="N"
+trackName="…"` contiguous and in that order, and counts `<rect>` + `<path>` in `g.track`.
+What may go, because the client ignores all of it: `color=` (duplicating the rgb already in
+`style=`), `class="track{id}"` (duplicating `trackID`), and the empty `<title>` on every band.
+
+So **this ships against an unchanged `pgb`**, and the frontend becomes its conformance test
+in production: a bad deploy surfaces as an error card, not as a diff nobody ran.
+
+> **If the compatibility constraint cannot be held, stop and escalate.** Do not work around
+> it. The no-client-change property is the entire reason B is safe to ship alone.
+
+---
+
+## Increment C — publish the numbers
+
+### [#23](https://github.com/CAST-genomics/PangenomeAPI/issues/23) — Floats, not strings
+
+Internal representation only; documents stay byte-identical. Every one of **127,101 of
+127,101** surveyed strand paths conforms to a single grammar at constant thickness 15, so six
+values plus a strand id describe a band completely. Measured, not assumed — the survey is in
+`pgb`'s ADR 0002.
+
+### [#24](https://github.com/CAST-genomics/PangenomeAPI/issues/24) — `?format=bands`
+
+JSON header (viewBox + the ~464-row strand table) plus a binary body of `Float32 × 6 +
+Uint16` per band, with segment boxes carrying id, outline and sequence. Per-strand values
+appear **once** instead of once per band, and a fixed-width body copies straight into `pgb`'s
+GPU instance buffer with no parse at all.
+
+**Additive.** Omit the parameter and you get today's response, byte for byte. The two repos
+never deploy in lockstep, and the SVG stays as the oracle.
+
+> Projected at ~1.5 MB against 10.07 MB — **arithmetic from the band count and record width,
+> not a measurement.** The ticket asks for the real figure. It is the one number in these
+> documents that is not a direct observation.
+
+### [#25](https://github.com/CAST-genomics/PangenomeAPI/issues/25) — Contract test
+
+Golden fixtures committed here; the test that parses them lives in `pgb`, where the parser
+lives, and runs in `pgb`'s CI. **Not a vendored copy of the parser** — two copies that must
+agree is precisely the failure mode this whole effort exists to remove.
+
+---
+
+## Increment D — delete the `vg` round trip
+
+**Do not start [#26](https://github.com/CAST-genomics/PangenomeAPI/issues/26) until
+[#16](https://github.com/CAST-genomics/PangenomeAPI/issues/16) reports.** It sits *upstream*
+of layout, untouched by A-C, and if `subgraph_extract` dominates the request it is not worth
+doing at all. The measurement decides.
+
+### [#26](https://github.com/CAST-genomics/PangenomeAPI/issues/26) — Graph JSON in-process
+
+`GFA → protobuf → JSON` exists only to change format between two processes this project
+controls: two subprocess spawns, two temp files, and a **13×** inflation (3.9 B per segment
+visit as a GFA walk, 51.0 B as vg JSON). The target shape is small and the source already
+contains it.
+
+Success is *demonstrated*, not asserted: the Seam 1 golden tests pass with `vg` uninstalled.
+
+### [#27](https://github.com/CAST-genomics/PangenomeAPI/issues/27) — No disk round trip
+
+Stages pass bytes rather than filenames; the response stops being written to disk purely to
+be read back. **The subgraph cache stays** — it is a deliberate optimisation, it is what makes
+a repeated region fast, and Seam 2 depends on it to run without graph data.
+
+---
+
+## Closed — do not reopen
+
+Each of these cost a grilling round. Reopening costs another.
+
+**Result caching.** Retrievals are near-random: a scientist loads a graph and pokes arbitrary
+nodes with no intent to repeat one. Settled on access patterns, not technology.
+
+**Haplotype collapsing.** The ~464 strands are fixed input, not a variable. Nothing here
+reduces cost by merging or dropping strands, regardless of how much time it would save.
+
+**Fixing `pathnumoption=compressed`.** Real defect — it keys on the entire walk across the
+region, so one SNP prevents any collapse, and it is measurably byte-identical to `normal`. But
+fixing it *merges strands*, which is a data change and out of scope. It stays as-is on the SVG
+route and does not exist on the band route; ADR 0001 records why.
+
+**Replacing SVG, or mutating the existing URL in place.** Both force lockstep deploys and
+both discard the oracle. See ADR 0001's rejected alternatives.
+
+**Changing the layout algorithm, or recolouring.** Geometry in equals geometry out. Colour is
+shared vocabulary with the PCLAI chart and the 3D graph.
+
+---
+
+## Still open
+
+- **Does `subgraph_extract` dominate?** The last inferred number in the effort. Gates
+  [#26](https://github.com/CAST-genomics/PangenomeAPI/issues/26) alone — A, B and C are
+  correct wherever that time lives.
+- **Does anything depend on the intermediate `.gfa` / `.vg` / `.json` files existing on
+  disk?** They are deleted after every response, which suggests purely internal. Confirm with
+  Cici before [#27](https://github.com/CAST-genomics/PangenomeAPI/issues/27).
+- **Two documents in `pgb` make a forward claim** — that
+  [#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22) ships byte-compatible. Verified
+  against the real regex and the real conformance gate, but describing code that does not exist
+  yet. If #22 cannot hold the constraint, those amendments need correcting rather than quietly
+  going stale. They live on `docs/tubemap-upstream-band-format` in `pgb`, unmerged.
+
+## Verifying the whole thing
+
+Against the baseline in [`seqtubemap-latency.md`](./perf/seqtubemap-latency.md) §1 — same
+regions, same parameters:
+
+| Region | TTFB before | Payload before |
+| --- | ---: | ---: |
+| 90 bp | 1.46 s | 178 KB |
+| 3,000 bp | 35.33 s | 3.2 MB |
+| 10,000 bp | 120.40 s | 10.1 MB |
+
+```sh
+node perf/bench.mjs --axis=spine
+SPINES=40,150,600 HAPS=464 ALT=0.08 node perf/cross.mjs
+python3 perf/gfa-rewrite-bench.py
+node --expose-gc --max-old-space-size=8192 perf/rss-split.mjs \
+  perf/fixtures/split-400.json 0 8000 compressed
+```
+
+`rss-split.mjs` is the one that matters after [#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22):
+it should report the DOM share at or near **zero**, because there should no longer be a DOM.
+Its `--expose-gc` requirement is not optional — retained-memory numbers taken without a forced
+collection measure garbage rather than retention.
+
+Then update the rendered report **by passing its URL**
+(`https://claude.ai/code/artifact/71539dd1-fb13-44d0-8468-a3a96e726114`); publishing without it
+forks the link into a second artifact.

--- a/main.py
+++ b/main.py
@@ -10,8 +10,9 @@ data_path = subprocess.check_output(
 
 sys.path.append(tool_path)
 
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 import logging
+import time
 import signal
 import ssl
 import traceback
@@ -449,6 +450,22 @@ def determineIfDupCoordShouldBeTaken(assembly_range, dup_assembly):
 
     return
         
+@contextmanager
+def stage_timing(stages, name):
+    """
+    Record the wall time of one pipeline stage into `stages`.
+
+    Used to attribute request latency across the seqtubemap pipeline. Timings are
+    emitted as a single `[stage-timing]` log line per request, so the breakdown can
+    be pulled out of the logs with a grep.
+    """
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        stages[name] = round(time.perf_counter() - t0, 3)
+
+
 @app.get("/seqtubemap")
 async def seqtubemap(
     background_tasks: BackgroundTasks,
@@ -469,19 +486,39 @@ async def seqtubemap(
     json_subgraph = Path(f"./cache/seqtubemap/mc/subgraph_{chrom}_{str(start)}_{str(end)}_path{pathnumoption}_{version}.json")
     seqtubemap_svg = Path(f"./cache/seqtubemap/mc/subgraph_{chrom}_{str(start)}_{str(end)}_path{pathnumoption}_{version}.svg")
     
-    if not preprocess_gfa_subgraph.exists():
-        if version == "v1":
-            SubgraphMC(query_region, preprocess_gfa_subgraph, mc_hg38_gbz_v1, log)
-        elif version == "v2":
-            SubgraphMC(query_region, preprocess_gfa_subgraph, mc_hg38_gbz_v2, log)
-        else:
-            log.error(f"Invalid graph version {version}(valid versions: \"v1\" or \"v2\")")
-    
-    SeqTubeGfaProcessor(preprocess_gfa_subgraph, postprocess_gfa_subgraph, pathnumoption)
-    ConvertGfaToVg(postprocess_gfa_subgraph, vg_subgraph)
-    ConvertVgToJson(vg_subgraph, json_subgraph)
-    GenerateSeqTubeMapSvg(json_subgraph, seqtubemap_svg, start, end, nodewidthoption)
-    
+    stages = {}
+    subgraph_cached = preprocess_gfa_subgraph.exists()
+
+    with stage_timing(stages, "subgraph_extract"):
+        if not subgraph_cached:
+            if version == "v1":
+                SubgraphMC(query_region, preprocess_gfa_subgraph, mc_hg38_gbz_v1, log)
+            elif version == "v2":
+                SubgraphMC(query_region, preprocess_gfa_subgraph, mc_hg38_gbz_v2, log)
+            else:
+                log.error(f"Invalid graph version {version}(valid versions: \"v1\" or \"v2\")")
+
+    with stage_timing(stages, "gfa_process"):
+        SeqTubeGfaProcessor(preprocess_gfa_subgraph, postprocess_gfa_subgraph, pathnumoption)
+    with stage_timing(stages, "gfa_to_vg"):
+        ConvertGfaToVg(postprocess_gfa_subgraph, vg_subgraph)
+    with stage_timing(stages, "vg_to_json"):
+        ConvertVgToJson(vg_subgraph, json_subgraph)
+    with stage_timing(stages, "generate_svg"):
+        GenerateSeqTubeMapSvg(json_subgraph, seqtubemap_svg, start, end, nodewidthoption)
+
+    def size_mb(path):
+        return round(path.stat().st_size / 1048576, 2) if path.exists() else None
+
+    total = round(sum(stages.values()), 3)
+    breakdown = " ".join(f"{name}={secs}s" for name, secs in stages.items())
+    log.info(
+        f"[stage-timing] {chrom}:{start}-{end} span={end - start}bp {version} "
+        f"path={pathnumoption} width={nodewidthoption} cached={subgraph_cached} "
+        f"total={total}s {breakdown} "
+        f"json_mb={size_mb(json_subgraph)} svg_mb={size_mb(seqtubemap_svg)}"
+    )
+
     background_tasks.add_task(delete_files, [postprocess_gfa_subgraph, vg_subgraph, json_subgraph, seqtubemap_svg])
     return FileResponse(seqtubemap_svg, media_type="image/svg+xml")
 

--- a/perf/.gitignore
+++ b/perf/.gitignore
@@ -1,0 +1,1 @@
+fixtures/

--- a/perf/bench.mjs
+++ b/perf/bench.mjs
@@ -1,0 +1,116 @@
+// Sweep orchestrator: builds fixtures, runs perf/stage-timer.mjs in its own process
+// for each, and prints a table. Sweeps one axis at a time so you can see WHICH
+// dimension of the graph the cost actually scales with.
+//
+//   node perf/bench.mjs                 # default sweep, all three axes
+//   node perf/bench.mjs --axis=spine    # one axis
+//   node perf/bench.mjs --input=real.json --start=0 --end=10000
+import { execFileSync } from "child_process";
+import { writeFileSync, mkdirSync, statSync } from "fs";
+import { generate } from "./gen-vg-json.mjs";
+
+const FIX = "perf/fixtures";
+const OUT = "perf/fixtures/out";
+mkdirSync(OUT, { recursive: true });
+
+const argv = Object.fromEntries(
+  process.argv.slice(2).map((a) => {
+    const [k, v] = a.replace(/^--/, "").split("=");
+    return [k, v ?? true];
+  })
+);
+const NODE_WIDTH = argv.nodeWidthOption ?? "compressed";
+
+function run(jsonPath, start, end) {
+  const svgPath = `${OUT}/${jsonPath.split("/").pop().replace(/\.json$/, "")}.svg`;
+  const wall0 = performance.now();
+  let stdout;
+  try {
+    stdout = execFileSync(
+      "node",
+      ["perf/stage-timer.mjs", jsonPath, svgPath, String(start), String(end), NODE_WIDTH],
+      { encoding: "utf8", maxBuffer: 1 << 28, timeout: 600000, stdio: ["ignore", "pipe", "pipe"] }
+    );
+  } catch (e) {
+    return { failed: true, reason: (e.stderr || e.message || "").split("\n").slice(-4).join(" ").slice(0, 160) };
+  }
+  const wall = performance.now() - wall0;
+  const lines = stdout.trim().split("\n").filter(Boolean);
+  const rec = JSON.parse(lines[lines.length - 1]);
+  rec.wallMs = +wall.toFixed(2);   // includes node process startup, as production pays it
+  return rec;
+}
+
+function fixture(name, params) {
+  const path = `${FIX}/${name}.json`;
+  const g = generate(params);
+  writeFileSync(path, JSON.stringify(g));
+  const bases = g.node.reduce((a, n) => a + n.sequence.length, 0);
+  return { path, bases };
+}
+
+const BASE = { spineNodes: 200, haplotypes: 10, bubbleRate: 0.3, seqLen: 32, seed: 42 };
+
+const AXES = {
+  spine:   { key: "spineNodes", values: [100, 200, 400, 800, 1600, 3200, 6400] },
+  haps:    { key: "haplotypes", values: [2, 5, 10, 20, 40, 80] },
+  bubbles: { key: "bubbleRate", values: [0.0, 0.1, 0.25, 0.5, 0.75, 1.0] },
+};
+
+function fmt(n, w = 9) { return String(n).padStart(w); }
+function mb(bytes) { return (bytes / 1048576).toFixed(2); }
+
+function table(title, rows, axisKey) {
+  console.log(`\n### ${title}`);
+  console.log(
+    [axisKey.padEnd(11), "nodes".padStart(7), "mappings".padStart(9), "inMB".padStart(7),
+     "wall_ms".padStart(9), "create_ms".padStart(10), "fixed_ms".padStart(9),
+     "svgMB".padStart(8), "elems".padStart(8), "bloat_x".padStart(8)].join(" ")
+  );
+  console.log("-".repeat(100));
+  for (const r of rows) {
+    if (r.rec.failed) {
+      console.log(`${String(r.axisValue).padEnd(11)} ${"FAILED: " + r.rec.reason}`);
+      continue;
+    }
+    const s = r.rec.stages;
+    const fixed = s["import:jsdom+canvas"] + s["jsdom:construct-dom"] + s["import:tubemap.js"];
+    const bloat = (r.rec.output.svgBytes / r.rec.input.bytes).toFixed(1);
+    console.log([
+      String(r.axisValue).padEnd(11),
+      fmt(r.rec.input.nodes, 7),
+      fmt(r.rec.input.mappings, 9),
+      fmt(mb(r.rec.input.bytes), 7),
+      fmt(r.rec.wallMs.toFixed(0), 9),
+      fmt(s["render:create()"].toFixed(0), 10),
+      fmt(fixed.toFixed(0), 9),
+      fmt(mb(r.rec.output.svgBytes), 8),
+      fmt(r.rec.output.elements, 8),
+      fmt(bloat + "x", 8),
+    ].join(" "));
+  }
+}
+
+if (argv.input) {
+  const start = Number(argv.start ?? 0);
+  const end = Number(argv.end ?? 10000);
+  console.log(`Real input: ${argv.input} (${mb(statSync(argv.input).size)} MB)`);
+  const rec = run(argv.input, start, end);
+  console.log(JSON.stringify(rec, null, 2));
+} else {
+  const which = argv.axis ? [argv.axis] : Object.keys(AXES);
+  for (const axisName of which) {
+    const axis = AXES[axisName];
+    if (!axis) { console.error(`unknown axis: ${axisName}`); process.exit(1); }
+    const rows = [];
+    for (const v of axis.values) {
+      const params = { ...BASE, [axis.key]: v };
+      const { path, bases } = fixture(`${axisName}-${v}`, params);
+      process.stderr.write(`  running ${axisName}=${v} ... `);
+      const rec = run(path, 0, bases);
+      process.stderr.write(rec.failed ? "FAILED\n" : `${rec.wallMs.toFixed(0)}ms\n`);
+      rows.push({ axisValue: v, rec });
+    }
+    table(`axis: ${axisName} (others fixed at spine=${BASE.spineNodes}, haps=${BASE.haplotypes}, bubbleRate=${BASE.bubbleRate})`, rows, axis.key);
+  }
+}

--- a/perf/cliff.mjs
+++ b/perf/cliff.mjs
@@ -1,0 +1,26 @@
+// Finds the scale at which create() blows the heap.
+import { execFileSync } from "child_process";
+import { writeFileSync, statSync, mkdirSync } from "fs";
+import { generate } from "./gen-vg-json.mjs";
+mkdirSync("perf/fixtures/out", { recursive: true });
+
+const COMBOS = [[2000,10],[2000,45],[2000,90],[5000,10],[5000,45],[5000,90],[10000,10],[10000,45]];
+console.log(["spine","haps","inMB","result","createMs","svgMB","elems","rssMB"].map(s=>s.padStart(9)).join(" "));
+console.log("-".repeat(80));
+for (const [spineNodes, haplotypes] of COMBOS) {
+  const p = "perf/fixtures/cliff.json";
+  writeFileSync(p, JSON.stringify(generate({ spineNodes, haplotypes, bubbleRate: 0.4, seqLen: 48, seed: 7 })));
+  const inMB = (statSync(p).size / 1048576).toFixed(1);
+  let row;
+  try {
+    const out = execFileSync("node", ["perf/stage-timer.mjs", p, "perf/fixtures/out/cliff.svg", "0", "300000", "compressed"],
+      { encoding: "utf8", maxBuffer: 1 << 28, stdio: ["ignore", "pipe", "pipe"] });
+    const lines = out.trim().split("\n").filter(Boolean);
+    const r = JSON.parse(lines[lines.length - 1]);
+    row = ["ok", r.stages["render:create()"].toFixed(0), (r.output.svgBytes/1048576).toFixed(2), r.output.elements, r.peakRssMb];
+  } catch (e) {
+    const isOom = /heap out of memory|Ineffective mark-compacts/.test((e.stderr||"") + (e.message||""));
+    row = [isOom ? "OOM" : "FAIL", "-", "-", "-", "-"];
+  }
+  console.log([spineNodes, haplotypes, inMB, ...row].map(s=>String(s).padStart(9)).join(" "));
+}

--- a/perf/cross.mjs
+++ b/perf/cross.mjs
@@ -1,0 +1,38 @@
+// The real case: MANY tracks AND a growing spine at the same time.
+// Earlier sweeps varied one axis with the other held low and looked linear;
+// this tests the cross term.
+import { execFileSync } from "child_process";
+import { writeFileSync, statSync, mkdirSync } from "fs";
+import { generate } from "./gen-vg-json.mjs";
+mkdirSync("perf/fixtures/out", { recursive: true });
+
+const HAPS = Number(process.env.HAPS ?? 464);
+const ALT = Number(process.env.ALT ?? 0.08);   // realistic allele sharing -> heavy merging
+const SPINES = (process.env.SPINES ?? "40,100,200,400,800,1600").split(",").map(Number);
+
+console.log(`haps=${HAPS} altFreq=${ALT}`);
+console.log(["spine","inMB","create_ms","total_ms","svgMB","elems","rssMB","ms/spine"].map(s=>s.padStart(10)).join(""));
+console.log("-".repeat(80));
+let prev = null;
+for (const spineNodes of SPINES) {
+  const p = "perf/fixtures/cross.json";
+  writeFileSync(p, JSON.stringify(generate({ spineNodes, haplotypes: HAPS, bubbleRate: 0.4, altFreq: ALT, seqLen: 8, seed: 11 })));
+  const inMB = (statSync(p).size / 1048576).toFixed(2);
+  try {
+    const out = execFileSync("node", ["--max-old-space-size=6144", "perf/stage-timer.mjs", p,
+      "perf/fixtures/out/cross.svg", "0", String(spineNodes * 8), "compressed"],
+      { encoding: "utf8", maxBuffer: 1 << 28, stdio: ["ignore", "pipe", "pipe"], timeout: 900000 });
+    const lines = out.trim().split("\n").filter(Boolean);
+    const r = JSON.parse(lines[lines.length - 1]);
+    const c = r.stages["render:create()"];
+    const growth = prev ? ` (${(c / prev).toFixed(1)}x for 2x input)` : "";
+    console.log([spineNodes, inMB, c.toFixed(0), r.totalMs.toFixed(0),
+      (r.output.svgBytes/1048576).toFixed(2), r.output.elements, r.peakRssMb,
+      (c/spineNodes).toFixed(2)].map(s=>String(s).padStart(10)).join("") + growth);
+    prev = c;
+  } catch (e) {
+    const oom = /heap out of memory|Ineffective mark-compacts/.test((e.stderr||"")+(e.message||""));
+    console.log(String(spineNodes).padStart(10) + String(inMB).padStart(10) + (oom ? "   *** OOM (6GB heap) ***" : "   *** FAILED ***"));
+    break;
+  }
+}

--- a/perf/gen-vg-json.mjs
+++ b/perf/gen-vg-json.mjs
@@ -1,0 +1,88 @@
+// Deterministic synthetic vg-JSON generator for tube map perf work.
+// Emits the same shape `vg view -j` produces, which is all tubemap.js reads:
+//   { node: [{id, sequence}], path: [{name, freq, mapping:[{position:{node_id,is_reverse}}]}] }
+//
+// Graph shape mimics a pangenome subgraph: a reference spine with bubbles
+// hanging off it, and haplotype paths choosing an allele at each bubble.
+import { writeFileSync } from "fs";
+
+// mulberry32 — seeded so every run produces byte-identical fixtures.
+function rng(seed) {
+  return function () {
+    seed |= 0; seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const BASES = "ACGT";
+function seq(rand, len) {
+  let s = "";
+  for (let i = 0; i < len; i += 1) s += BASES[(rand() * 4) | 0];
+  return s;
+}
+
+export function generate({
+  spineNodes = 200,   // nodes along the reference backbone
+  haplotypes = 10,    // number of haplotype paths
+  bubbleRate = 0.3,   // fraction of spine positions carrying an alternate allele
+  altFreq = 0.5,      // P(haplotype takes the alt allele). Real haplotypes mostly
+                      // share alleles, so low values reproduce the heavy node
+                      // merging seen in real subgraphs; 0.5 is worst-case divergence.
+  seqLen = 32,        // mean node sequence length
+  seed = 42,
+} = {}) {
+  const rand = rng(seed);
+  const node = [];
+  const spine = [];   // [{ref, alt|null}] by position
+  let nextId = 1;
+
+  for (let i = 0; i < spineNodes; i += 1) {
+    const len = Math.max(1, Math.round(seqLen * (0.5 + rand())));
+    const ref = nextId++;
+    node.push({ id: ref, sequence: seq(rand, len) });
+    let alt = null;
+    if (rand() < bubbleRate) {
+      alt = nextId++;
+      const altLen = Math.max(1, Math.round(seqLen * (0.5 + rand())));
+      node.push({ id: alt, sequence: seq(rand, altLen) });
+    }
+    spine.push({ ref, alt });
+  }
+
+  const path = [];
+  // Reference path first — always the pure spine, like GRCh38 in a real subgraph.
+  path.push({
+    name: "GRCh38#0#chr1",
+    freq: 1,
+    indexOfFirstBase: 0,
+    mapping: spine.map((s) => ({ position: { node_id: s.ref, is_reverse: false } })),
+  });
+  for (let h = 0; h < haplotypes; h += 1) {
+    const mapping = [];
+    for (const s of spine) {
+      const useAlt = s.alt !== null && rand() < altFreq;
+      mapping.push({ position: { node_id: useAlt ? s.alt : s.ref, is_reverse: false } });
+    }
+    path.push({
+      name: `HG${String(10000 + h).padStart(5, "0")}#${(h % 2) + 1}#chr1`,
+      freq: 1,
+      indexOfFirstBase: 0,
+      mapping,
+    });
+  }
+  return { node, path };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = Object.fromEntries(
+    process.argv.slice(3).map((a) => {
+      const [k, v] = a.replace(/^--/, "").split("=");
+      return [k, Number(v)];
+    })
+  );
+  const out = process.argv[2];
+  writeFileSync(out, JSON.stringify(generate(args)));
+  console.log(`wrote ${out}`);
+}

--- a/perf/gfa-rewrite-bench.py
+++ b/perf/gfa-rewrite-bench.py
@@ -1,0 +1,74 @@
+"""
+Times SeqTubeGfaProcessor's W->P rewrite in isolation.
+
+Pure Python with no external tools, so it runs anywhere -- no gbz-base, no vg,
+no data.path. Replicates main.py's rewrite loop exactly and reports throughput
+against a synthetic GFA of the same shape the real pipeline produces.
+"""
+import random, re, time, io, os, sys, tempfile
+
+WALKS = 464  # haplotype count is fixed input, not a variable
+
+def make_gfa(path, walks, nodes_per_walk, seed=5):
+    rnd = random.Random(seed)
+    with open(path, "w") as f:
+        f.write("H\tVN:Z:1.1\n")
+        for nid in range(1, nodes_per_walk * 2):
+            f.write(f"S\t{nid}\t{''.join(rnd.choice('ACGT') for _ in range(32))}\n")
+        for w in range(walks):
+            sample = "GRCh38" if w == 0 else f"HG{10000+w:05d}"
+            walk = "".join(
+                f"{'>' if rnd.random() < 0.9 else '<'}{rnd.randrange(1, nodes_per_walk*2)}"
+                for _ in range(nodes_per_walk)
+            )
+            f.write(f"W\t{sample}\t{w%2+1}\tchr8\t0\t{nodes_per_walk*32}\t{walk}\n")
+
+def rewrite(src, dst, pathnumoption):
+    """Byte-for-byte the loop from main.py SeqTubeGfaProcessor."""
+    input_gfa = open(src, "r")
+    output_gfa = open(dst, "w")
+    path_summary = {}
+    hg38_line = ""
+    for line in input_gfa:
+        parts = line.strip().split("\t")
+        header = parts[0]
+        if header != "W":
+            output_gfa.write(line)
+            continue
+        sample, haplo, contig, walk = parts[1], parts[2], parts[3], parts[6]
+        walk_parts = re.split(r'([<>])', walk)[1:]
+        walk_update = ""
+        for i in range(1, len(walk_parts), 2):
+            if walk_parts[i-1] == ">":
+                walk_update += f"{walk_parts[i]}+,"
+            else:
+                walk_update += f"{walk_parts[i]}-,"
+        walk_update = walk_update[:-1]
+        if pathnumoption == "compressed":
+            if sample == "GRCh38":
+                hg38_line = f"P\t{sample}#{haplo}#{contig}\t{walk_update}\t*\n"
+            else:
+                if walk_update not in path_summary:
+                    path_summary[walk_update] = f"{sample}#{haplo}#{contig}"
+                else:
+                    path_summary[walk_update] += f",{sample}#{haplo}#{contig}"
+        else:
+            output_gfa.write(f"P\t{sample}#{haplo}#{contig}\t{walk_update}\t*\n")
+    if pathnumoption == "compressed":
+        output_gfa.write(hg38_line)
+        for path, assembly_list in path_summary.items():
+            output_gfa.write(f"P\t{assembly_list}\t{path}\t*\n")
+    input_gfa.close(); output_gfa.close()
+
+print(f"walks={WALKS} (fixed)\n")
+print(f"{'nodes/walk':>11} {'in_MB':>8} {'out_MB':>8} {'gen_s':>8} {'rewrite_s':>10} {'MB/s':>8}")
+print("-" * 60)
+tmp = tempfile.mkdtemp()
+for npw in (200, 1000, 5000):
+    src = os.path.join(tmp, f"in_{npw}.gfa")
+    dst = os.path.join(tmp, f"out_{npw}.gfa")
+    t0 = time.perf_counter(); make_gfa(src, WALKS, npw); gen = time.perf_counter() - t0
+    t0 = time.perf_counter(); rewrite(src, dst, "normal"); el = time.perf_counter() - t0
+    inmb = os.path.getsize(src) / 1048576
+    outmb = os.path.getsize(dst) / 1048576
+    print(f"{npw:>11} {inmb:>8.1f} {outmb:>8.1f} {gen:>8.1f} {el:>10.2f} {inmb/el:>8.1f}")

--- a/perf/rss-split.mjs
+++ b/perf/rss-split.mjs
@@ -1,0 +1,128 @@
+// Answers one question the stage timer cannot: inside `render:create()`, how much of the
+// memory is tubemap.js's LAYOUT, and how much is the jsdom DOM it builds?
+//
+// That split decides whether a wire format that skips the DOM raises the OOM ceiling
+// (DOM-dominated) or only saves bytes and time (layout-dominated).
+//
+// Method: mark heapUsed at each boundary, forcing a full GC before each mark so the
+// number is RETAINED memory rather than garbage-in-flight. Then tear the DOM down and
+// GC again -- what is released is what the DOM was holding.
+//
+// MUST run with --expose-gc, e.g.
+//   node --expose-gc --max-old-space-size=8192 perf/rss-split.mjs <input.json> <start> <end> <widthOption>
+import { readFileSync } from "fs";
+
+if (typeof globalThis.gc !== "function") {
+  console.error("rss-split needs --expose-gc; retained numbers are meaningless without it.");
+  process.exit(2);
+}
+
+const marks = [];
+function mark(name) {
+  globalThis.gc(); globalThis.gc();
+  const m = process.memoryUsage();
+  marks.push({
+    name,
+    heapMb: +(m.heapUsed / 1048576).toFixed(1),
+    rssMb: +(m.rss / 1048576).toFixed(1),
+    externalMb: +(m.external / 1048576).toFixed(1),
+  });
+  const last = marks[marks.length - 1];
+  process.stderr.write(`    [rss] ${name.padEnd(24)} heap=${last.heapMb}MB rss=${last.rssMb}MB\n`);
+}
+
+const [inputFile, start, end, nodeWidthOption] = process.argv.slice(2);
+
+const { JSDOM } = await import("jsdom");
+const { createCanvas } = await import("canvas");
+
+globalThis["__sequence_tube_map_config"] = {
+  defaultHaplotypeColorPalette: { mainPalette: "reds", auxPalette: "blues" },
+  defaultReadColorPalette: { mainPalette: "reds", auxPalette: "blues" },
+  defaultGraphColorPalette: { mainPalette: "reds", auxPalette: "blues" },
+  nodeIntervalThreshold: 150,
+  coloredNodes: [], DATA_SOURCES: [], BACKEND_URL: "",
+};
+
+let dom = new JSDOM(`<!DOCTYPE html><body><svg id="mysvg"></svg></body>`, {
+  resources: "usable",
+  pretendToBeVisual: true,
+});
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+const canvas = createCanvas(200, 200);
+const ctx = canvas.getContext("2d");
+ctx.font = '14px "Courier New"';
+dom.window.SVGElement.prototype.getComputedTextLength = function () {
+  return ctx.measureText(this.textContent).width;
+};
+
+const { create, vgExtractNodes, vgExtractTracks, getImageCoordinates } =
+  await import("../seqtubemap/tubemap.js");
+
+mark("A:booted");
+
+let raw = readFileSync(inputFile, "utf8");
+let vgJson = JSON.parse(raw);
+const inputBytes = Buffer.byteLength(raw);
+raw = null;
+mark("B:input-parsed");
+
+let nodes = vgExtractNodes(vgJson);
+let tracks = vgExtractTracks(vgJson, 0, 1);
+const trackCount = tracks.length;
+const nodeCount = nodes.length;
+vgJson = null;
+mark("C:vg-extracted");
+
+create({
+  svgID: "#mysvg",
+  nodes, tracks, reads: null,
+  region: [0, Number(end) - Number(start) - 1],
+  hideLegend: true,
+  nodeWidthOption,
+});
+nodes = null; tracks = null;
+mark("D:after-create");
+
+const { maxXCoordinate, maxYCoordinate, minYCoordinate } = getImageCoordinates();
+const svgElement = dom.window.document.getElementById("mysvg");
+svgElement.setAttribute("viewBox", `0 ${minYCoordinate - 20} ${maxXCoordinate + 50} ${maxYCoordinate - minYCoordinate + 50}`);
+svgElement.setAttribute("width", maxXCoordinate + 50);
+svgElement.setAttribute("height", maxYCoordinate - minYCoordinate + 50);
+svgElement.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+
+let svg = svgElement.outerHTML;
+const svgBytes = Buffer.byteLength(svg);
+const elementCount = (svg.match(/<[a-zA-Z]/g) || []).length;
+mark("E:after-serialize");
+
+svg = null;
+mark("F:svg-string-dropped");
+
+// Tear the DOM down. What is released here is what the DOM was holding; what survives
+// is tubemap.js's module-level layout state (plus jsdom's own fixed overhead).
+svgElement.textContent = "";
+while (dom.window.document.body.firstChild) {
+  dom.window.document.body.removeChild(dom.window.document.body.firstChild);
+}
+mark("G:dom-emptied");
+
+const at = (n) => marks.find((m) => m.name.startsWith(n));
+const createTotal = +(at("D").heapMb - at("C").heapMb).toFixed(1);
+const domShare = +(at("F").heapMb - at("G").heapMb).toFixed(1);
+const layoutShare = +(createTotal - domShare).toFixed(1);
+
+console.log(JSON.stringify({
+  input: { file: inputFile, bytes: inputBytes, nodes: nodeCount, tracks: trackCount },
+  output: { svgBytes, elementCount },
+  marks,
+  split: {
+    createRetainedMb: createTotal,
+    domRetainedMb: domShare,
+    layoutRetainedMb: layoutShare,
+    domPercentOfCreate: createTotal > 0 ? +((domShare / createTotal) * 100).toFixed(1) : null,
+    svgStringMb: +(at("E").heapMb - at("D").heapMb).toFixed(1),
+  },
+  peakRssMb: +(Math.max(...marks.map((m) => m.rssMb))).toFixed(1),
+}, null, 2));

--- a/perf/stage-timer.mjs
+++ b/perf/stage-timer.mjs
@@ -1,0 +1,125 @@
+// Runs ONE tube map render, mirroring seqtubemap/generate-svg.mjs stage for stage,
+// but timing each stage and measuring the output. Emits a single JSON line on stdout.
+//
+// Runs as its own process on purpose: tubemap.js keeps module-level layout state,
+// so a fresh process per render is both the only way to get clean numbers and
+// exactly what production does (one `node` subprocess per API request).
+//
+// Usage: node perf/stage-timer.mjs <input.json> <output.svg> <start> <end> <nodeWidthOption>
+import { readFileSync, writeFileSync } from "fs";
+
+const t = [];
+let last = performance.now();
+function mark(name) {
+  const now = performance.now();
+  t.push([name, +(now - last).toFixed(2)]);
+  // Progress to stderr as we go, so a crash still tells us which stage died.
+  process.stderr.write(
+    `    [stage] ${name} ${(now - last).toFixed(1)}ms rss=${(process.memoryUsage().rss / 1048576).toFixed(0)}MB\n`
+  );
+  last = now;
+}
+
+const processStart = performance.now();
+const [inputFile, outputFile, start, end, nodeWidthOption] = process.argv.slice(2);
+
+const { JSDOM } = await import("jsdom");
+const { createCanvas } = await import("canvas");
+mark("import:jsdom+canvas");
+
+globalThis["__sequence_tube_map_config"] = {
+  defaultHaplotypeColorPalette: { mainPalette: "reds", auxPalette: "blues" },
+  defaultReadColorPalette: { mainPalette: "reds", auxPalette: "blues" },
+  defaultGraphColorPalette: { mainPalette: "reds", auxPalette: "blues" },
+  nodeIntervalThreshold: 150,
+  coloredNodes: [], DATA_SOURCES: [], BACKEND_URL: "",
+};
+
+const dom = new JSDOM(`<!DOCTYPE html><body><svg id="mysvg"></svg></body>`, {
+  resources: "usable",
+  pretendToBeVisual: true,
+});
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+const canvas = createCanvas(200, 200);
+const ctx = canvas.getContext("2d");
+ctx.font = '14px "Courier New"';
+dom.window.SVGElement.prototype.getComputedTextLength = function () {
+  return ctx.measureText(this.textContent).width;
+};
+mark("jsdom:construct-dom");
+
+const { create, vgExtractNodes, vgExtractTracks, getImageCoordinates } =
+  await import("../seqtubemap/tubemap.js");
+mark("import:tubemap.js");
+
+const raw = readFileSync(inputFile, "utf8");
+mark("io:read-input");
+
+const vgJson = JSON.parse(raw);
+mark("parse:JSON.parse");
+
+const nodes = vgExtractNodes(vgJson);
+mark("convert:vgExtractNodes");
+
+const tracks = vgExtractTracks(vgJson, 0, 1);
+mark("convert:vgExtractTracks");
+
+create({
+  svgID: "#mysvg",
+  nodes, tracks, reads: null,
+  region: [0, Number(end) - Number(start) - 1],
+  hideLegend: true,
+  nodeWidthOption,
+});
+mark("render:create()");
+
+const { maxXCoordinate, maxYCoordinate, minYCoordinate } = getImageCoordinates();
+const svgElement = dom.window.document.getElementById("mysvg");
+const width = maxXCoordinate + 50;
+const height = maxYCoordinate - minYCoordinate + 50;
+svgElement.setAttribute("viewBox", `0 ${minYCoordinate - 20} ${width} ${height}`);
+svgElement.setAttribute("width", width);
+svgElement.setAttribute("height", height);
+svgElement.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+mark("render:fix-dimensions");
+
+const svg = svgElement.outerHTML;
+mark("serialize:outerHTML");
+
+writeFileSync(outputFile, svg, "utf8");
+mark("io:write-svg");
+
+// --- output shape: the "bloated data" half of the symptom ---
+const tagCounts = {};
+for (const m of svg.matchAll(/<([a-zA-Z][a-zA-Z0-9]*)/g)) {
+  tagCounts[m[1]] = (tagCounts[m[1]] || 0) + 1;
+}
+let dAttrChars = 0;
+for (const m of svg.matchAll(/\sd="([^"]*)"/g)) dAttrChars += m[1].length;
+let transformChars = 0;
+for (const m of svg.matchAll(/\stransform="([^"]*)"/g)) transformChars += m[1].length;
+
+const totalRefBases = vgJson.node.reduce((a, n) => a + n.sequence.length, 0);
+
+console.log(JSON.stringify({
+  input: {
+    bytes: Buffer.byteLength(raw),
+    nodes: vgJson.node.length,
+    paths: vgJson.path.length,
+    mappings: vgJson.path.reduce((a, p) => a + p.mapping.length, 0),
+    bases: totalRefBases,
+  },
+  output: {
+    svgBytes: Buffer.byteLength(svg),
+    elements: Object.values(tagCounts).reduce((a, b) => a + b, 0),
+    tagCounts,
+    dAttrChars,
+    transformChars,
+    widthPx: width,
+    heightPx: height,
+  },
+  stages: Object.fromEntries(t),
+  totalMs: +(performance.now() - processStart).toFixed(2),
+  peakRssMb: +(process.memoryUsage().rss / 1048576).toFixed(1),
+}));


### PR DESCRIPTION
`/seqtubemap` is slow because it boots a headless browser to serialize XML that `pgb` parses straight back into numbers. This branch measures that, writes down what to do about it, and adds the instrumentation for the one number still missing.

**Nothing here changes production behaviour.** The only edit to a code path is `stage_timing()` in `main.py`, which logs. Verify with `git show ab3e5b0 -- main.py`.

## What was measured

**93.7% of the render's memory is the DOM, not the layout.** `perf/rss-split.mjs` marks retained heap either side of `tubemap.js`'s `create()`, forcing a full GC before each mark, then tears the document down and marks again — what the DOM releases is what it was holding.

| fixture | `create()` retained | **DOM share** | layout share |
| --- | ---: | ---: | ---: |
| spine 150 × 464 strands | 567.6 MB | **530.7 MB (93.5%)** | 36.9 MB |
| spine 400 × 464 strands | 1522.7 MB | **1427.5 MB (93.7%)** | 95.2 MB |

The layout is ~15× smaller than the document built to hold it, and holds no DOM references. So the ceiling that makes large nodes unfetchable is a **DOM** ceiling — which also explains why no threshold in bytes or seconds separates a success from a 500: the failure tracks element count, which the client can't see.

**41–47% of every response carries no information.** Byte census across the five real golden documents `pgb` commits (0.29 MB to 13.56 MB, 369 to 464 strands):

| | 90 bp | 600 bp | node 5520 |
| --- | ---: | ---: | ---: |
| `d=` — the geometry | 15.0% | 28.1% | 29.9% |
| `style=` — 1 of ~464 rgb triples | 16.4% | 14.5% | 14.2% |
| `trackName=` — 1 of ~464 names | 11.4% | 10.3% | 10.1% |
| `color=` — *the same rgb as `style`* | 8.6% | 7.6% | 7.5% |
| `class="track{id}"` — same int as `trackID` | 5.4% | 4.8% | 4.8% |
| `<title></title>` — empty | 5.0% | 4.4% | 4.3% |
| **redundant** | **46.9%** | **41.5%** | **40.8% (5.53 MB)** |

Node 5520 carries **40,716 empty `<title>` elements** — which are also 40,716 jsdom nodes, feeding straight back into the memory finding. The geometry is under a third of the payload. There are zero `<text>` and zero `<line>` elements: the document is bands and segment boxes and nothing else.

**One slow request stalls every concurrent one.** `main.py:470` and `:527` are both `async def`, and neither awaits anything — every pipeline stage is a blocking `subprocess.run`. Observed live: four requests failed with empty HTTP status while a 120 s request was in flight.

**`pathnumoption=compressed` never fires.** It keys on the entire walk across the region (`main.py:212-226`), so one SNP prevents any collapse. Byte-identical output to `normal` at 1000 bp.

## What is proposed

[`docs/adr/0001-additive-band-format.md`](docs/adr/0001-additive-band-format.md). `/seqtubemap` gains `?format=bands` returning the numbers directly; the band data becomes canonical and the SVG becomes a rendering of it. **Additive** — the existing URL keeps returning SVG, so the two repos never deploy in lockstep and the SVG stays as the oracle.

Four increments, each shippable alone:

| | change | wins |
| --- | --- | --- |
| **A** | `async def` → `def` ×2; lazy `TabixFile` | one request stops taking the API down — **and this fixes `/json` too** |
| **B** | capture the d3 joins; derive SVG from band data; delete `jsdom` + `canvas` | ceiling ~15×; −722 ms per request; −16.6% bytes |
| **C** | floats not strings; binary body; `?format=bands` | ~1.5 MB vs 10.07 MB at 10 kb; client's regex pass deleted |
| **D** | delete the `vg` round trip | 2 spawns, 2 temp files, the 13× intermediate — **gated on the ask below** |

**A is a two-word diff.** FastAPI runs a plain `def` endpoint in a threadpool automatically, so deleting the word `async` twice is the whole fix. I'd like to land it separately and first.

**B ships against an unchanged `pgb`.** It's held byte-compatible with `parseBands.ts` as a deliberate constraint — that parser requires `style="fill: rgb(R, G, B); fill-opacity: 1;" trackID="N" trackName="…"` contiguous and in that order, and counts `<rect>` + `<path>` in `g.track`. Dropping `color=`, `class=` and the empty `<title>`s changes neither. So the frontend becomes B's conformance test: a bad deploy surfaces as an error card, not as a diff nobody ran.

## The ask

Two things, one deploy — detail in [`docs/perf/deploy-request.md`](docs/perf/deploy-request.md).

**1. Merge or deploy this branch and send a grep.** The ~34 s upstream figure is the last number in the effort that's inferred by subtraction rather than observed. Three requests, each against a **fresh region** so `cached=False` — the cached path skips the stage I most suspect:

```
/seqtubemap?chrom=chr8&start=78900000&end=78900090&version=v2&pathnumoption=normal&nodewidthoption=compressed
/seqtubemap?chrom=chr8&start=78910000&end=78913000&version=v2&pathnumoption=normal&nodewidthoption=compressed
/seqtubemap?chrom=chr8&start=78920000&end=78930000&version=v2&pathnumoption=normal&nodewidthoption=compressed
```

```sh
grep '\[stage-timing\]' <logfile>
```

The 10 kb one will hold the API for ~2 minutes — that's the `async def` bug above, not the instrumentation, but pick a quiet moment.

This gates **D only**. A–C are correct regardless of where the upstream time goes.

**2. The pipeline intermediates for five regions.** `pgb` commits five golden tube maps but only the *outputs*. To test the server end-to-end I need what produced them — `postprocess_gfa_subgraph` or the vg JSON, either works: `chr8:78,771,162-78,771,252`, `chr1:25,331,046-25,331,646`, `chr8:10,079,054-10,080,461`, `chr1:25,301,271-25,309,238`, `chr1:25,331,646-25,335,796`.

## Files

| | |
| --- | --- |
| `main.py` | `stage_timing()` + one log line per request. The only code-path edit. |
| `CONTEXT.md` | The glossary `CLAUDE.md` already points at. Adopts `pgb`'s vocabulary so the two repos don't diverge — one concept had **five** spellings (walk / path / track / strand / haplotype), and `node` meant two different granularities in the same URL. |
| `docs/adr/0001-…` | The decision, four measurements, four rejected alternatives. |
| `docs/perf/seqtubemap-latency.md` | Full findings, §1–9. |
| `docs/perf/seqtubemap-plan.md` | Increments A–D and what's already been ruled out. |
| `docs/perf/deploy-request.md` | The ask above, in full. |
| `perf/` | The harness. `rss-split.mjs` produced the 93.7%; needs `--expose-gc`. |

## Ruled out, so it doesn't get re-litigated

**Result caching** — retrievals are near-random; a scientist pokes arbitrary nodes with no intent to repeat one. Settled on access patterns, not technology.

**Haplotype collapsing** — the ~464 strands are fixed input, not a variable. Nothing here reduces cost by merging or dropping haplotypes. (The `pathnumoption` defect above is real and worth its own issue; it just isn't the performance strategy.)
