### PR TITLE
Add a test runner per language, and CI that runs both

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+# Runs both test suites on every pull request, and on pushes to main.
+#
+# The two suites are independent — the Python one boots the app, the Node one
+# drives the sequence tube map generator — so they run as separate jobs and either can
+# fail the build on its own.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  python:
+    name: Python tests
+    runs-on: ubuntu-latest
+    env:
+      # Both pinned to the versions the Dockerfile installs.
+      VG_VERSION: v1.75.0
+      PANCT_COMMIT: 03c406b
+      PANCT_PATH: ${{ github.workspace }}/.tools
+      # In CI a missing dependency is a broken workflow, not a bare machine:
+      # tests that would skip for want of one fail the build instead.
+      PANGENOME_TESTS_REQUIRE_ALL: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-test.txt
+
+      # The endpoint seam still shells out to `vg`, so CI has it. Tests that
+      # need it skip with a reason elsewhere; here they must actually run.
+      - name: Cache vg
+        id: cache-vg
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/vg
+          key: vg-${{ env.VG_VERSION }}
+      - name: Install vg
+        if: steps.cache-vg.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.local/bin
+          curl -fsSL "https://github.com/vgteam/vg/releases/download/${VG_VERSION}/vg" -o ~/.local/bin/vg
+          chmod +x ~/.local/bin/vg
+      - name: Put vg on PATH
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install panCT
+        run: |
+          git clone --quiet https://github.com/CAST-genomics/panCT.git "$PANCT_PATH/panCT"
+          git -C "$PANCT_PATH/panCT" checkout --quiet "$PANCT_COMMIT"
+
+      - name: Install Python dependencies
+        run: pip install -r requirements-test.txt
+
+      - name: Check vg is available
+        run: vg version
+
+      - name: Run tests
+        run: pytest
+
+  node:
+    name: Node tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ node_modules/
 .env
 
 .ipynb_checkpoints
