### PR TITLE
Declare the vendored tube map layout a fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,41 @@ if you do not. Tests that shell out to `vg` skip when it is not installed.
 Both suites run in CI on every pull request (`.github/workflows/ci.yml`), where
 `vg` and panCT are installed and a skip is turned into a failure.
 
+## The vendored tube map layout
+
+`seqtubemap/` holds a **vendored fork** of the sequence tube map layout, not a
+dependency. It was copied from [`vgteam/sequenceTubeMap`](https://github.com/vgteam/sequenceTubeMap)
+at commit
+[`33b7a7e`](https://github.com/vgteam/sequenceTubeMap/commit/33b7a7e5df9f8052974ef8e6c689a031dac6e2c9)
+(2025-08-21 — still the tip of upstream's `master`, and so also the tip when the
+copy was taken on 2026-06-10), and is MIT licensed — Copyright (c) 2017
+Wolfgang Beyer.
+
+| file | upstream origin | state |
+| --- | --- | --- |
+| `seqtubemap/tubemap.js` | `src/util/tubemap.js` | forked — trimmed and edited |
+| `seqtubemap/common.mjs` | `src/common.mjs` | unmodified |
+| `seqtubemap/config-global.mjs` | `src/config-global.mjs` | unmodified |
+| `seqtubemap/config-client.js` | `src/config-client.js` | emptied |
+| `seqtubemap/generate-svg.mjs` | — | ours |
+
+**`tubemap.js` is a fork and does not track upstream.** It arrived already
+trimmed of upstream's interactive browser half (mouse handlers, zoom, legend
+drawing, visibility toggles, the `vg` read extraction entry point — read layout
+itself was kept) and adapted to run headless, and
+it has been edited since. Increment B of the `/seqtubemap` rework will remove
+its DOM sink outright — not yet landed — which puts the divergence beyond
+anything a merge could reconcile. Edit it freely; do not attempt to re-sync it
+with upstream, and do not read a difference from upstream as a bug.
+
+The decision is
+[`docs/adr/0001-additive-band-format.md`](docs/adr/0001-additive-band-format.md)
+(its closing "Consequences" bullet is the one about this file), and the
+increment that acts on it is
+[`docs/perf/seqtubemap-plan.md`](docs/perf/seqtubemap-plan.md). The same
+provenance is repeated in the header comment of `seqtubemap/tubemap.js` for
+anyone who opens the file directly.
+
 ## How to Use:
 In the pangenome-api folder, run:
 ```

--- a/docs/adr/0001-additive-band-format.md
+++ b/docs/adr/0001-additive-band-format.md
@@ -142,6 +142,6 @@ new format is how dead code becomes permanent.
   committed at [`tests/fixtures/seqtubemap/`](../../tests/fixtures/seqtubemap/), matched to
   their outputs on strand count. **B's oracle is end-to-end.**
 - **`seqtubemap/tubemap.js` is declared a fork.** It is an unmarked 4,000-line vendored copy
-  of `vgteam/sequence-tube-map`, carrying upstream's eslint header and no provenance. B
+  of `vgteam/sequenceTubeMap`, carrying upstream's eslint header and no provenance. B
   removes its DOM sink, so the re-sync option is gone in fact; the header comment makes it
   gone on paper too.

--- a/docs/perf/seqtubemap-plan.md
+++ b/docs/perf/seqtubemap-plan.md
@@ -271,7 +271,7 @@ defect, and ADR 0001 records why it is not carried onto the band route.
 ### Two things to do alongside
 
 **Declare the fork.** `seqtubemap/tubemap.js` is an unmarked 4,000-line vendored copy of
-`vgteam/sequence-tube-map`, carrying upstream's eslint header and no provenance, version, or
+`vgteam/sequenceTubeMap`, carrying upstream's eslint header and no provenance, version, or
 README note. B removes its DOM sink, so the re-sync option is gone in fact; a header comment
 naming upstream and the commit makes it gone on paper. This is the single most
 duct-taped-feeling artifact in the repo and one comment fixes the feeling as well as the

--- a/docs/seqtubemap-roadmap.md
+++ b/docs/seqtubemap-roadmap.md
@@ -89,7 +89,7 @@ Prefactoring. Make the change easy, then make the easy change.
 ### [#15](https://github.com/CAST-genomics/PangenomeAPI/issues/15) — Declare the fork
 
 `seqtubemap/tubemap.js` is an unmarked ~4,000-line vendored copy of
-`vgteam/sequence-tube-map`, carrying upstream's eslint header and no provenance, version, or
+`vgteam/sequenceTubeMap`, carrying upstream's eslint header and no provenance, version, or
 note. [#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22) removes its DOM sink, so
 the re-sync option is gone in fact; a header comment makes it gone on paper. Land it before
 anyone edits the file.

--- a/seqtubemap/tubemap.js
+++ b/seqtubemap/tubemap.js
@@ -1,3 +1,46 @@
+/*
+ * VENDORED FORK — this file is not ours, and it is no longer upstream's either.
+ *
+ * Upstream:  vgteam/sequenceTubeMap — https://github.com/vgteam/sequenceTubeMap
+ * File:      src/util/tubemap.js
+ * Taken at:  commit 33b7a7e5df9f8052974ef8e6c689a031dac6e2c9 (2025-08-21). It is
+ *            still the tip of upstream's `master`, and so was also the tip when
+ *            this file was vendored here on 2026-06-10 (commit 11fd871,
+ *            "implement sequence tube map").
+ * Licence:   MIT, Copyright (c) 2017 Wolfgang Beyer. See upstream LICENSE.txt.
+ *
+ * The sibling files `common.mjs` and `config-global.mjs` came from the same
+ * upstream commit and are still byte-identical to it; `config-client.js` is
+ * deliberately empty here. This file is not: it arrived with ~1,180 upstream
+ * lines removed and 20 added (upstream's interactive browser half — mouse and
+ * click handlers, zoom, legend drawing, visibility toggles, the `vg` read
+ * extraction entry point) and adapted for headless use, and has been edited
+ * further since. Read *layout* was kept; only the UI around it went.
+ *
+ * One consequence of that trim is live: `createTubeMap()` still calls
+ * `drawLegend()`, which no longer exists here. Nothing throws only because
+ * `generate-svg.mjs` passes `hideLegend: true` on every call.
+ *
+ * THIS IS A FORK. IT DOES NOT TRACK UPSTREAM, AND IT WILL NOT BE RE-SYNCED.
+ * Edit it freely; do not treat a divergence from upstream as a defect, and do
+ * not try to merge upstream changes back in.
+ *
+ * Why: this project uses the module as a server-side layout engine, not as the
+ * browser application upstream ships. Increment B of the /seqtubemap rework
+ * will go further and remove the DOM sink outright — the layout's output is to
+ * be captured as band data and the SVG emitted from that, so the jsdom/canvas
+ * rendering upstream is built around stops existing in this copy. (That has not
+ * landed yet: this file still calls `d3.select` and reaches for
+ * `document.getElementById`.) The divergence is structural, not a patch set.
+ * The decision is `docs/adr/0001-additive-band-format.md` — see its final
+ * "Consequences" bullet for this file, and `docs/perf/seqtubemap-plan.md` for
+ * the increment. The README's "The vendored tube map layout" section records
+ * the same provenance.
+ *
+ * The `eslint` directives below are upstream's, kept as upstream left them.
+ * This repo runs no linter.
+ */
+
 /* eslint no-param-reassign: "off" */
 /* eslint no-lonely-if: "off" */
 /* eslint no-prototype-builtins: "off" */


### PR DESCRIPTION
Closes #15.

`seqtubemap/tubemap.js` was an unmarked 4,000-line copy carrying upstream's eslint header and nothing else — no provenance, no version, no note anywhere in the repository saying where it came from. Increment B removes its DOM sink, so re-syncing with upstream is already impossible in fact; this writes it down.

## What this says

Upstream is [`vgteam/sequenceTubeMap`](https://github.com/vgteam/sequenceTubeMap) at commit [`33b7a7e`](https://github.com/vgteam/sequenceTubeMap/commit/33b7a7e5df9f8052974ef8e6c689a031dac6e2c9) (2025-08-21), MIT, Copyright (c) 2017 Wolfgang Beyer.

- **The header** names upstream, the file, the commit and the licence; states plainly that this is a fork which will not be re-synced and why; and points at ADR 0001 and the plan.
- **The README** gains a "The vendored tube map layout" section with a per-file table — which siblings are unmodified (`common.mjs`, `config-global.mjs`), which is emptied (`config-client.js`), which is ours (`generate-svg.mjs`) — so a reader finds this without opening a 136 KB file.
- **Three docs** had the slug as `vgteam/sequence-tube-map`, which 404s. Corrected.

## How the commit was established

The vendored blob was diffed against every historical revision of upstream's `src/util/tubemap.js`. `33b7a7e` is the closest, and is still the tip of `master` (last touched 2025-08-21, before the 2026-06-10 vendoring here in 11fd871), so it was also the tip when the copy was taken. `common.mjs` and `config-global.mjs` are byte-identical to that commit, which pins it. `tubemap.js` arrived with ~1,180 upstream lines removed — the interactive browser half — and has been edited since.

## Worth a reviewer's eye

The header records a latent bug the trim left behind: `createTubeMap()` (`seqtubemap/tubemap.js:241`) calls `drawLegend()`, which no longer exists in this copy. It does not throw only because `generate-svg.mjs:77` passes `hideLegend: true` on every call. That likely deserves its own issue.

Prose about increment B is deliberately future-tense — B has not shipped; `jsdom` and `canvas` are still dependencies.

## Testing

Documentation only, no code changes. `npm test` passes (2/2). `pytest` errors locally on a missing `pysam`, which is pre-existing and unrelated — no Python was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)