### PR TITLE
Capture band data from the layout, alongside the existing document (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Wolfgang Beyer.
 | `seqtubemap/config-global.mjs` | `src/config-global.mjs` | unmodified |
 | `seqtubemap/config-client.js` | `src/config-client.js` | emptied |
 | `seqtubemap/generate-svg.mjs` | — | ours |
+| `seqtubemap/render.mjs` | — | ours |
+| `seqtubemap/band-data.mjs` | — | ours |
 
 **`tubemap.js` is a fork and does not track upstream.** It arrived already
 trimmed of upstream's interactive browser half (mouse handlers, zoom, legend

--- a/seqtubemap/band-data.mjs
+++ b/seqtubemap/band-data.mjs
@@ -1,0 +1,140 @@
+// The band data a sequence tube map render produces: the numbers the layout
+// computed, before anything turned them into attribute strings.
+//
+// Today the layout binds those numbers to elements in an emulated browser
+// document and the document is what `/seqtubemap` returns. That document is
+// 93.7% of the render's retained memory (docs/adr/0001-additive-band-format.md),
+// and it exists only so the result can be serialized to text and parsed straight
+// back into numbers by the client. Removing it means first making the numbers
+// reachable, which is what this collector is for.
+//
+// The collector is not a second sink alongside the document. Each draw function
+// collects what it is about to draw and then binds *the collected bands* as its
+// d3 data, so the two cannot describe different pictures: band order is document
+// order because it is the same list, in the same order, read twice.
+//
+// Shape of the data:
+//
+//   strands   one row per strand appearance: its id, name, colour, and PCLAI
+//             placement. The per-band constants, sent once.
+//   bands     one entry per drawn shape, in document order - which is draw
+//             order, and therefore paint order: later bands draw on top.
+//             `strand` indexes into `strands`.
+//               { kind: "rect",   strand, x, y, width, height, alpha? }
+//               { kind: "curve",  strand, path, alpha? }
+//               { kind: "corner", strand, path }
+//             Curves and corners carry the path string the layout built; making
+//             those numbers too is a later increment.
+//             `alpha` is the band's fill opacity, and is absent on the bands the
+//             document has never painted one on: corners, and the vertical
+//             rectangles of a reversal. That is a property of the shape rather
+//             than of the strand, which is why opacity sits on the band while
+//             colour sits on the strand.
+//   segments  one entry per drawn segment box, in document order.
+//   document  the picture's dimensions, including the viewBox string.
+
+// The margins the document is given around the layout's extent: 50 px of slack
+// on the width and height, and 20 px of headroom above the topmost shape.
+const MARGIN = 50;
+const HEADROOM = 20;
+
+/** The document's dimensions for a layout that ended up with this extent. */
+export function documentDimensions({ maxXCoordinate, maxYCoordinate, minYCoordinate }) {
+  const width = maxXCoordinate + MARGIN;
+  const height = maxYCoordinate - minYCoordinate + MARGIN;
+  return {
+    width,
+    height,
+    viewBox: `0 ${minYCoordinate - HEADROOM} ${width} ${height}`,
+    extent: { maxXCoordinate, maxYCoordinate, minYCoordinate },
+  };
+}
+
+// A property the layout has no value for is absent, not undefined: the document
+// leaves such an attribute off entirely, and the band data has to survive a
+// round trip through JSON, which drops undefined values anyway.
+function present(record) {
+  for (const key of Object.keys(record)) {
+    if (record[key] === undefined) delete record[key];
+  }
+  return record;
+}
+
+export class BandCollector {
+  constructor() {
+    this.reset();
+  }
+
+  reset() {
+    this.strands = [];
+    this.bands = [];
+    this.segments = [];
+    // The extent a render that draws nothing has, so that an empty render still
+    // reports the dimensions its document would be given.
+    this.document = documentDimensions({
+      maxXCoordinate: 0,
+      maxYCoordinate: 0,
+      minYCoordinate: 0,
+    });
+    this.rowByKey = new Map();
+  }
+
+  /**
+   * The index of the strand row for a shape, adding the row if it is new.
+   *
+   * A row is a strand *appearance* - an id and a colour. In practice that is
+   * one row per strand; a strand only gets a second row if something recolours
+   * part of it, and then the extra row is the truth about the picture rather
+   * than a defect in the table.
+   *
+   * Not every shape knows its strand's name: the layout builds the corners of a
+   * reversal without one. Such a shape still finds its strand's row - by id and
+   * colour - and the row keeps the name and placement the strand's other bands
+   * supplied, which is the point of a table the bands can point at.
+   */
+  strand({ id, name, color, pclaiX, pclaiY, pclaiScore }) {
+    const key = `${id} ${color}`;
+    const index = this.rowByKey.get(key);
+    if (index === undefined) {
+      this.rowByKey.set(key, this.strands.length);
+      this.strands.push(present({ id, name, color, pclaiX, pclaiY, pclaiScore }));
+      return this.strands.length - 1;
+    }
+    const row = this.strands[index];
+    if (row.name === undefined && name !== undefined) {
+      Object.assign(row, { name, pclaiX, pclaiY, pclaiScore });
+    }
+    return index;
+  }
+
+  /** The strand row a band belongs to. */
+  strandOf(band) {
+    return this.strands[band.strand];
+  }
+
+  /** Collect a band and return it, for the caller to bind and draw. */
+  band(band) {
+    this.bands.push(present(band));
+    return band;
+  }
+
+  /** Collect a segment box and return it, for the caller to bind and draw. */
+  segment(segment) {
+    this.segments.push(present(segment));
+    return segment;
+  }
+
+  setExtent(extent) {
+    this.document = documentDimensions(extent);
+  }
+
+  /** Everything this render produced. Plain data - no DOM, no live references. */
+  data() {
+    return {
+      strands: this.strands,
+      bands: this.bands,
+      segments: this.segments,
+      document: this.document,
+    };
+  }
+}

--- a/seqtubemap/generate-svg.mjs
+++ b/seqtubemap/generate-svg.mjs
@@ -1,6 +1,10 @@
-import { readFileSync, writeFileSync } from "fs";
-import { JSDOM } from "jsdom";
-import { createCanvas } from "canvas";
+// CLI over the sequence tube map renderer: vg JSON in, one SVG document out.
+// This is the process `/seqtubemap` spawns. The render itself — including the
+// browser emulation it still needs — lives in `render.mjs`, so that a caller
+// inside Node can render without spawning anything.
+import { writeFileSync } from "fs";
+
+import { renderTubeMap } from "./render.mjs";
 
 if (process.argv.length < 7 || process.argv.length > 8) {
   console.error(`Error: 5 or 6 arguments required, got ${process.argv.length - 2}`);
@@ -8,37 +12,6 @@ if (process.argv.length < 7 || process.argv.length > 8) {
   process.exit(1);
 }
 
-// 1. Config must be set first
-globalThis["__sequence_tube_map_config"] = {
-  defaultHaplotypeColorPalette: { mainPalette: "reds", auxPalette: "blues" },
-  defaultReadColorPalette:      { mainPalette: "reds", auxPalette: "blues" },
-  defaultGraphColorPalette:     { mainPalette: "reds", auxPalette: "blues" },
-  nodeIntervalThreshold: 150,
-  coloredNodes: [],
-  DATA_SOURCES: [],
-  BACKEND_URL: "",
-};
-
-// 2. Fake browser environment
-const dom = new JSDOM(`<!DOCTYPE html><body><svg id="mysvg"></svg></body>`, {
-  resources: "usable",
-  pretendToBeVisual: true,
-});
-globalThis.window   = dom.window;
-globalThis.document = dom.window.document;
-
-// Patch getComputedTextLength
-const canvas = createCanvas(200, 200);
-const ctx = canvas.getContext("2d");
-ctx.font = '14px "Courier New"';
-dom.window.SVGElement.prototype.getComputedTextLength = function() {
-  return ctx.measureText(this.textContent).width;
-};
-
-// 3. Import TubeMap
-const { create, vgExtractNodes, vgExtractTracks, getImageCoordinates, reorderTracksForLayout } = await import("./tubemap.js");
-
-// 4. Load vg JSON
 const inputFile  = process.argv[2];
 const outputFile = process.argv[3];
 const start = parseInt(process.argv[4]);
@@ -51,45 +24,19 @@ if (pclaiColorSchemeArg !== undefined) {
   pclaiColorScheme = JSON.parse(pclaiColorSchemeArg);
 }
 
-const vgJson = JSON.parse(readFileSync(inputFile, "utf8"));
-
-// 5. Convert to TubeMap format
-const nodes  = vgExtractNodes(vgJson);
-let tracks = vgExtractTracks(vgJson, 0, 1);
-tracks = reorderTracksForLayout(tracks);
-
-
 // DEBUGGING
 setInterval(() => {
   const m = process.memoryUsage();
   console.error(`[mem] rss=${(m.rss/1e6).toFixed(0)}MB heapUsed=${(m.heapUsed/1e6).toFixed(0)}MB heapTotal=${(m.heapTotal/1e6).toFixed(0)}MB`);
 }, 500).unref();
 
-console.error("tracks[0].name:", tracks[0].name, "length:", tracks[0].sequence.length);
-
-// 6. Render
-create({
-  svgID: "#mysvg",
-  nodes: nodes,
-  tracks: tracks,
-  reads: null,
-  region: [0, end-start-1],
-  hideLegend: true,
-  nodeWidthOption: nodeWidthOption,
-  pclaiColorScheme: pclaiColorScheme
+const { document } = await renderTubeMap({
+  inputFile,
+  start,
+  end,
+  nodeWidthOption,
+  pclaiColorScheme,
 });
 
-// 7. Fix SVG dimensions to fit full graph
-const { maxXCoordinate, maxYCoordinate, minYCoordinate } = getImageCoordinates();
-
-const svgElement = dom.window.document.getElementById("mysvg");
-const width = maxXCoordinate + 50;
-const height = maxYCoordinate - minYCoordinate + 50;
-
-svgElement.setAttribute("viewBox", `0 ${minYCoordinate - 20} ${width} ${height}`);
-svgElement.setAttribute("width", width);
-svgElement.setAttribute("height", height);
-svgElement.setAttribute("xmlns", "http://www.w3.org/2000/svg");
-
-writeFileSync(outputFile, svgElement.outerHTML, "utf8");
+writeFileSync(outputFile, document, "utf8");
 console.log(`SVG written to ${outputFile}`);

--- a/seqtubemap/render.mjs
+++ b/seqtubemap/render.mjs
@@ -1,0 +1,119 @@
+// Render a sequence tube map in this process, and hand back both of its
+// products: the document, and the band data the layout produced on the way to
+// it.
+//
+// The document is byte-for-byte what `generate-svg.mjs` has always written —
+// that CLI is now a thin wrapper around this function. The band data is the
+// same numbers, before they were turned into attribute strings; see
+// `band-data.mjs` for its shape.
+//
+// The browser emulation lives here because the layout still needs it: config
+// first, then a jsdom window, and only then may `tubemap.js` be imported at
+// all. That ordering is the reason this module loads it dynamically.
+import { readFileSync } from "node:fs";
+import { JSDOM } from "jsdom";
+import { createCanvas } from "canvas";
+
+let loaded = null;
+
+// One jsdom window and one measuring canvas per process, not per render: both
+// are expensive to build, and `create()` clears the SVG element before it draws.
+async function environment() {
+  if (loaded) return loaded;
+
+  // 1. Config must be set first
+  globalThis["__sequence_tube_map_config"] = {
+    defaultHaplotypeColorPalette: { mainPalette: "reds", auxPalette: "blues" },
+    defaultReadColorPalette:      { mainPalette: "reds", auxPalette: "blues" },
+    defaultGraphColorPalette:     { mainPalette: "reds", auxPalette: "blues" },
+    nodeIntervalThreshold: 150,
+    coloredNodes: [],
+    DATA_SOURCES: [],
+    BACKEND_URL: "",
+  };
+
+  // 2. Fake browser environment
+  const dom = new JSDOM(`<!DOCTYPE html><body><svg id="mysvg"></svg></body>`, {
+    resources: "usable",
+    pretendToBeVisual: true,
+  });
+  globalThis.window   = dom.window;
+  globalThis.document = dom.window.document;
+
+  // Patch getComputedTextLength
+  const canvas = createCanvas(200, 200);
+  const ctx = canvas.getContext("2d");
+  ctx.font = '14px "Courier New"';
+  dom.window.SVGElement.prototype.getComputedTextLength = function() {
+    return ctx.measureText(this.textContent).width;
+  };
+
+  // 3. Import TubeMap
+  const module = await import("./tubemap.js");
+  loaded = { dom, module };
+  return loaded;
+}
+
+/**
+ * Render one vg JSON input.
+ *
+ * @param {object} options
+ * @param {string} options.inputFile   path to the `vg view -j` JSON
+ * @param {number} options.start       the requested region's first base
+ * @param {number} options.end         the requested region's last base
+ * @param {string} options.nodeWidthOption  "compressed", "normal" or "small"
+ * @param {object|null} [options.pclaiColorScheme]
+ * @returns {{document: string, bandData: object}}
+ */
+export async function renderTubeMap({
+  inputFile,
+  start,
+  end,
+  nodeWidthOption,
+  pclaiColorScheme = null,
+}) {
+  const { dom, module } = await environment();
+  const {
+    create,
+    vgExtractNodes,
+    vgExtractTracks,
+    reorderTracksForLayout,
+    getBandData,
+  } = module;
+
+  const vgJson = JSON.parse(readFileSync(inputFile, "utf8"));
+
+  const segments = vgExtractNodes(vgJson);
+  const strands = reorderTracksForLayout(vgExtractTracks(vgJson, 0, 1));
+  // DEBUGGING — the fork logs its own progress to stderr; this is the line the
+  // CLI has always printed alongside it.
+  console.error("tracks[0].name:", strands[0].name, "length:", strands[0].sequence.length);
+
+  create({
+    svgID: "#mysvg",
+    // The layout's own vocabulary: its `nodes` are this codebase's segments,
+    // and its `tracks` are its strands (CONTEXT.md).
+    nodes: segments,
+    tracks: strands,
+    reads: null,
+    region: [0, end - start - 1],
+    hideLegend: true,
+    nodeWidthOption: nodeWidthOption,
+    pclaiColorScheme: pclaiColorScheme,
+  });
+
+  const bandData = getBandData();
+
+  // Fix SVG dimensions to fit full graph. The numbers come from the band data
+  // rather than being recomputed here: the document and the band data have to
+  // agree about how big the picture is, and the only way to guarantee that is
+  // for there to be one of them.
+  const { width, height, viewBox } = bandData.document;
+  const svgElement = dom.window.document.getElementById("mysvg");
+  svgElement.setAttribute("viewBox", viewBox);
+  svgElement.setAttribute("width", width);
+  svgElement.setAttribute("height", height);
+  svgElement.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+
+  return { document: svgElement.outerHTML, bandData };
+}

--- a/seqtubemap/tubemap.js
+++ b/seqtubemap/tubemap.js
@@ -56,6 +56,7 @@ import "d3-selection-multi";
 import "./config-client.js";
 import externalConfig from "./config-global.mjs";
 import { defaultTrackColors } from "./common.mjs";
+import { BandCollector } from "./band-data.mjs";
 import deepEqual from "deep-equal";
 // const deepEqual = require("deep-equal");
 
@@ -217,6 +218,11 @@ export let minYCoordinate = 0;
 export let maxXCoordinate = 0;
 let trackForRuler;
 
+// The band data of the most recent render, gathered by the same draw functions
+// that build the document, from the same lists and in the same order. See
+// band-data.mjs, and getBandData() below for how a caller reads it.
+const bandCollector = new BandCollector();
+
 let bed;
 
 // main function to call from outside
@@ -367,6 +373,7 @@ function createTubeMap() {
   trackCorners = [];
   trackVerticalRectangles = [];
   trackRectanglesStep3 = [];
+  bandCollector.reset();
   assignments = [];
   extraLeft = [];
   extraRight = [];
@@ -483,6 +490,7 @@ function createTubeMap() {
     console.log(assignments);
   }
   getImageDimensions();
+  bandCollector.setExtent({ maxXCoordinate, maxYCoordinate, minYCoordinate });
   t("getImageDimensions");
 
   // all drawn tracks are grouped
@@ -3220,18 +3228,31 @@ function drawNodes(dNodes, groupNode) {
 
   console.log("config:", config);
 
+  const segments = dNodes.map((node) => {
+    const colors = colorNodes(node.name);
+    return bandCollector.segment({
+      id: node.name,
+      outline: node.d,
+      sequence: node.seq,
+      fill: colors["fill"],
+      fillOpacity: colors["fill-opacity"],
+      stroke: colors["outline"],
+      strokeWidth: "2px",
+    });
+  });
+
   groupNode
     .selectAll("node")
-    .data(dNodes)
+    .data(segments)
     .enter()
     .append("path")
-    .attr("id", (d) => d.name)
-    .attr("d", (d) => d.d)
-    .attr("sequence", (d) => d.seq)
-    .style("fill", (d) => colorNodes(d.name)["fill"])
-    .style("fill-opacity", (d) => colorNodes(d.name)["fill-opacity"])
-    .style("stroke", (d) => colorNodes(d.name)["outline"])
-    .style("stroke-width", "2px")
+    .attr("id", (d) => d.id)
+    .attr("d", (d) => d.outline)
+    .attr("sequence", (d) => d.sequence)
+    .style("fill", (d) => d.fill)
+    .style("fill-opacity", (d) => d.fillOpacity)
+    .style("stroke", (d) => d.stroke)
+    .style("stroke-width", (d) => d.strokeWidth)
     .append("svg:title")
 }
 
@@ -3600,28 +3621,79 @@ function filterObjectByAttribute(attribute, value) {
   return (item) => item[attribute] === value;
 }
 
+// The strand row for a shape about to be drawn. The per-band constants — id,
+// name, colour and PCLAI placement — are looked up once here and shared by
+// every band of that strand, instead of being re-derived per attribute.
+function collectStrand(shape) {
+  const [pclaiX, pclaiY] = getPclaiXY(shape.name);
+  return bandCollector.strand({
+    id: shape.id,
+    name: shape.name,
+    color: shape.color,
+    pclaiX,
+    pclaiY,
+    pclaiScore: getPclaiScore(shape.name),
+  });
+}
+
+function strandOf(band) {
+  return bandCollector.strandOf(band);
+}
+
+// The band data keeps a missing PCLAI placement as null; the document has
+// always written the string "None" for it.
+function orNone(value) {
+  return value === null ? "None" : value;
+}
+
+// Bind the per-strand attributes every band carries. Shared by the three shapes
+// so that a change to what a band says about its strand cannot reach one shape
+// and miss another.
+function bindStrandAttributes(selection) {
+  return selection
+    .attr("trackID", (d) => strandOf(d).id)
+    // A corner carries no strand name, because the layout builds one without a
+    // name to give it (see the trackCorners.push calls above). Its strand row
+    // knows the name; the element has never said it, and must not start to.
+    .attr("trackName", (d) => (d.kind === "corner" ? null : strandOf(d).name))
+    .attr("class", (d) => `track${strandOf(d).id}`)
+    .attr("color", (d) => strandOf(d).color)
+    .attr("pclaiX", (d) => orNone(strandOf(d).pclaiX))
+    .attr("pclaiY", (d) => orNone(strandOf(d).pclaiY))
+    .attr("pclaiScore", (d) => orNone(strandOf(d).pclaiScore));
+}
+
 function drawTrackRectangles(rectangles, type, groupTrack) {
   rectangles = rectangles.filter(filterObjectByAttribute("type", type));
 
-  groupTrack
-    .selectAll("trackRectangles")
-    .data(rectangles)
-    .enter()
-    .append("rect")
-    .attr("x", (d) => d.xStart)
-    .attr("y", (d) => d.yStart)
-    .attr("width", (d) => d.xEnd - d.xStart + 1)
-    .attr("height", (d) => d.yEnd - d.yStart + 1)
-    .style("fill", (d) => d.color)
-    .style("fill-opacity", (d) => d.alpha)
-    .attr("trackID", (d) => d.id)
-    .attr("trackName", (d) => d.name)
-    .attr("class", (d) => `track${d.id}`)
-    .attr("color", (d) => d.color)
-    .attr("pclaiX", (d) => { const [x] = getPclaiXY(d.name); return x === null ? "None" : x; })
-    .attr("pclaiY", (d) => { const [, y] = getPclaiXY(d.name); return y === null ? "None" : y; })
-    .attr("pclaiScore", (d) => { const s = getPclaiScore(d.name); return s === null ? "None" : s; })
-    .append("svg:title")
+  // Collect first, then draw what was collected: the elements below are bound
+  // to the bands themselves, so the band data and the document are one list
+  // read twice rather than two descriptions that have to be kept in step.
+  const bands = rectangles.map((rectangle) =>
+    bandCollector.band({
+      kind: "rect",
+      strand: collectStrand(rectangle),
+      x: rectangle.xStart,
+      y: rectangle.yStart,
+      width: rectangle.xEnd - rectangle.xStart + 1,
+      height: rectangle.yEnd - rectangle.yStart + 1,
+      alpha: rectangle.alpha,
+    })
+  );
+
+  bindStrandAttributes(
+    groupTrack
+      .selectAll("trackRectangles")
+      .data(bands)
+      .enter()
+      .append("rect")
+      .attr("x", (d) => d.x)
+      .attr("y", (d) => d.y)
+      .attr("width", (d) => d.width)
+      .attr("height", (d) => d.height)
+      .style("fill", (d) => strandOf(d).color)
+      .style("fill-opacity", (d) => d.alpha)
+  ).append("svg:title")
 }
 
 function compareCurvesByXYStartValue(a, b) {
@@ -3718,42 +3790,50 @@ function drawTrackCurves(type, groupTrack) {
     flattenedGroups = flattenedGroups.concat(groupedCurves[key]);
   }
 
-  groupTrack
-    .selectAll("trackCurves")
-    .data(flattenedGroups)
-    .enter()
-    .append("path")
-    .attr("d", (d) => d.path)
-    .style("fill", (d) => d.color)
-    .style("fill-opacity", (d) => d.alpha)
-    .attr("trackID", (d) => d.id)
-    .attr("trackName", (d) => d.name)
-    .attr("class", (d) => `track${d.id}`)
-    .attr("color", (d) => d.color)
-    .attr("pclaiX", (d) => { const [x] = getPclaiXY(d.name); return x === null ? "None" : x; })
-    .attr("pclaiY", (d) => { const [, y] = getPclaiXY(d.name); return y === null ? "None" : y; })
-    .attr("pclaiScore", (d) => { const s = getPclaiScore(d.name); return s === null ? "None" : s; })
-    .append("svg:title")
+  // Collected in the order they are about to be drawn — which is the order the
+  // grouping and the within-group sort above arrived at, not the order the
+  // curves were generated in.
+  const bands = flattenedGroups.map((curve) =>
+    bandCollector.band({
+      kind: "curve",
+      strand: collectStrand(curve),
+      path: curve.path,
+      alpha: curve.alpha,
+    })
+  );
+
+  bindStrandAttributes(
+    groupTrack
+      .selectAll("trackCurves")
+      .data(bands)
+      .enter()
+      .append("path")
+      .attr("d", (d) => d.path)
+      .style("fill", (d) => strandOf(d).color)
+      .style("fill-opacity", (d) => d.alpha)
+  ).append("svg:title")
 }
 
 function drawTrackCorners(corners, type, groupTrack) {
   corners = corners.filter(filterObjectByAttribute("type", type));
 
-  groupTrack
-    .selectAll("trackCorners")
-    .data(corners)
-    .enter()
-    .append("path")
-    .attr("d", (d) => d.path)
-    .style("fill", (d) => d.color)
-    .attr("trackID", (d) => d.id)
-    .attr("trackName", (d) => d.name)
-    .attr("class", (d) => `track${d.id}`)
-    .attr("color", (d) => d.color)
-    .attr("pclaiX", (d) => { const [x] = getPclaiXY(d.name); return x === null ? "None" : x; })
-    .attr("pclaiY", (d) => { const [, y] = getPclaiXY(d.name); return y === null ? "None" : y; })
-    .attr("pclaiScore", (d) => { const s = getPclaiScore(d.name); return s === null ? "None" : s; })
-    .append("svg:title")
+  const bands = corners.map((corner) =>
+    bandCollector.band({
+      kind: "corner",
+      strand: collectStrand(corner),
+      path: corner.path,
+    })
+  );
+
+  bindStrandAttributes(
+    groupTrack
+      .selectAll("trackCorners")
+      .data(bands)
+      .enter()
+      .append("path")
+      .attr("d", (d) => d.path)
+      .style("fill", (d) => strandOf(d).color)
+  ).append("svg:title")
 }
 
 // extract info about nodes from vg-json
@@ -4203,4 +4283,16 @@ function filterReads(reads) {
 
 export function getImageCoordinates() {
   return { maxXCoordinate, maxYCoordinate, minYCoordinate };
+}
+
+/**
+ * The complete band data of the most recent create() call: every band's
+ * geometry and strand, the per-strand table of colour, name and placement, the
+ * segment boxes, and the document's dimensions. See band-data.mjs.
+ *
+ * The document is still built and still returned exactly as before; this is the
+ * same numbers by a shorter route, for a caller that wants them as numbers.
+ */
+export function getBandData() {
+  return bandCollector.data();
 }

--- a/tests/node/band-data.test.mjs
+++ b/tests/node/band-data.test.mjs
@@ -1,0 +1,285 @@
+// The layout's band data, captured alongside the document it currently produces.
+//
+// The document that /seqtubemap returns is 93.7% emulated browser, and that
+// document exists only so the numbers the layout already held can be serialized
+// to text and parsed straight back into numbers by the client. Before it can be
+// removed, the numbers going into it have to be reachable — which is what
+// `getBandData()` makes them.
+//
+// Nothing observable changes yet, so the claim this file has to carry is not
+// "the data looks right" but "the data is enough": enough to rebuild the
+// document that is shipping today. It demonstrates that rather than asserting
+// it, by reconstructing the document from the captured data alone
+// (reconstruct-document.mjs, which is given the data and nothing else) and
+// comparing the result against the render byte for byte.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { renderTubeMap } from "../../seqtubemap/render.mjs";
+import { cases, goldenPath, inputPath, regionFor, repoRoot } from "./golden-cases.mjs";
+import { reconstructDocument } from "./reconstruct-document.mjs";
+
+// The smallest of the committed real subgraphs, named for the region it was
+// fetched for — which is where the render gets its coordinates, as the endpoint
+// does.
+const REAL_SUBGRAPH = "subgraph_chr8_78771162_78771252_v2_with_walk";
+
+// One render per case, in this process — the same render the CLI performs, and
+// the only way to reach the band data, which is held in memory rather than
+// written anywhere.
+const rendered = new Map();
+for (const testCase of cases) {
+  const inputFile = inputPath(testCase);
+  const { start, end } = regionFor(JSON.parse(readFileSync(inputFile, "utf8")));
+  rendered.set(
+    testCase.name,
+    await renderTubeMap({ inputFile, start, end, nodeWidthOption: testCase.nodeWidthOption }),
+  );
+}
+
+for (const testCase of cases) {
+  const { document, bandData } = rendered.get(testCase.name);
+
+  test(`the ${testCase.name} render still produces its golden document`, () => {
+    // The capture is meant to change nothing about the output, and this render
+    // goes through the same code the golden test drives through the CLI. If the
+    // two ever disagree, the reconstruction below is being checked against the
+    // wrong oracle, and it should say so here rather than there.
+    assert.equal(document, readFileSync(goldenPath(testCase), "utf8"));
+  });
+
+  test(`the ${testCase.name} document can be rebuilt from its band data alone`, () => {
+    // This is the acceptance criterion the ticket asks to be demonstrated
+    // rather than asserted: everything below comes out of the band data, and if
+    // anything needed to draw the picture were missing from it, these bytes
+    // could not be produced.
+    const rebuilt = reconstructDocument(bandData);
+    assert.ok(
+      document.startsWith(rebuilt),
+      describeDifference(document, rebuilt),
+    );
+
+    // What the reconstruction stops short of is the ruler, which is not band
+    // data: the axis line, its ticks and their labels. Everything the band data
+    // covers has to be inside the prefix, so the tail must carry no band, no
+    // segment box and no group of either.
+    const tail = document.slice(rebuilt.length);
+    assert.equal(tail.slice(-6), "</svg>");
+    for (const marker of ["<g ", "trackID=", "sequence="]) {
+      assert.ok(!tail.includes(marker), `${marker} appears after the reconstructed prefix`);
+    }
+  });
+
+  test(`the ${testCase.name} band data survives a round trip through JSON`, () => {
+    // The point of capturing the data is to be able to hand it to somebody
+    // else. Plain numbers and strings — no DOM nodes, no live references into
+    // the layout, nothing that only means something inside this process.
+    const rebuilt = reconstructDocument(JSON.parse(JSON.stringify(bandData)));
+    assert.equal(rebuilt, reconstructDocument(bandData));
+  });
+
+  test(`the ${testCase.name} band data has one strand row per strand`, () => {
+    // The table is the per-band constants sent once. A row per strand is what
+    // makes that true; a row per band would be the repetition it exists to
+    // remove.
+    const { strands, bands } = bandData;
+    const ids = new Set(strands.map((strand) => strand.id));
+    assert.equal(ids.size, strands.length, "a strand appears in more than one row");
+
+    const namesInDocument = new Set(
+      [...document.matchAll(/trackName="([^"]+)"/g)].map((match) => match[1]),
+    );
+    assert.equal(strands.length, namesInDocument.size);
+    assert.ok(bands.length > strands.length * 2, "too few bands to be worth a table");
+
+    for (const band of bands) {
+      assert.ok(strands[band.strand], `band ${bands.indexOf(band)} names no strand`);
+    }
+  });
+
+  test(`the ${testCase.name} band data is in paint order`, () => {
+    // Ordering is not incidental: bands are drawn in the order they appear, so
+    // a later band draws over an earlier one. The reconstruction above is the
+    // real check — it would not be byte-identical if the order were wrong — and
+    // this states the count the document and the data have to agree on.
+    const trackGroup = document.slice(
+      document.indexOf('<g class="track">'),
+      document.indexOf('<g class="node">'),
+    );
+    const shapes = trackGroup.match(/<(?:rect|path)\b/g) ?? [];
+    assert.equal(bandData.bands.length, shapes.length);
+
+    // The segment boxes are the only thing in `g.node` at this width — labels
+    // and mismatches are drawn in "normal" mode only — so the count is exact.
+    // The slice stops at the group's own close: the ruler's arrow is a <path>
+    // too, and it is drawn after the group rather than inside it.
+    const nodeGroupStart = document.indexOf('<g class="node">');
+    const nodeGroup = document.slice(nodeGroupStart, document.indexOf("</g>", nodeGroupStart));
+    const boxes = nodeGroup.match(/<path\b/g) ?? [];
+    assert.ok(bandData.segments.length > 0, "no segment boxes captured");
+    assert.equal(bandData.segments.length, boxes.length);
+  });
+}
+
+test("the document's dimensions come from the band data", () => {
+  const { document, bandData } = rendered.get("large");
+  const { width, height, viewBox, extent } = bandData.document;
+
+  assert.match(document, new RegExp(` viewBox="${escapeForRegExp(viewBox)}" `));
+  assert.match(document, new RegExp(` width="${escapeForRegExp(String(width))}" `));
+  assert.match(document, new RegExp(` height="${escapeForRegExp(String(height))}"`));
+  // The extent the margins were added to, kept so a consumer can tell where the
+  // layout actually ends rather than inferring it back out of the viewBox.
+  assert.ok(extent.maxXCoordinate > 0);
+  assert.ok(extent.maxYCoordinate > extent.minYCoordinate);
+});
+
+test("a strand's colour and placement are on the strand, not on every band", () => {
+  const { bandData } = rendered.get("large");
+  for (const strand of bandData.strands) {
+    assert.equal(typeof strand.id, "number");
+    assert.equal(typeof strand.name, "string");
+    assert.match(strand.color, /^(#[0-9a-f]{6}|rgb\(\d+, \d+, \d+\))$/i);
+    // No PCLAI scheme is loaded for these fixtures, so every placement is
+    // absent — as null, which is what the document writes as "None".
+    assert.equal(strand.pclaiX, null);
+    assert.equal(strand.pclaiY, null);
+    assert.equal(strand.pclaiScore, null);
+  }
+  for (const band of bandData.bands) {
+    assert.ok(!("color" in band), "a band carries a colour of its own");
+    assert.ok(!("name" in band), "a band carries a strand name of its own");
+  }
+});
+
+test("a real subgraph's document is rebuilt from its band data, in full", async () => {
+  // The synthetic fixtures above are shaped like a subgraph; this one is a
+  // subgraph — 464 strands, fetched from the live server (see
+  // tests/fixtures/seqtubemap/README.md). It carries no ruler, which is what
+  // production documents look like, so here the reconstruction accounts for
+  // every byte of the document rather than for its leading ones.
+  const { document, bandData } = await renderTubeMap({
+    inputFile: join(repoRoot, "tests", "fixtures", "seqtubemap", `${REAL_SUBGRAPH}.json`),
+    start: 78771162,
+    end: 78771252,
+    nodeWidthOption: "compressed",
+  });
+
+  const rebuilt = reconstructDocument(bandData);
+  assert.ok(document.startsWith(rebuilt), describeDifference(document, rebuilt));
+  assert.equal(document.slice(rebuilt.length), "</svg>");
+  assert.ok(bandData.strands.length > 400, `only ${bandData.strands.length} strands`);
+});
+
+test("an inversion's corners and vertical rectangles are captured too", async () => {
+  // No committed fixture contains an inversion, and an inversion is the only
+  // thing that produces corner bands — or a rectangle the document paints no
+  // opacity on. So one is made here, by sending a single strand backwards
+  // through three segments of the smoke fixture, which is exactly what a
+  // reversal is.
+  const inputFile = join(mkdtempSync(join(tmpdir(), "tubemap-inverted-")), "inverted.json");
+  const vg = JSON.parse(readFileSync(join(repoRoot, "tests", "fixtures", "tiny-vg.json"), "utf8"));
+  const mapping = vg.path[1].mapping;
+  vg.path[1].mapping = [
+    ...mapping.slice(0, 2),
+    ...mapping
+      .slice(2, 5)
+      .reverse()
+      .map((step) => ({ position: { ...step.position, is_reverse: true } })),
+    ...mapping.slice(5),
+  ];
+  writeFileSync(inputFile, JSON.stringify(vg), "utf8");
+
+  const { document, bandData } = await renderTubeMap({
+    inputFile,
+    start: 0,
+    end: 69,
+    nodeWidthOption: "compressed",
+  });
+
+  const corners = bandData.bands.filter((band) => band.kind === "corner");
+  assert.ok(corners.length > 0, "the inverted input produced no corner bands");
+  assert.ok(
+    bandData.bands.some((band) => band.kind === "rect" && band.alpha === undefined),
+    "the inverted input produced no rectangle without an opacity",
+  );
+
+  // The layout builds a corner without a strand name — which is why the
+  // document carries none on it. The band data must still say which strand the
+  // corner belongs to: it points at the strand's own row, named like any other,
+  // rather than at a second nameless row for the same strand.
+  const ids = bandData.strands.map((strand) => strand.id);
+  assert.equal(new Set(ids).size, ids.length, "a strand appears in more than one row");
+  for (const corner of corners) {
+    const strand = bandData.strands[corner.strand];
+    assert.equal(typeof strand.name, "string", "a corner points at a nameless strand");
+    assert.ok(document.includes(`trackName="${strand.name}"`));
+  }
+
+  assert.ok(
+    document.startsWith(reconstructDocument(bandData)),
+    describeDifference(document, reconstructDocument(bandData)),
+  );
+});
+
+test("a strand's PCLAI placement reaches the strand table", async () => {
+  // The fixtures above are rendered without a PCLAI colour scheme, which is the
+  // one case where every placement is absent — so on its own it would leave the
+  // placement columns of the table asserted only against null. This renders with
+  // a scheme in the shape main.py builds: rgb, an x/y coordinate pair, and a
+  // score, keyed by "sample#haplotype#contig". A strand the scheme does not
+  // cover keeps its light grey and has no placement.
+  const covered = "HG10000#1#chr1";
+  const inputFile = inputPath(cases[0]);
+  const { start, end } = regionFor(JSON.parse(readFileSync(inputFile, "utf8")));
+  const { document, bandData } = await renderTubeMap({
+    inputFile,
+    start,
+    end,
+    nodeWidthOption: cases[0].nodeWidthOption,
+    pclaiColorScheme: { [covered]: [[12, 34, 56], [1.5, -2.5], 0.875] },
+  });
+
+  const placed = bandData.strands.find((strand) => strand.name === covered);
+  assert.deepEqual(placed, {
+    id: placed.id,
+    name: covered,
+    color: "rgb(12, 34, 56)",
+    pclaiX: 1.5,
+    pclaiY: -2.5,
+    pclaiScore: 0.875,
+  });
+
+  for (const strand of bandData.strands) {
+    if (strand.name === covered) continue;
+    assert.equal(strand.color, "rgb(211, 211, 211)", `${strand.name} kept a palette colour`);
+    assert.equal(strand.pclaiX, null);
+    assert.equal(strand.pclaiScore, null);
+  }
+
+  // And the document is still exactly what the table says it is — including the
+  // "None" it writes where a placement is absent.
+  const rebuilt = reconstructDocument(bandData);
+  assert.ok(document.startsWith(rebuilt), describeDifference(document, rebuilt));
+  assert.ok(document.includes(`pclaiX="1.5" pclaiY="-2.5" pclaiScore="0.875"`));
+});
+
+function escapeForRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function describeDifference(document, rebuilt) {
+  let at = 0;
+  while (at < document.length && at < rebuilt.length && document[at] === rebuilt[at]) at += 1;
+  const context = 120;
+  return (
+    `the reconstruction diverges from the document at byte ${at} ` +
+    `(${rebuilt.length} bytes rebuilt, ${document.length} in the document)\n` +
+    `  document:      ...${document.slice(at, at + context)}\n` +
+    `  reconstructed: ...${rebuilt.slice(at, at + context)}\n` +
+    "The band data is missing something the document says, or says it differently."
+  );
+}

--- a/tests/node/reconstruct-document.mjs
+++ b/tests/node/reconstruct-document.mjs
@@ -1,0 +1,108 @@
+// Rebuild a sequence tube map document from band data and nothing else.
+//
+// This exists to demonstrate a claim, not to serve traffic: that the data
+// captured in `seqtubemap/band-data.mjs` is sufficient to reconstruct the
+// document the layout currently builds. The emitter that replaces the browser
+// emulation is a later increment; this is the proof that it can be written.
+//
+// So it is deliberately written *against the data*, with no access to the
+// layout: everything it emits comes from the strand table, the bands, the
+// segment boxes and the document's dimensions. If something needed to draw the
+// picture were missing from the band data, this file could not compile it, and
+// the test that uses it would fail with a byte offset.
+//
+// What it does not cover is the ruler — the axis, ticks and labels a fixture
+// with a reference offset gets. Those are not bands, they are not segment
+// boxes, and production documents contain none of them (see
+// docs/adr/0001-additive-band-format.md, "There are zero `<text>` and zero
+// `<line>` elements"). The caller compares the reconstruction against the
+// document's leading bytes for that reason.
+
+/** The document that this band data describes, up to the end of the segment boxes. */
+export function reconstructDocument(bandData) {
+  const { document, strands, bands, segments } = bandData;
+  return (
+    `<svg id="mysvg" viewBox="${attribute(document.viewBox)}" ` +
+    `width="${attribute(document.width)}" height="${attribute(document.height)}" ` +
+    `xmlns="http://www.w3.org/2000/svg">` +
+    `<g class="track">${bands.map((band) => bandElement(band, strands[band.strand])).join("")}</g>` +
+    `<g class="node">${segments.map(segmentElement).join("")}</g>`
+  );
+}
+
+function bandElement(band, strand) {
+  const geometry =
+    band.kind === "rect"
+      ? ` x="${attribute(band.x)}" y="${attribute(band.y)}"` +
+        ` width="${attribute(band.width)}" height="${attribute(band.height)}"`
+      : ` d="${attribute(band.path)}"`;
+
+  // A band paints an opacity when it has one. Corners never do, and neither do
+  // the vertical rectangles of a reversal.
+  const style =
+    band.alpha === undefined
+      ? css({ fill: cssColor(strand.color) })
+      : css({ fill: cssColor(strand.color), "fill-opacity": band.alpha });
+
+  const element = band.kind === "rect" ? "rect" : "path";
+  return (
+    `<${element}${geometry} style="${attribute(style)}"` +
+    // A corner names no strand: the layout builds it without a name, and the
+    // document has never carried one on it.
+    ` trackID="${attribute(strand.id)}"` +
+    (band.kind === "corner" ? "" : attr("trackName", strand.name)) +
+    ` class="track${attribute(strand.id)}" color="${attribute(strand.color)}"` +
+    ` pclaiX="${attribute(orNone(strand.pclaiX))}"` +
+    ` pclaiY="${attribute(orNone(strand.pclaiY))}"` +
+    ` pclaiScore="${attribute(orNone(strand.pclaiScore))}">` +
+    `<title></title></${element}>`
+  );
+}
+
+function segmentElement(segment) {
+  const style = css({
+    fill: cssColor(segment.fill),
+    "fill-opacity": segment.fillOpacity,
+    stroke: cssColor(segment.stroke),
+    "stroke-width": segment.strokeWidth,
+  });
+  return (
+    `<path id="${attribute(segment.id)}" d="${attribute(segment.outline)}"` +
+    `${attr("sequence", segment.sequence)} style="${attribute(style)}">` +
+    `<title></title></path>`
+  );
+}
+
+// An attribute the layout may not have a value for. d3 removes an attribute
+// whose value is null or undefined rather than writing an empty one, so an
+// unnamed strand or a segment with no sequence has no attribute at all.
+function attr(name, value) {
+  return value === null || value === undefined ? "" : ` ${name}="${attribute(value)}"`;
+}
+
+function orNone(value) {
+  return value === null ? "None" : value;
+}
+
+function css(declarations) {
+  return Object.entries(declarations)
+    .map(([property, value]) => `${property}: ${value};`)
+    .join(" ");
+}
+
+// The layout names colours as hex; a stylesheet says them as `rgb()`, and the
+// document has always carried the stylesheet's spelling.
+function cssColor(color) {
+  const hex = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color);
+  if (!hex) return color; // already `rgb(r, g, b)` — what a PCLAI scheme supplies
+  const [r, g, b] = hex.slice(1).map((pair) => parseInt(pair, 16));
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+// The escaping an XML serializer applies inside an attribute value.
+function attribute(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/ /g, "&nbsp;");
+}


### PR DESCRIPTION
Closes #21. The expand half of the expand–contract pair in #13; the decision is [`docs/adr/0001-additive-band-format.md`](docs/adr/0001-additive-band-format.md).

## What this does

The layout computes each band's geometry, colour, **strand** id and strand name, and immediately binds all of it to elements in an emulated browser document — 93.7% of the render's retained memory, existing only so the result can be serialized to text and parsed straight back into numbers by `pgb`. Before that document can be removed, the data going into it has to be reachable.

`getBandData()` now returns it:

- **strands** — one row per strand: id, name, colour, PCLAI placement. The per-band constants, sent once.
- **bands** — one entry per drawn shape in paint order, each pointing at a strand row. `rect` carries x/y/width/height; `curve` and `corner` carry the path string the layout built (making those numbers too is increment C).
- **segments** — the segment boxes.
- **document** — the dimensions, including the viewBox string.

`seqtubemap/render.mjs` renders in-process and hands back `{ document, bandData }`, so a caller inside Node can have both without spawning anything. `generate-svg.mjs` is now a thin CLI over it.

**The collector is not a second sink.** Each draw function collects what it is about to draw and then binds *the collected bands* as its d3 data, so band order is document order because it is the same list read twice, and the two cannot drift apart.

## Nothing observable changes

The golden documents are untouched and unbaselined — that is the point of this increment. The next one switches the emitter over and deletes the emulation.

## The data is enough — demonstrated, not asserted

`tests/node/reconstruct-document.mjs` rebuilds the document from the band data and nothing else, and the new tests compare it byte for byte against:

- both synthetic golden fixtures (7 and 121 strands),
- a real 464-strand subgraph — the whole document, not a prefix, since production documents carry no ruler,
- a PCLAI-coloured render, so the placement columns are exercised against real values rather than only against `null`,
- a synthesised inversion, which is the only thing that produces corner bands.

Mutation-checked: dropping one band in ten fails 9 of the 15 new tests.

## Two layout quirks captured rather than smoothed over

Because the document has them, and byte-compatibility is the constraint:

- a corner, and a reversal's vertical rectangles, paint no opacity — so `alpha` sits on the band, while colour sits on the strand;
- a corner carries no strand name. It still points at its strand's own row, found by id and colour, so its placement is not lost.

## Verification

- `npm test` — 22 pass, 2 pre-existing skips.
- `pytest` — 11 pass, 5 skipped for want of a local `vg` binary (unchanged by this PR; CI has `vg`).
- No dependency changes; `package.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)