### PR TITLE
Open the walk derivatives when something reads them (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ pytest                 # Python: boots the app and exercises the endpoint seam
 npm test               # Node: drives the sequence tube map generator
 ```
 
-Neither suite needs graph data: the Python tests stand in tiny files for the
-`.walk.gz` derivatives and stub the two natively-compiled layout libraries, and
-the Node tests read a committed vg JSON fixture. panCT is used for real if you
+Neither suite needs graph data: the Python tests run against an empty data
+directory — the `.walk.gz` derivatives are opened only when a request reads one
+— and stub the two natively-compiled layout libraries, while the Node tests
+read a committed vg JSON fixture. panCT is used for real if you
 have it — from the `tools.path` Step 5 sets, or from `PANCT_PATH` — and stubbed
 if you do not. Tests that shell out to `vg` skip when it is not installed, and
 so does the `/seqtubemap` endpoint test when `node_modules` is not installed —

--- a/docs/seqtubemap-roadmap.md
+++ b/docs/seqtubemap-roadmap.md
@@ -154,10 +154,11 @@ fast one does not wait.
 
 ### [#19](https://github.com/CAST-genomics/PangenomeAPI/issues/19) — Lazy tabix opens
 
-Three module-scope `pysam.TabixFile` opens (`main.py:71`, `:73`, `:81`) mean the app cannot
-boot unless all three `.walk.gz` derivatives are present, even for a request touching none of
-them. They are team-generated files, not public downloads — this is the first wall anyone
-hits trying to run the server.
+Done. The `.walk.gz` derivatives used to be opened at module scope, so the app could not boot
+unless all of them were present — even for a request touching none of them. They are
+team-generated files, not public downloads, which made this the first wall anyone hit trying
+to run the server. Each is now opened the first time something reads it (`WalkDerivative` in
+`main.py`), once per process, and a missing one is a 503 naming the file and what wanted it.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ import logging
 import time
 import signal
 import ssl
+import threading
 import traceback
 import numpy as np
 import os
@@ -74,17 +75,84 @@ mc_hg38_gbz_v1 = Path(f"{data_path}/hprc-v1.1-mc-grch38.gbz")
 mc_hg38_gbz_v2 = Path(f"{data_path}/hprc-v2.0-mc-grch38.gbz")
 minigraph_hg38_gfa_v1 = Path(f"{data_path}/hprc-v1.0-minigraph-grch38.gfa")
 minigraph_hg38_gfa_v2 = Path(f"{data_path}/hprc-v2.0-minigraph-grch38.gfa")
-mc_mapped_walks_v1 = pysam.TabixFile(f"{data_path}/hprc-v1.1-mc-grch38-mapped-flattened.walk.gz")
-mc_mapped_walks_v2 = pysam.TabixFile(f"{data_path}/hprc-v2.0-mc-grch38-v2.2.walk.gz")
-minigraph_walks_v1 = pysam.TabixFile(f"{data_path}/hprc_v1.0_minigraph_filtered_with_id.walk.gz")
 generate_svg_js_script = Path("./seqtubemap/generate-svg.mjs")
+
+
+class MissingWalkDerivative(RuntimeError):
+    """A walk derivative was read and is not on this machine."""
+
+
+class WalkDerivative:
+    """One tabix-indexed walk derivative, opened the first time it is read.
+
+    Stands in for the `pysam.TabixFile` the call sites used to be handed: they
+    call `fetch` and nothing else. The open is deferred because these files are
+    team-generated rather than public downloads, so requiring all of them at
+    import time stopped the application from booting for anyone who had none of
+    them — including for requests that read no walk derivative at all. A missing file is
+    now a `MissingWalkDerivative` on the request that needed it, naming the file
+    and what wanted it, instead of a crash before the first request.
+
+    The handle is kept, so a file is opened once per process rather than once
+    per request. Endpoints run in FastAPI's threadpool, hence the lock.
+    """
+
+    def __init__(self, path, purpose):
+        self.path = Path(path)
+        self.purpose = purpose
+        self._tabix_file = None
+        self._lock = threading.Lock()
+
+    def fetch(self, *args, **kwargs):
+        return self._open().fetch(*args, **kwargs)
+
+    def _open(self):
+        with self._lock:
+            if self._tabix_file is None:
+                try:
+                    self._tabix_file = pysam.TabixFile(str(self.path))
+                except (OSError, ValueError) as error:
+                    # pysam raises for both the file and its tabix index, and
+                    # says only "could not open" — the path and the caller are
+                    # what makes it actionable.
+                    raise MissingWalkDerivative(
+                        f"{self.path} could not be opened, and it is needed to "
+                        f"{self.purpose}. It is a team-generated walk derivative: "
+                        f"put it, and its tabix index, in the directory named by "
+                        f"`git config data.path`. ({error})"
+                    ) from error
+        return self._tabix_file
+
+
+@app.exception_handler(MissingWalkDerivative)
+def missing_walk_derivative_handler(request, exc):
+    """Report a missing derivative to the client rather than only to the log."""
+    api_log.error(str(exc))
+    return JSONResponse(status_code=503, content={"detail": str(exc)})
+
+
+mc_mapped_walks_v1 = WalkDerivative(
+    f"{data_path}/hprc-v1.1-mc-grch38-mapped-flattened.walk.gz",
+    "map the chopped node ids of a minigraph-cactus v1 subgraph back to their unchopped ids",
+)
+mc_mapped_walks_v2 = WalkDerivative(
+    f"{data_path}/hprc-v2.0-mc-grch38-v2.2.walk.gz",
+    "attach strands to a minigraph-cactus v2 subgraph",
+)
+minigraph_walks_v1 = WalkDerivative(
+    f"{data_path}/hprc_v1.0_minigraph_filtered_with_id.walk.gz",
+    "attach strands to a minigraph v1 subgraph",
+)
 
 # walks updated in 4/22/2026 with features:
 #   1. filled missing nodes
 #   2. pclai for both hg38 and asm coordinates
 #   3. discarded median approach, used impainting methods on euclidean distance
 #   4. with assembly coordinates
-minigraph_walks_v2_updated = pysam.TabixFile(f"{data_path}/v1_1_hprc_v2.0_minigraph.sorted.pclai.walk.gz")
+minigraph_walks_v2_updated = WalkDerivative(
+    f"{data_path}/v1_1_hprc_v2.0_minigraph.sorted.pclai.walk.gz",
+    "attach strands and PCLAI colours to a minigraph v2 subgraph",
+)
 
 def delete_files(path_list):
     for path in path_list:
@@ -185,7 +253,7 @@ def GenerateWalksMC(preprocess_gfa_subgraph_no_walk, preprocess_gfa_subgraph_w_w
             subgraph minigraph cactus gfa w/o W lines
         preprocess_gfa_subgraph_w_walk: Path
             output file path; subgraph minigraph cactus gfa w W lines added
-        mc_mapped_walks_v2: pysam.TabixFile Object
+        mc_mapped_walks_v2: WalkDerivative
             minigraph cactus walk file
     """
     

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,16 +1,19 @@
 """Shared setup for the Python tests.
 
-Booting `main` is the whole difficulty here: it reaches for panCT, for four
-tabix-indexed walk derivatives, and — through `bandage_graph` and
-`adaptagrams_converter` — for two natively-compiled layout libraries that only
-exist inside the Docker image. None of that is needed to answer "does the app
-boot and serve", so this module stands each one up cheaply:
+Booting `main` is the whole difficulty here: it reaches for panCT and —
+through `bandage_graph` and `adaptagrams_converter` — for two
+natively-compiled layout libraries that only exist inside the Docker image.
+None of that is needed to answer "does the app boot and serve", so this module
+stands each one up cheaply:
 
-* the walk derivatives become tiny tabix files written into a temp directory,
 * the native layout libraries become import stubs,
 * panCT is used for real when the machine has it, and stubbed when it does not,
 * `tools.path` and `data.path` are supplied through git's environment config,
   so the developer's own `git config --local` values are left alone.
+
+`data.path` points at an empty directory on purpose: the walk derivatives are
+opened when something reads them, so the whole suite runs on a machine that
+has none of them. A test that wants one writes it with `walk_stand_in`.
 
 The panCT stub is the one stand-in that costs something: a machine without
 panCT boots the app against a placeholder `Region`, so a break in panCT's own
@@ -34,14 +37,6 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # developer machine without `vg`, and must fail the build instead of skipping.
 REQUIRE_ALL = os.environ.get("PANGENOME_TESTS_REQUIRE_ALL") == "1"
 
-# The four `.walk.gz` derivatives `main` opens at import time (main.py:77-88).
-WALK_FILES = (
-    "hprc-v1.1-mc-grch38-mapped-flattened.walk.gz",
-    "hprc-v2.0-mc-grch38-v2.2.walk.gz",
-    "hprc_v1.0_minigraph_filtered_with_id.walk.gz",
-    "v1_1_hprc_v2.0_minigraph.sorted.pclai.walk.gz",
-)
-
 
 def _skip_or_fail(reason: str) -> None:
     """Skip for a missing dependency — unless CI said there must not be one."""
@@ -50,20 +45,20 @@ def _skip_or_fail(reason: str) -> None:
     pytest.skip(reason)
 
 
-def _write_walk_stand_ins(data_dir: Path) -> None:
-    """Write one bgzipped, tabix-indexed stand-in per walk derivative.
+def _write_walk_stand_in(path: Path) -> Path:
+    """Write one bgzipped, tabix-indexed stand-in for a walk derivative.
 
     A few bed rows in place of a multi-gigabyte walk file: enough for
-    `pysam.TabixFile` to open, which is all module import requires.
+    `pysam.TabixFile` to open and fetch from.
     """
     import pysam
 
-    for name in WALK_FILES:
-        plain = data_dir / name[: -len(".gz")]
-        plain.write_text("chr1\t0\t100\nchr1\t100\t200\n")
-        pysam.tabix_compress(str(plain), str(data_dir / name), force=True)
-        plain.unlink()
-        pysam.tabix_index(str(data_dir / name), preset="bed", force=True)
+    plain = path.with_suffix("")
+    plain.write_text("chr1\t0\t100\nchr1\t100\t200\n")
+    pysam.tabix_compress(str(plain), str(path), force=True)
+    plain.unlink()
+    pysam.tabix_index(str(path), preset="bed", force=True)
+    return path
 
 
 def _install_native_stubs() -> None:
@@ -143,10 +138,14 @@ def _panct_path() -> str | None:
 
 @pytest.fixture(scope="session")
 def data_dir(tmp_path_factory) -> Path:
-    """A stand-in for the graph data directory, holding only the walk files."""
-    directory = tmp_path_factory.mktemp("data")
-    _write_walk_stand_ins(directory)
-    return directory
+    """A stand-in for the graph data directory, holding nothing at all."""
+    return tmp_path_factory.mktemp("data")
+
+
+@pytest.fixture
+def walk_stand_in(tmp_path) -> Path:
+    """A tiny stand-in walk derivative, for a test that needs one present."""
+    return _write_walk_stand_in(tmp_path / "stand-in.walk.gz")
 
 
 @pytest.fixture(scope="session")

--- a/tests/python/test_walk_derivatives.py
+++ b/tests/python/test_walk_derivatives.py
@@ -1,0 +1,86 @@
+"""The walk derivatives, opened when something reads them rather than at import.
+
+The four `.walk.gz` files are team-generated, not public downloads, so the
+machine running these tests is exactly the machine that does not have them.
+Every test here therefore runs against `data_dir`, which is empty: the app in
+this session was booted with no walk derivative on disk at all.
+"""
+
+import pytest
+
+
+def test_the_app_boots_with_no_walk_derivative_present(data_dir, client):
+    """The premise of this file, asserted rather than assumed."""
+    assert not list(data_dir.glob("*.walk.gz"))
+
+    assert client.get("/openapi.json").status_code == 200
+
+
+def test_a_request_reading_no_walk_derivative_succeeds(client):
+    """Routing, and the handlers' own imports, do not touch a derivative."""
+    assert client.get("/no-such-route").status_code == 404
+
+
+def test_reading_a_missing_derivative_names_the_file_and_the_reason(main_module):
+    derivative = main_module.minigraph_walks_v2_updated
+
+    with pytest.raises(main_module.MissingWalkDerivative) as raised:
+        derivative.fetch(".", 0, 1)
+
+    message = str(raised.value)
+    assert "v1_1_hprc_v2.0_minigraph.sorted.pclai.walk.gz" in message
+    assert derivative.purpose in message
+
+
+def test_a_missing_derivative_is_served_as_an_error_response(main_module, client):
+    """The failure reaches the client as a 503, rather than only the log.
+
+    Driven through a route added for the test, because every endpoint that
+    genuinely reads a walk derivative reaches for a multi-gigabyte graph first.
+    The route is removed again, so the app the other tests see is unchanged.
+    """
+    app = main_module.app
+
+    @app.get("/test-only-reads-a-walk")
+    def reads_a_walk():
+        return list(main_module.minigraph_walks_v2_updated.fetch(".", 0, 1))
+
+    try:
+        response = client.get("/test-only-reads-a-walk")
+    finally:
+        app.router.routes.pop()
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert "v1_1_hprc_v2.0_minigraph.sorted.pclai.walk.gz" in detail
+    assert main_module.minigraph_walks_v2_updated.purpose in detail
+
+
+def test_a_present_derivative_is_read(main_module, walk_stand_in):
+    """Behaviour when the file is there: the rows come back."""
+    derivative = main_module.WalkDerivative(walk_stand_in, "a test")
+
+    assert [line.split("\t")[:2] for line in derivative.fetch("chr1", 0, 200)] == [
+        ["chr1", "0"],
+        ["chr1", "100"],
+    ]
+
+
+def test_a_derivative_is_opened_once_per_process(main_module, walk_stand_in, monkeypatch):
+    """Not once per request: the tabix index is paid for the first time only."""
+    import pysam
+
+    opens = []
+    real = pysam.TabixFile
+
+    def counting_tabix_file(path, *args, **kwargs):
+        opens.append(path)
+        return real(path, *args, **kwargs)
+
+    monkeypatch.setattr(pysam, "TabixFile", counting_tabix_file)
+    derivative = main_module.WalkDerivative(walk_stand_in, "a test")
+
+    list(derivative.fetch("chr1", 0, 200))
+    list(derivative.fetch("chr1", 0, 200))
+
+    assert opens == [str(walk_stand_in)]


### PR DESCRIPTION
Closes #19.

The four tabix-indexed `.walk.gz` derivatives were opened at module scope, so the process could not start unless all of them were present — even for a request touching none. They are team-generated files rather than public downloads, which made this the first wall anyone hit trying to run the server, and it kept the test seams away from everything that does not need them.

Each is now a `WalkDerivative`: it stands in for the `pysam.TabixFile` its call sites were handed (they call `fetch`, and nothing else) and opens the file the first time something reads it, once per process, under a lock because the endpoints run in FastAPI's threadpool. A file that cannot be opened raises `MissingWalkDerivative`, which the app serves as a 503 naming the file and what wanted it — on the request that needed it, rather than before the first one.

The Python tests now run against an empty data directory, so booting with no derivative present is what the whole suite exercises.

## Acceptance criteria

- [x] The application starts with none of the derivatives present
- [x] A request needing none of them succeeds
- [x] A request needing one that is missing fails with an error naming the file and the reason
- [x] Each file is opened at most once per process, not once per request
- [x] A test covers boot with the files absent
- [x] Behaviour is unchanged when all are present — the `/seqtubemap` end-to-end test still passes; it skips locally without `vg`, and runs in CI

The issue says three derivatives; there are four. All four are deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)