### PR TITLE
Exercise /seqtubemap end to end with no graph data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,16 @@ jobs:
           git clone --quiet https://github.com/CAST-genomics/panCT.git "$PANCT_PATH/panCT"
           git -C "$PANCT_PATH/panCT" checkout --quiet "$PANCT_COMMIT"
 
+      # The endpoint seam renders its tube map by shelling out to
+      # `node seqtubemap/generate-svg.mjs`, which imports jsdom and canvas, so
+      # the Python job needs the Node dependencies too.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+      - name: Install Node dependencies
+        run: npm ci
+
       - name: Install Python dependencies
         run: pip install -r requirements-test.txt
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ data; anything that genuinely needs a missing dependency skips and says so.
 
 ```
 pip install -r requirements-test.txt
-pytest                 # Python: boots the app and exercises the vg seam
+npm ci                 # the Python endpoint test renders through the Node stage
+pytest                 # Python: boots the app and exercises the endpoint seam
 npm test               # Node: drives the sequence tube map generator
 ```
 
@@ -49,7 +50,9 @@ Neither suite needs graph data: the Python tests stand in tiny files for the
 `.walk.gz` derivatives and stub the two natively-compiled layout libraries, and
 the Node tests read a committed vg JSON fixture. panCT is used for real if you
 have it — from the `tools.path` Step 5 sets, or from `PANCT_PATH` — and stubbed
-if you do not. Tests that shell out to `vg` skip when it is not installed.
+if you do not. Tests that shell out to `vg` skip when it is not installed, and
+so does the `/seqtubemap` endpoint test when `node_modules` is not installed —
+it renders a real tube map, which reaches Node through `jsdom` and `canvas`.
 
 Both suites run in CI on every pull request (`.github/workflows/ci.yml`), where
 `vg` and panCT are installed and a skip is turned into a failure.

--- a/tests/fixtures/seqtubemap/README.md
+++ b/tests/fixtures/seqtubemap/README.md
@@ -61,6 +61,15 @@ they are the two that matter most for increment **B** — and the 4.2 kb region 
 of graph into 13.56 MB of XML is the whole argument of
 [ADR 0001](../../../docs/adr/0001-additive-band-format.md) in one row.
 
+## Standing in for the graph at the cache path
+
+`tests/python/test_seqtubemap_endpoint.py` copies the 90 bp `.gfa` into
+`cache/seqtubemap/mc/` under a temporary working directory and requests that region.
+The endpoint skips extraction when that file is present (`main.py:665-676`), so the rest
+of the pipeline runs with no `.gbz` anywhere — which is why the filenames here must stay
+exactly as the server wrote them: the endpoint rebuilds the name from the query
+parameters, and a renamed fixture is a cache miss.
+
 ## The `.json` beside each `.gfa`
 
 Each `.gfa` now has a matching `.json` — the same subgraph in the shape the Node stage

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -97,7 +97,16 @@ def _install_panct_stub() -> None:
     data = types.ModuleType("panCT.panct.data")
     data.Region = Region
     logging_module = types.ModuleType("panCT.panct.logging")
