### PR TITLE
Rewrite the deploy request as steps Cici can follow

### DIFF
--- a/docs/perf/after-timings.md
+++ b/docs/perf/after-timings.md
@@ -1,0 +1,32 @@
+# After the stage timings come back
+
+Follow-ups for me, once Cici returns the log from
+[`deploy-request.md`](./deploy-request.md).
+
+- Fill in §2 and close §6 of [`seqtubemap-latency.md`](./seqtubemap-latency.md), where the
+  ~34 s upstream figure is currently marked as inferred by subtraction rather than measured.
+- Re-rank increment **D** in [`seqtubemap-plan.md`](./seqtubemap-plan.md) — it's the only
+  one gated on this. A-C are correct regardless of where the upstream time goes.
+- Update the rendered report **by passing its URL**
+  (`https://claude.ai/code/artifact/71539dd1-fb13-44d0-8468-a3a96e726114`); publishing
+  without it forks the link into a second artifact.
+
+## Reading the log
+
+Each `/seqtubemap` request prints one line. To pull them out of whatever she sends:
+
+```sh
+grep '\[stage-timing\]' seqtubemap-log.txt
+```
+
+Shape of a line:
+
+```
+[stage-timing] chr8:78900000-78900090 span=90bp v2 path=normal width=compressed
+cached=False total=8.412s subgraph_extract=6.1s gfa_process=1.2s gfa_to_vg=0.4s
+vg_to_json=0.5s generate_svg=0.2s json_mb=0.4 svg_mb=0.3
+```
+
+Check `cached=False` on all three before trusting them — a cached subgraph skips
+`subgraph_extract`, which is the stage in question. If any line says `cached=True`, that
+region had been requested before and needs re-running at shifted coordinates.

--- a/docs/perf/deploy-request.md
+++ b/docs/perf/deploy-request.md
@@ -1,109 +1,150 @@
-# The ask for Cici — one deploy, two things to send back
+# What I need from the server
 
-Two things are needed from the live server before the `/seqtubemap` work can be verified,
-and both come from the same deploy, so they go in one message rather than two.
+Hi Cici — two things, and they both come off the same deploy. Probably 15 minutes.
 