+# test fixtures — small, committed on purpose. The exemption is load-bearing on
+# a case-insensitive filesystem, where `*.JSON*` above swallows tiny-vg.json.
+!tests/fixtures/**
+
+# test tooling
+.pytest_cache/
+.tools/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ git config --local tools.path [PATH_TO_TOOL_DIR_WITH_PANCT]
 git config --local data.path [PATH_TO_DATA_DIR_WITH_MINIGRAPH_AND_MINIGRAPH-CACTUS_GFA]
 ```
 
+## How to Test
+
+Two suites, one command each. Both are safe to run on a machine without graph
+data; anything that genuinely needs a missing dependency skips and says so.
+
+```
+pip install -r requirements-test.txt
+pytest                 # Python: boots the app and exercises the vg seam
+npm test               # Node: drives the sequence tube map generator
+```
+
+Neither suite needs graph data: the Python tests stand in tiny files for the
+`.walk.gz` derivatives and stub the two natively-compiled layout libraries, and
+the Node tests read a committed vg JSON fixture. panCT is used for real if you
+have it — from the `tools.path` Step 5 sets, or from `PANCT_PATH` — and stubbed
+if you do not. Tests that shell out to `vg` skip when it is not installed.
+
+Both suites run in CI on every pull request (`.github/workflows/ci.yml`), where
+`vg` and panCT are installed and a skip is turned into a failure.
+
 ## How to Use:
 In the pangenome-api folder, run:
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "type": "module",
+  "scripts": {
+    "test": "node --test \"tests/node/**/*.test.mjs\""
+  },
   "dependencies": {
     "canvas": "^3.2.3",
     "d3": "^7.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+testpaths = ["tests/python"]
+addopts = "-ra"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,10 @@
+# Everything needed to run `pytest`, on top of a Python 3.11+ interpreter.
+#
+# The runtime dependencies here are a subset of the Dockerfile's: the two
+# natively-compiled layout libraries (ogdf-python, adaptagrams) are stood in for
+# by tests/python/conftest.py rather than built, since no test exercises layout.
+fastapi
+numpy
+pysam
+pytest
+httpx  # the transport behind fastapi.testclient.TestClient

--- a/tests/fixtures/tiny-vg.json
+++ b/tests/fixtures/tiny-vg.json
@@ -1,0 +1,282 @@
+{
+  "node": [
+    {
+      "id": 1,
+      "sequence": "ATGG"
+    },
+    {
+      "id": 2,
+      "sequence": "AGGCATGA"
+    },
+    {
+      "id": 3,
+      "sequence": "CGCTATA"
+    },
+    {
+      "id": 4,
+      "sequence": "CGTAT"
+    },
+    {
+      "id": 5,
+      "sequence": "GGTGTTAA"
+    },
+    {
+      "id": 6,
+      "sequence": "AATCCCT"
+    },
+    {
+      "id": 7,
+      "sequence": "GCCAATCAGC"
+    },
+    {
+      "id": 8,
+      "sequence": "TGTGTAGGT"
+    },
+    {
+      "id": 9,
+      "sequence": "TGTTGTAGCGGT"
+    },
+    {
+      "id": 10,
+      "sequence": "TCGGGCAA"
+    },
+    {
+      "id": 11,
+      "sequence": "TGAGGGTCTGTG"
+    },
+    {
+      "id": 12,
+      "sequence": "ATGGACATTGG"
+    },
+    {
+      "id": 13,
+      "sequence": "GTCAGTTAG"
+    },
+    {
+      "id": 14,
+      "sequence": "ACCCAAAA"
+    }
+  ],
+  "path": [
+    {
+      "name": "GRCh38#0#chr1",
+      "freq": 1,
+      "indexOfFirstBase": 0,
+      "mapping": [
+        {
+          "position": {
+            "node_id": 1,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 3,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 5,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 7,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 9,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 10,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 12,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 13,
+            "is_reverse": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "HG10000#1#chr1",
+      "freq": 1,
+      "indexOfFirstBase": 0,
+      "mapping": [
+        {
+          "position": {
+            "node_id": 2,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 3,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 5,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 8,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 9,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 11,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 12,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 14,
+            "is_reverse": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "HG10001#2#chr1",
+      "freq": 1,
+      "indexOfFirstBase": 0,
+      "mapping": [
+        {
+          "position": {
+            "node_id": 2,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 3,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 6,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 8,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 9,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 10,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 12,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 13,
+            "is_reverse": false
+          }
+        }
+      ]
+    },
+    {
+      "name": "HG10002#1#chr1",
+      "freq": 1,
+      "indexOfFirstBase": 0,
+      "mapping": [
+        {
+          "position": {
+            "node_id": 1,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 3,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 5,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 8,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 9,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 10,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 12,
+            "is_reverse": false
+          }
+        },
+        {
+          "position": {
+            "node_id": 14,
+            "is_reverse": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/node/generate-svg.smoke.test.mjs
+++ b/tests/node/generate-svg.smoke.test.mjs
@@ -1,0 +1,61 @@
+// Smoke test for the Node stage of /seqtubemap: the sequence tube map generator
+// is driven over a small fixture and must produce a document.
+//
+// The fixture is the shape `vg view -j` emits, which is all tubemap.js reads.
+// It needs no `vg` binary and no graph data, so this test runs anywhere Node does.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const generator = join(repoRoot, "seqtubemap", "generate-svg.mjs");
+const fixture = join(repoRoot, "tests", "fixtures", "tiny-vg.json");
+
+// The fixture's reference strand spans 69 bases; the generator is handed the
+// region as [start, end] in the same coordinates /seqtubemap passes them.
+const START = 0;
+const END = 69;
+const NODE_WIDTH_OPTION = "normal";
+
+function generateSvg() {
+  const outDir = mkdtempSync(join(tmpdir(), "tubemap-smoke-"));
+  const outFile = join(outDir, "tubemap.svg");
+  execFileSync(
+    process.execPath,
+    [generator, fixture, outFile, String(START), String(END), NODE_WIDTH_OPTION],
+    { cwd: repoRoot, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  assert.ok(existsSync(outFile), `generator did not write ${outFile}`);
+  return readFileSync(outFile, "utf8");
+}
+
+// One document, read by every test below: the generator is a subprocess, and
+// nothing here mutates what it returns.
+const svg = generateSvg();
+
+test("the generator produces an SVG document from a vg JSON fixture", () => {
+  assert.match(svg, /^<svg /, "output does not start with an <svg> element");
+  assert.match(svg, /xmlns="http:\/\/www\.w3\.org\/2000\/svg"/);
+  assert.match(svg, /viewBox="[-\d. ]+"/);
+  assert.ok(svg.trimEnd().endsWith("</svg>"), "output is not a closed document");
+});
+
+test("the document carries bands attributed to named strands", () => {
+  // pgb's parser reads bands out of `g.track`, keyed by the trackID/trackName
+  // pair. A document without them is a document it cannot use.
+  assert.ok(svg.includes('<g class="track">'), "no g.track group in the document");
+
+  const bands = svg.match(/<(rect|path)\b/g) ?? [];
+  assert.ok(bands.length > 0, "document contains no bands");
+
+  const strandNames = new Set(
+    [...svg.matchAll(/trackName="([^"]+)"/g)].map((m) => m[1]),
+  );
+  // The fixture carries GRCh38 plus three assembly strands.
+  assert.equal(strandNames.size, 4);
+  assert.ok(strandNames.has("GRCh38#0#chr1"), "the reference strand is missing");
+});

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,193 @@
+"""Shared setup for the Python tests.
+
+Booting `main` is the whole difficulty here: it reaches for panCT, for four
+tabix-indexed walk derivatives, and — through `bandage_graph` and
+`adaptagrams_converter` — for two natively-compiled layout libraries that only
+exist inside the Docker image. None of that is needed to answer "does the app
+boot and serve", so this module stands each one up cheaply:
+
+* the walk derivatives become tiny tabix files written into a temp directory,
+* the native layout libraries become import stubs,
+* panCT is used for real when the machine has it, and stubbed when it does not,
+* `tools.path` and `data.path` are supplied through git's environment config,
+  so the developer's own `git config --local` values are left alone.
+
+The panCT stub is the one stand-in that costs something: a machine without
+panCT boots the app against a placeholder `Region`, so a break in panCT's own
+interface would not show up there. CI installs panCT for real and sets
+`PANGENOME_TESTS_REQUIRE_ALL`, which turns every stand-in of that kind — and
+every skip — into a failure, so the gap is closed where it matters.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# CI sets this: there, a missing dependency is a broken workflow rather than a
+# developer machine without `vg`, and must fail the build instead of skipping.
+REQUIRE_ALL = os.environ.get("PANGENOME_TESTS_REQUIRE_ALL") == "1"
+
+# The four `.walk.gz` derivatives `main` opens at import time (main.py:77-88).
+WALK_FILES = (
+    "hprc-v1.1-mc-grch38-mapped-flattened.walk.gz",
+    "hprc-v2.0-mc-grch38-v2.2.walk.gz",
+    "hprc_v1.0_minigraph_filtered_with_id.walk.gz",
+    "v1_1_hprc_v2.0_minigraph.sorted.pclai.walk.gz",
+)
+
+
+def _skip_or_fail(reason: str) -> None:
+    """Skip for a missing dependency — unless CI said there must not be one."""
+    if REQUIRE_ALL:
+        pytest.fail(f"{reason} (PANGENOME_TESTS_REQUIRE_ALL is set)")
+    pytest.skip(reason)
+
+
+def _write_walk_stand_ins(data_dir: Path) -> None:
+    """Write one bgzipped, tabix-indexed stand-in per walk derivative.
+
+    A few bed rows in place of a multi-gigabyte walk file: enough for
+    `pysam.TabixFile` to open, which is all module import requires.
+    """
+    import pysam
+
+    for name in WALK_FILES:
+        plain = data_dir / name[: -len(".gz")]
+        plain.write_text("chr1\t0\t100\nchr1\t100\t200\n")
+        pysam.tabix_compress(str(plain), str(data_dir / name), force=True)
+        plain.unlink()
+        pysam.tabix_index(str(data_dir / name), preset="bed", force=True)
+
+
+def _install_native_stubs() -> None:
+    """Stub the layout libraries that are only built inside the Docker image."""
+    if "ogdf_python" not in sys.modules:
+        ogdf_python = types.ModuleType("ogdf_python")
+        ogdf_python.ogdf = types.SimpleNamespace()
+        ogdf_python.cppinclude = lambda *args, **kwargs: None
+        sys.modules["ogdf_python"] = ogdf_python
+
+    if "adaptagrams" not in sys.modules:
+        sys.modules["adaptagrams"] = types.ModuleType("adaptagrams")
+
+
+def _install_panct_stub() -> None:
+    """Stand in for panCT with a placeholder `Region`.
+
+    Only reached on a machine that does not have panCT. `Region` is the one
+    name this codebase imports from it, and no test here does anything with a
+    region beyond letting `main` import.
+    """
+
+    class Region:
+        def __init__(self, chrom, start, end):
+            self.chrom, self.start, self.end = chrom, start, end
+
+    package = types.ModuleType("panCT")
+    package.__path__ = []
+    panct = types.ModuleType("panCT.panct")
+    panct.__path__ = []
+    data = types.ModuleType("panCT.panct.data")
+    data.Region = Region
+    logging_module = types.ModuleType("panCT.panct.logging")
+    logging_module.getLogger = __import__("logging").getLogger
+
+    sys.modules.update(
+        {
+            "panCT": package,
+            "panCT.panct": panct,
+            "panCT.panct.data": data,
+            "panCT.panct.logging": logging_module,
+        }
+    )
+
+
+def _panct_path() -> str | None:
+    """Where panCT lives, or None if this machine does not have it.
+
+    Honours `PANCT_PATH` first, then the `tools.path` the README asks
+    developers to set.
+    """
+    candidates = [os.environ.get("PANCT_PATH")]
+    try:
+        candidates.append(
+            subprocess.check_output(
+                ["git", "config", "--get", "tools.path"], text=True
+            ).strip()
+        )
+    except (subprocess.CalledProcessError, OSError):
+        # No such config key, no git, or no repository — all mean "not here".
+        pass
+
+    for candidate in candidates:
+        if candidate and (Path(candidate) / "panCT" / "panct").is_dir():
+            return candidate
+    return None
+
+
+@pytest.fixture(scope="session")
+def data_dir(tmp_path_factory) -> Path:
+    """A stand-in for the graph data directory, holding only the walk files."""
+    directory = tmp_path_factory.mktemp("data")
+    _write_walk_stand_ins(directory)
+    return directory
+
+
+@pytest.fixture(scope="session")
+def main_module(data_dir):
+    """The imported `main` module, with its heavy surroundings stood in for."""
+    tools_path = _panct_path()
+    if tools_path is None:
+        if REQUIRE_ALL:
+            pytest.fail(
+                "panCT is not installed (PANGENOME_TESTS_REQUIRE_ALL is set): "
+                "set PANCT_PATH to the directory containing it"
+            )
+        _install_panct_stub()
+        tools_path = str(REPO_ROOT)
+
+    _install_native_stubs()
+
+    with pytest.MonkeyPatch.context() as patch:
+        # git reads these ahead of any config file, so `git config --get`
+        # inside main and its helpers resolves to the stand-ins without
+        # touching .git/config — and they are undone when the session ends.
+        patch.setenv("GIT_CONFIG_COUNT", "2")
+        patch.setenv("GIT_CONFIG_KEY_0", "tools.path")
+        patch.setenv("GIT_CONFIG_VALUE_0", tools_path)
+        patch.setenv("GIT_CONFIG_KEY_1", "data.path")
+        patch.setenv("GIT_CONFIG_VALUE_1", str(data_dir))
+        patch.syspath_prepend(str(REPO_ROOT))
+
+        import main
+
+        yield main
+
+
+@pytest.fixture(scope="session")
+def app(main_module):
+    """The booted FastAPI application."""
+    return main_module.app
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    from fastapi.testclient import TestClient
+
+    return TestClient(app)
+
+
+@pytest.fixture(scope="session")
+def vg() -> str:
+    """The `vg` binary, skipping the test when this machine has none."""
+    binary = shutil.which("vg")
+    if binary is None:
+        _skip_or_fail("vg is not installed on this machine")
+    return binary

--- a/tests/python/test_app_smoke.py
+++ b/tests/python/test_app_smoke.py
@@ -1,0 +1,28 @@
+"""Smoke test: the application boots and serves.
+
+Nothing here asserts anything about the pangenome — it asserts that `main`
+imports, that the app object is a live FastAPI application, and that a request
+reaches it and comes back. Everything downstream of this file assumes that
+much works.
+"""
+
+
+def test_the_app_serves_its_schema(client):
+    """`/openapi.json` is FastAPI's own route — the most trivial one there is."""
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    assert response.json()["openapi"].startswith("3.")
+
+
+def test_the_endpoints_are_registered(client):
+    """The two endpoints the browser calls are present on the booted app."""
+    paths = client.get("/openapi.json").json()["paths"]
+
+    assert "/seqtubemap" in paths
+    assert "/json" in paths
+
+
+def test_an_unknown_route_is_a_404(client):
+    """The app routes rather than falling over."""
+    assert client.get("/no-such-route").status_code == 404

--- a/tests/python/test_vg_round_trip.py
+++ b/tests/python/test_vg_round_trip.py
@@ -1,0 +1,53 @@
+"""The `vg` seam: GFA in, vg JSON out.
+
+`/seqtubemap` reaches Node through two `vg` subprocesses — `vg convert -g` then
+`vg view -j` — and increment D of the roadmap deletes them. This pins what they
+produce first, so the deletion has something to be checked against.
+
+Every test here takes the `vg` fixture, which skips with a reason when the
+binary is absent.
+"""
+
+import json
+
+# A three-segment GFA with a bubble and one walk through it. Small enough to
+# read, large enough that the round trip has something to carry.
+TINY_GFA = """H\tVN:Z:1.1
+S\t1\tACGT
+S\t2\tA
+S\t3\tG
+S\t4\tTTTT
+L\t1\t+\t2\t+\t0M
+L\t1\t+\t3\t+\t0M
+L\t2\t+\t4\t+\t0M
+L\t3\t+\t4\t+\t0M
+W\tGRCh38\t0\tchr1\t0\t9\t>1>2>4
+W\tHG00001\t1\tchr1\t0\t9\t>1>3>4
+"""
+
+
+def test_a_gfa_round_trips_to_vg_json(vg, main_module, tmp_path):
+    gfa_file = tmp_path / "subgraph.gfa"
+    gfa_file.write_text(TINY_GFA)
+    vg_file = tmp_path / "subgraph.vg"
+    json_file = tmp_path / "subgraph.json"
+
+    assert main_module.ConvertGfaToVg(str(gfa_file), vg_file)
+    assert vg_file.stat().st_size > 0
+
+    assert main_module.ConvertVgToJson(vg_file, json_file)
+    document = json.loads(json_file.read_text())
+
+    # The shape tubemap.js reads: segments under `node`, strands under `path`.
+    assert {segment["sequence"] for segment in document["node"]} == {
+        "ACGT",
+        "A",
+        "G",
+        "TTTT",
+    }
+    # `vg` is free to decorate a W-line's name with a subrange suffix, so this
+    # asserts the two strands survive the round trip, not how vg spells them.
+    names = [strand["name"] for strand in document["path"]]
+    assert len(names) == 2
+    assert any(name.startswith("GRCh38") for name in names), names
+    assert any(name.startswith("HG00001") for name in names), names


### PR DESCRIPTION
Closes #14.

The repository had no tests, no runner configuration and no workflows, so every ticket after this one had nowhere to put its assertions. **No production files are touched.**

## The two commands

| | command | smoke test |
|---|---|---|
| Python | `pytest` | boots the app and asserts `/openapi.json` responds, both endpoints are registered, and an unknown route 404s |
| Node | `npm test` (`node --test`, no new dependencies) | runs `seqtubemap/generate-svg.mjs` over a committed vg JSON fixture and asserts a closed SVG comes out, with bands under `g.track` carrying `trackName` |

A third Python test pins what the `vg` round trip produces (`vg convert -g` → `vg view -j`), so increment D has something to be checked against when it deletes it. It skips with a reason when `vg` is absent.

## Booting the app without the world

The hard part. `main` imports panCT, opens four tabix-indexed `.walk.gz` derivatives, and pulls in two natively-compiled layout libraries that exist only inside the Docker image. `tests/python/conftest.py` stands in for each of them:

- the walk derivatives become tiny tabix files written with pysam,
- `ogdf_python` and `adaptagrams` become import stubs (no test exercises layout),
- panCT is used for real when the machine has it and stubbed when it does not,
- `tools.path` and `data.path` are supplied through git's environment config, so nobody's `git config --local` is touched.

So both suites run on a laptop with no graph data and no `vg`.

## CI

`.github/workflows/ci.yml` runs the two suites as separate jobs on every pull request (and on pushes to `main`), either of which fails the build on its own. It installs `vg` v1.75.0 and panCT at `03c406b` — the same pins as the Dockerfile.

One addition beyond the ticket, which the ticket needs in order to be verifiable: CI sets `PANGENOME_TESTS_REQUIRE_ALL=1`, which turns "skipped for a missing dependency" into a failure. Without it, "`vg` is available to CI" would be satisfied by a green build that silently skipped everything.

## What isn't verified locally

The `vg` round-trip test. `vg` ships Linux-only binaries and there's no Docker on this machine, so it skipped every local run — **this PR's CI is its first real execution.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)