-    logging_module.getLogger = __import__("logging").getLogger
+
+    def getLogger(name=None, level="ERROR"):
+        """panCT's signature: a name and a level, both keyword-friendly."""
+        import logging
+
+        logger = logging.getLogger(name)
+        logger.setLevel(level)
+        return logger
+
+    logging_module.getLogger = getLogger
 
     sys.modules.update(
         {
@@ -190,4 +199,20 @@ def vg() -> str:
     binary = shutil.which("vg")
     if binary is None:
         _skip_or_fail("vg is not installed on this machine")
+    return binary
+
+
+@pytest.fixture(scope="session")
+def node_stage() -> str:
+    """The Node stage's prerequisites, skipping the test when they are absent.
+
+    `GenerateSeqTubeMapSvg` shells out to `node seqtubemap/generate-svg.mjs`,
+    which imports `jsdom` and `canvas` from the repository's `node_modules`.
+    A checkout that has never had `npm ci` run in it cannot render a tube map.
+    """
+    binary = shutil.which("node")
+    if binary is None:
+        _skip_or_fail("node is not installed on this machine")
+    if not (REPO_ROOT / "node_modules" / "jsdom").is_dir():
+        _skip_or_fail("node_modules is not installed — run `npm ci`")
     return binary

--- a/tests/python/test_seqtubemap_endpoint.py
+++ b/tests/python/test_seqtubemap_endpoint.py
@@ -1,0 +1,157 @@
+"""The `/seqtubemap` endpoint, end to end, with no pangenome graph data.
+
+The endpoint normally extracts its subgraph from a multi-gigabyte `.gbz` that
+no developer machine has. It does not have to: the pipeline already skips
+extraction when the extracted subgraph is present (`main.py:665-676`), an
+existing production branch rather than a test hook. Placing one of the
+committed golden subgraphs at that cache path makes everything downstream of
+extraction runnable from a checkout.
+
+The request therefore runs from a temporary working directory holding
+
+    cache/seqtubemap/mc/<the golden subgraph>
+    seqtubemap/ -> the repository's generator
+
+because every path the endpoint builds is relative to the process's working
+directory. Everything the pipeline writes lands in there and goes with it, so
+nothing leaks into the repository or into the next test.
+
+`vg` is still required: the pipeline reaches Node through `vg convert -g` and
+`vg view -j`. Increment D of the roadmap removes that, and these assertions are
+what it will be checked against — so they are written against what a client can
+observe in the response, and not against the pipeline's intermediates, whose
+disappearance is the point of increments B and D.
+"""
+
+import os
+import shutil
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+import pytest
+
+SVG_NS = "{http://www.w3.org/2000/svg}"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "seqtubemap"
+
+# The smallest of the five committed subgraphs: chr8:78,771,162-78,771,252, 90 bp
+# over 9 segments. Its name is not decoration — the endpoint builds exactly this
+# filename from the query parameters below, and that is what makes it cache-hit.
+CHROM, START, END, VERSION = "chr8", 78771162, 78771252, "v2"
+SUBGRAPH = FIXTURES / f"subgraph_{CHROM}_{START}_{END}_{VERSION}_with_walk.gfa"
+
+
+def _segment_sequences(gfa: Path) -> dict[str, str]:
+    """The `S` lines of a GFA, as id -> sequence."""
+    segments = {}
+    for line in gfa.read_text().splitlines():
+        if line.startswith("S\t"):
+            _, segment_id, sequence = line.split("\t")[:3]
+            segments[segment_id] = sequence
+    return segments
+
+
+@pytest.fixture(scope="module")
+def tube_map(client, vg, node_stage, main_module, tmp_path_factory):
+    """The response to one `/seqtubemap` request over the golden subgraph.
+
+    Module-scoped: the request runs the real `vg` pair and a real Node render,
+    and every test below reads the same response rather than paying for its own.
+    """
+    workdir = tmp_path_factory.mktemp("seqtubemap")
+    cache = workdir / "cache" / "seqtubemap" / "mc"
+    cache.mkdir(parents=True)
+    shutil.copy(SUBGRAPH, cache / SUBGRAPH.name)
+    # `generate_svg_js_script` is relative too (main.py:80), so the generator
+    # has to be reachable from the new working directory. A symlink keeps its
+    # real path inside the repository, where `node_modules` is.
+    (workdir / "seqtubemap").symlink_to(REPO_ROOT / "seqtubemap")
+
+    # `main_module` is taken for its import, which resolves `data.path` before
+    # the working directory moves out from under it.
+    previous = Path.cwd()
+    os.chdir(workdir)
+    try:
+        yield client.get(
+            "/seqtubemap",
+            params={"chrom": CHROM, "start": START, "end": END, "version": VERSION},
+        )
+    finally:
+        os.chdir(previous)
+
+
+@pytest.fixture(scope="module")
+def document(tube_map):
+    """The response parsed as XML, read by every test that inspects content."""
+    return ElementTree.fromstring(tube_map.content)
+
+
+def test_the_graph_the_endpoint_would_extract_from_is_absent(data_dir):
+    """The premise of this file: there is no graph here to extract from.
+
+    If a `.gbz` ever appeared beside the walk stand-ins, the request below
+    could be passing for the ordinary reason, and would stop demonstrating
+    anything about the cache branch.
+    """
+    assert not list(data_dir.glob("*.gbz"))
+
+
+def test_the_endpoint_returns_an_svg_document(tube_map):
+    assert tube_map.status_code == 200
+    assert tube_map.headers["content-type"].startswith("image/svg+xml")
+
+
+def test_the_document_is_well_formed(tube_map):
+    # Parsed here rather than through the `document` fixture, so a malformed
+    # document fails this test rather than erroring in every other one.
+    root = ElementTree.fromstring(tube_map.content)
+
+    assert root.tag == f"{SVG_NS}svg"
+    # Without a viewBox the client has no coordinate system to draw into.
+    assert root.get("viewBox")
+
+
+def test_the_document_carries_bands_attributed_to_strands(document):
+    """Bands are the drawable elements of `g.track`, keyed by strand.
+
+    This is what `pgb`'s parser reads: a document whose bands carry no strand
+    identity is a document it cannot colour.
+    """
+    tracks = document.find(f'{SVG_NS}g[@class="track"]')
+
+    assert tracks is not None, "no g.track group in the document"
+    bands = list(tracks)
+    assert bands, "the track group carries no bands"
+    assert all(
+        band.get("trackID") is not None and band.get("trackName") is not None
+        for band in bands
+    )
+
+    # The subgraph carries 464 strands and the layout draws a band per strand
+    # per step, so what is recovered here is a population of strands rather
+    # than one strand drawn repeatedly.
+    strand_names = {band.get("trackName") for band in bands}
+    assert len(strand_names) > 1, strand_names
+
+
+def test_the_document_carries_the_subgraph_segments(document):
+    """Segment boxes are `g.node`'s paths, each carrying its own sequence.
+
+    Asserted against the `S` lines of the fixture that went in, so this says
+    the pipeline carried the right DNA through — not merely that boxes exist.
+
+    Equality holds because this subgraph's segments are neither merged nor
+    reversed by the layout, and `vg` neither chops nor renumbers nodes this
+    small. A break here is one of those four things changing, which is worth
+    hearing about rather than tolerating.
+    """
+    segments = document.find(f'{SVG_NS}g[@class="node"]')
+
+    assert segments is not None, "no g.node group in the document"
+    boxes = list(segments)
+    assert boxes, "the node group carries no segment boxes"
+
+    expected = _segment_sequences(SUBGRAPH)
+    assert {box.get("sequence") for box in boxes} == set(expected.values())
+    assert all(box.get("d") for box in boxes), "a segment box has no outline"


### PR DESCRIPTION
Closes #17.

## What this is

A test that drives `/seqtubemap` end to end on a machine with no pangenome graph data.

The endpoint normally extracts its subgraph from a multi-gigabyte `.gbz`. It does not have to: the pipeline already skips extraction when the extracted subgraph is present (`main.py:665-676`) — an existing production branch, not a test hook. Copying the smallest of the five committed golden subgraphs (`chr8:78,771,162-78,771,252`, 9 segments, 464 strands) to that cache path, under a temporary working directory, makes everything downstream of extraction runnable from a checkout.

## What it asserts

- The SVG content type, and a document that parses, with a viewBox.
- Bands in `g.track`, every one carrying `trackID` and `trackName`, across a population of strands — what `pgb`'s parser reads.
- Segment boxes in `g.node` whose sequences are exactly the `S` lines of the GFA that went in, so the pipeline carried the right DNA through rather than merely returning bytes.

Assertions are written against what a client can observe in the response, and not against the pipeline's intermediates — their disappearance is the point of increments B and D. One request serves the whole file, so the real `vg` pair and the real Node render run once.

## Supporting changes

- A `node_stage` fixture: the render shells out to `node seqtubemap/generate-svg.mjs`, which imports `jsdom` and `canvas`, so the test skips with a reason when `node` or `node_modules` is missing. `vg` skips as before.
- The Python CI job gains the Node dependencies for that reason; the README gains the prerequisite.
- The panCT stand-in's `getLogger` grows the `level` argument the real one takes — without it the endpoint fails on a machine that has no panCT.

**No production behaviour changes.**

## One thing to watch on the first CI run

`vg` is Linux-only in practice, so locally this was exercised against a stand-in that swaps `perf/gfa-to-vg-json.mjs` in for `vg view -j`. Everything but the two `vg` subprocesses is proven; CI is the first real `vg` in the loop. The assertion most exposed to that is the exact segment-sequence equality — it holds as long as `vg` neither chops nor renumbers nodes this small, which it should not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)