-1. **Stage timings for three fresh regions** — the last unmeasured number in the effort.
-2. **The pipeline intermediates for five regions** — the missing half of the golden
-   fixtures.
-
-**Why this can't be done locally.** This machine is arm64 and `docker-compose.yml` pins
-`platform: linux/amd64`, so a local container runs under x86 emulation — which inflates the
-native binaries (`vg`, `gbz-base`) unevenly, and those are exactly the stages being
-measured. Local Docker is fine for *developing* the fix, not for timing it. Separately, the
-three `.walk.gz` files are team-generated derivatives rather than public HPRC downloads, and
-the server won't boot without all three.
-
-**Status.** PR [#12](https://github.com/CAST-genomics/PangenomeAPI/pull/12) carries the
-`[stage-timing]` instrumentation. It is logging only — no behaviour change — and the diff is
-reviewable in a minute (`git show ab3e5b0 -- main.py`). The message below is a comment on
-that PR, or a Slack message pointing at it; it is written as a peer asking a colleague, so
-adjust the tone to taste.
+Anywhere below that says `<something>`, that's a placeholder for a real value on your end.
+If a step doesn't work, stop and ping me rather than digging — none of this is worth your
+afternoon.
 
 ---
 
-**Subject: Two things off one deploy — stage timings + five fixture dumps**
+## Task 1 — deploy a logging patch, then send me the log file
 
-Hi Cici —
+PR [#12](https://github.com/CAST-genomics/PangenomeAPI/pull/12) added timing printouts to
+`/seqtubemap`. It's already merged into `main`, so there's no branch to switch to — the
+server just needs to pull and restart. It only prints things; it doesn't change what the
+endpoint returns.
 
-I've been digging into why `/seqtubemap` is slow and I've got it down to one unmeasured
-number plus one missing artifact. Both come off the same deploy, so I've bundled them.
-Maybe 15 minutes of your time.
+### Step 1 — deploy it
 
-**What I've found.** A 10 kb region takes **120 seconds** and returns a **10 MB** SVG. Two
-measurements say where most of that goes:
-
-- **93.7% of the render's memory is the jsdom document**, not the layout — measured by
-  tearing the DOM down and watching what's released, at two fixture sizes. That's why big
-  nodes can't be fetched at all; the ceiling is the DOM.
-- **41–47% of every response carries no information** — measured across five real documents
-  from 0.29 MB to 13.6 MB. Per-strand constants re-serialized on every band, `color=`
-  duplicating the rgb already in `style=`, `class=` duplicating `trackID`, and 40,716 empty
-  `<title>` elements in one document.
-
-The plan is in
-[`docs/adr/0001-additive-band-format.md`](https://github.com/CAST-genomics/PangenomeAPI/blob/perf/seqtubemap-diagnosis/docs/adr/0001-additive-band-format.md).
-Short version: `/seqtubemap` gains `?format=bands` that returns the numbers directly. It's
-**additive** — the existing URL keeps returning SVG, unchanged, so nothing has to deploy in
-lockstep. There's also a two-word fix I'd like to land first, separately: both endpoints are
-`async def` and neither awaits anything, so one slow request currently stalls every
-concurrent one. Deleting the word `async` twice makes FastAPI run them in a threadpool. That
-one helps `/json` as much as `/seqtubemap`.
-
-**Ask 1 — deploy PR #12 and send me a grep.** It's logging only; it adds one line per
-request. Then hit three URLs, each against a **fresh region** so `cached=False` — the cached
-path skips the stage I most suspect:
-
-```
-https://pangenome-api.ucsd.edu:8000/seqtubemap?chrom=chr8&start=78900000&end=78900090&version=v2&pathnumoption=normal&nodewidthoption=compressed
-https://pangenome-api.ucsd.edu:8000/seqtubemap?chrom=chr8&start=78910000&end=78913000&version=v2&pathnumoption=normal&nodewidthoption=compressed
-https://pangenome-api.ucsd.edu:8000/seqtubemap?chrom=chr8&start=78920000&end=78930000&version=v2&pathnumoption=normal&nodewidthoption=compressed
-```
-
-Then:
+On the server, from the repo directory:
 
 ```sh
-grep '\[stage-timing\]' <logfile>
+git checkout main
+git pull
 ```
 
-Fair warning: the 10 kb one will hold the API for around two minutes. That's the
-event-loop bug above, not something the instrumentation introduced — but pick a quiet
-moment.
+Then **restart the API** the way you normally do. The restart matters — until the process
+restarts, it's still running the old code and won't print anything.
 
-Three lines is all I need. They tell me whether the time is in the `gbz-base` query, the GFA
-rewrite, or the `vg` hop, and that decides whether one of the four planned changes is worth
-doing at all.
+### Step 2 — run three requests
 
-**Ask 2 — the intermediates for five regions.** `pgb` has five committed golden tube maps,
-but only the *outputs*. To test the server end-to-end I need what produced them: the
-`postprocess_gfa_subgraph` (or the vg JSON, either works) for:
+Paste this whole block into a terminal (it can be your laptop or the server, either is
+fine). It makes three requests, one after another, and prints a line for each.
 
-| region | size |
-| --- | ---: |
-| `chr8:78,771,162-78,771,252` | 0.29 MB |
-| `chr1:25,331,046-25,331,646` | 3.37 MB |
-| `chr8:10,079,054-10,080,461` | 3.97 MB |
-| `chr1:25,301,271-25,309,238` (node 5514) | 12.92 MB |
-| `chr1:25,331,646-25,335,796` (node 5520) | 13.56 MB |
+```sh
+BASE='https://pangenome-api.ucsd.edu:8000/seqtubemap'
+OPTS='version=v2&pathnumoption=normal&nodewidthoption=compressed'
 
-Any way you can get them to me is fine. With those, `pgb`'s existing fixtures become a real
-end-to-end test and I can verify the rework against known-good output rather than against
-my own synthetic data.
+for R in 'chrom=chr8&start=78900000&end=78900090' \
+         'chrom=chr8&start=78910000&end=78913000' \
+         'chrom=chr8&start=78920000&end=78930000'; do
+  curl -s -o /dev/null -w "%{http_code}  %{size_download} bytes  %{time_total}s\n" \
+    "$BASE?$R&$OPTS"
+done
+```
 
-Happy to jump on a call and do the deploy together if that's easier than doing it
-asynchronously.
+Two things to expect:
+
+- **It will look frozen.** The third request holds the whole API for about two minutes.
+  That's a known bug I'm fixing separately, not something you did. Let it finish.
+- **Three lines print out**, each starting with `200`. If you get a `500` or a `000`, send
+  me what you got and stop there.
+
+Because the API stalls while this runs, pick a moment when nobody else is using it.
+
+### Step 3 — save the log and send it to me
+
+Don't read it or filter it — I just want the raw file. Run these **in order** and stop at
+the first one that produces a file with something in it:
+
+```sh
+# If the API runs under Docker:
+docker compose logs api > ~/seqtubemap-log.txt
+
+# If it runs under systemd:
+journalctl -u <service-name> --since '2 hours ago' > ~/seqtubemap-log.txt
+
+# If it writes to a log file somewhere, just copy that file:
+cp <path-to-the-logfile> ~/seqtubemap-log.txt
+```
+
+Check it isn't empty:
+
+```sh
+wc -l ~/seqtubemap-log.txt
+```
+
+If that's `0`, try the next command in the list. If none of them work, tell me how the API
+gets started on that machine and I'll figure out where the log goes.
+
+Then send me `~/seqtubemap-log.txt` however is easiest — Slack, email, attached to the PR.
+It's fine if it's big or full of unrelated stuff; I'll pull out what I need.
+
+---
+
+## Task 2 — five subgraph files
+
+Same server, same idea: five requests, then copy five files. Do this *after* Task 1 so the
+two don't overlap.
+
+### Step 1 — request the five regions
+
+Paste this block into a terminal. Same as before: one request at a time, `-o /dev/null`
+throws away the picture, and a status line prints for each.
+
+```sh
+BASE='https://pangenome-api.ucsd.edu:8000/seqtubemap'
+OPTS='version=v2&pathnumoption=normal&nodewidthoption=compressed'
+
+for R in 'chrom=chr8&start=78771162&end=78771252' \
+         'chrom=chr1&start=25331046&end=25331646' \
+         'chrom=chr8&start=10079054&end=10080461' \
+         'chrom=chr1&start=25301271&end=25309238' \
+         'chrom=chr1&start=25331646&end=25335796'; do
+  curl -s -o /dev/null -w "%{http_code}  %{size_download} bytes  %{time_total}s\n" \
+    "$BASE?$R&$OPTS"
+done
+```
+
+The last two are large regions and will each take a few minutes. Same as Task 1: the API is
+unresponsive while they run, so pick a quiet moment. If a region has been requested before
+it'll come back almost instantly — that's fine and actually saves time.
+
+### Step 2 — copy the five files out
+
+Each request leaves a `.gfa` file behind on the server, in the API's cache directory:
+
+```sh
+cd <the-repo-directory-on-the-server>/cache/seqtubemap/mc
+ls -la subgraph_chr8_78771162_78771252_v2.gfa \
+       subgraph_chr1_25331046_25331646_v2.gfa \
+       subgraph_chr8_10079054_10080461_v2.gfa \
+       subgraph_chr1_25301271_25309238_v2.gfa \
+       subgraph_chr1_25331646_25335796_v2.gfa
+```
+
+All five should be listed, and none should be 0 bytes. If one is missing, its request in
+Step 1 probably failed — re-run just that one and check again.
+
+Then bundle them up:
+
+```sh
+tar czf ~/seqtubemap-subgraphs.tar.gz subgraph_chr8_78771162_78771252_v2.gfa \
+                                      subgraph_chr1_25331046_25331646_v2.gfa \
+                                      subgraph_chr8_10079054_10080461_v2.gfa \
+                                      subgraph_chr1_25301271_25309238_v2.gfa \
+                                      subgraph_chr1_25331646_25335796_v2.gfa
+```
+
+Send me `~/seqtubemap-subgraphs.tar.gz` — email, Drive, or just tell me it's on the server
+and where, if it's too big to attach. I can take it from that file onward; everything else
+in the pipeline I can regenerate myself.
+
+---
+
+Happy to jump on a call and do any of this together if that's easier than going back and
+forth.
 
 Thanks —
 Doug
-
----
-
-## When the timings come back
-
-- Fill in §2 and close §6 of [`seqtubemap-latency.md`](./seqtubemap-latency.md), where the
-  ~34 s upstream figure is currently marked as inferred by subtraction rather than measured.
-- Re-rank increment **D** in [`seqtubemap-plan.md`](./seqtubemap-plan.md) — it's the only
-  one gated on this. A-C are correct regardless of where the upstream time goes.
-- Update the rendered report **by passing its URL**
-  (`https://claude.ai/code/artifact/71539dd1-fb13-44d0-8468-a3a96e726114`); publishing
-  without it forks the link into a second artifact.

--- a/docs/perf/seqtubemap-plan.md
+++ b/docs/perf/seqtubemap-plan.md
@@ -17,7 +17,7 @@ Written 2026-08-27, at the end of the diagnosis phase.
 
 | | |
 | --- | --- |
-| Branch | `perf/seqtubemap-diagnosis`, PR [#12](https://github.com/CAST-genomics/PangenomeAPI/pull/12) open |
+| Branch | `perf/seqtubemap-diagnosis` merged to `main` via PR [#12](https://github.com/CAST-genomics/PangenomeAPI/pull/12) |
 | Diagnosis | Complete. One gap remains: the upstream stage (see Step 0) |
 | Grilling | Complete, 2026-08-27. Produced [`CONTEXT.md`](../../CONTEXT.md) and [ADR 0001](../adr/0001-additive-band-format.md) |
 | Built | Local harness (`perf/`), server-side stage timers (`main.py`) |
@@ -80,17 +80,18 @@ Verification at the end measures against these. All from the live API, 2026-08-2
 
 ---
 
-## Step 0 — Push, and start the timers
+## Step 0 — Deploy, and start the timers
 
 **Skill:** none. Plain git and a deploy.
 
-Push `perf/seqtubemap-diagnosis` and get the `[stage-timing]` instrumentation onto the
-server. Capture three requests — roughly 90 bp, 3 kb, 10 kb — each against a **fresh
-region** so `cached=False`, because the cached path skips the stage most likely to dominate.
+The `[stage-timing]` instrumentation is merged (PR #12, on `main`); what remains is getting
+it onto the server and capturing three requests — roughly 90 bp, 3 kb, 10 kb — each against
+a **fresh region** so `cached=False`, because the cached path skips the stage most likely to
+dominate.
 
-```sh
-grep '\[stage-timing\]' <logfile>
-```
+That deploy is somebody else's machine, so the steps are written up for them in
+[`deploy-request.md`](./deploy-request.md); the parsing notes for the log that comes back
+are in [`after-timings.md`](./after-timings.md).
 
 **Why first:** the ~34 s upstream figure is inferred by subtraction. Everything downstream
 of here is ranked on that inference. One deploy converts it to fact and may reorder the


### PR DESCRIPTION
`docs/perf/deploy-request.md` was written as a case for *why* the deploy is needed, with the actual work buried in two code fences that assumed the reader knew where the API's logs live and how to produce a pipeline intermediate. Cici is a student; that framing put the arcane parts on her.

It is now only her tasks — no findings, no rationale:

- **Task 1** pulls `main` (PR #12 is merged, so there is no branch to check out), runs three requests from a paste-in loop, and sends the whole log file. Finding the log is three commands tried in order until one produces a non-empty file, rather than knowledge of the deployment. The grep, the sample line, and the `cached=False` check moved to `after-timings.md`, since reading the log is the requester's job.
- **Task 2** was unactionable as written: it named `postprocess_gfa_subgraph`, which the background delete in `main.py:520` removes seconds after each response, so collecting it means racing a cleanup. It now asks for the pre-process GFA, which survives because it is the cache key, with exact filenames under `cache/seqtubemap/mc/`. Nothing is lost — `SeqTubeGfaProcessor` is plain Python in `main.py:173`, and the `vg` hops only need Docker, where emulation distorts timing but not output.

Also notes that the two-minute API stall is expected, and gives an exit ramp: ping rather than dig.

`seqtubemap-plan.md` Step 0 said to push `perf/seqtubemap-diagnosis`; it is merged. Step 0 and the status table now say so and point at the two docs.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)