### PR TITLE
Record when the server is stood up for testing (ADR 0002)

### DIFF
--- a/docs/adr/0002-when-the-server-is-stood-up.md
+++ b/docs/adr/0002-when-the-server-is-stood-up.md
@@ -1,0 +1,118 @@
+---
+status: proposed
+date: 2026-08-27
+---
+
+# The server is stood up only for claims the fixtures cannot carry
+
+Both test suites run from a bare checkout: no `.gbz`, no `.walk.gz` derivatives, no
+network. That is deliberate, and it is not a limitation to be fixed by pointing the tests
+at a running server. **Fixtures are the default oracle. A server — local or live — is
+stood up only when the claim being made is one the fixtures cannot carry, and a live
+deploy only when the claim is end-to-end.**
+
+This is written down because the suites look, from the outside, like they are missing
+something. They are not.
+
+## What each rung can prove
+
+**Fixtures — the default.** `tests/python/conftest.py` stubs the two natively-compiled
+layout libraries, stubs panCT where the machine lacks it, and points `data.path` at an
+empty directory, because the walk derivatives are opened when something reads them.
+`tests/python/test_seqtubemap_endpoint.py` then drives `/seqtubemap` end to end with no
+graph data at all, by planting a committed subgraph at the pipeline's own cache path — the
+`subgraph_cached` branch in `main.py`, an existing production shortcut rather than a test
+hook. The Node suite renders committed inputs and asserts byte-identity against committed
+documents.
+
+This covers more than it looks like it does: the endpoint's request path, the generator's
+output byte for byte, and — in CI, where `PANGENOME_TESTS_REQUIRE_ALL=1` turns every skip
+and every stand-in into a failure — `vg` and panCT for real.
+
+What it cannot cover: whether the real client accepts the output, and what anything costs
+at production size.
+
+**A local server — rare.** `fastapi dev main.py`, or `docker-compose` with `DATA_DIR`
+mounted at `/data`. It needs the multi-gigabyte graph data on the machine and spends
+around five minutes indexing on first run. Worth it to look at a real picture in a browser
+or to reproduce a report against real data; not worth it as a routine step, and never as a
+substitute for a test.
+
+**A live deploy — the exception.** The server follows `release`, not `main`
+([`docs/releasing.md`](../releasing.md)), so merging is not shipping: a deploy is a
+promotion somebody performs on purpose (`git merge --ff-only main`) and then a colleague
+with server access pulls and restarts. It costs someone else's afternoon-fragment, and it
+is the only rung that can answer the two questions the fixtures cannot.
+
+That the two are separate is what makes the rest of this decision safe to hold. Work can
+land on `main` — including a rewrite as large as increment B — without anybody deciding to
+put it in front of a researcher.
+
+## When a live deploy is required
+
+The test is not "is this change risky" — it is **"is the claim end-to-end?"** Three cases
+qualify, and nothing else does:
+
+1. **The claim is that `pgb` accepts the output.** [ADR 0001](./0001-additive-band-format.md)
+   holds increment B byte-compatible with `pgb`'s existing parser as a deliberate
+   constraint, precisely so that "`pgb` becomes its conformance test: a bad B shows up as
+   an error card rather than as a diff nobody ran". That property is worth nothing unless
+   the deploy actually happens, while the client is still unchanged.
+2. **The claim is about time or memory at production size.** The committed fixtures top out
+   well below the regime that fails. `subgraph_extract` is 77% of a 10 kb request and no
+   fixture exercises it at all.
+3. **The claim is about production data the fixtures do not carry** — a region, a strand
+   naming convention, or a graph build that nothing in `tests/fixtures/` represents.
+
+A change that makes none of these claims ships on the strength of the suites.
+
+## Before any deploy, capture the before-state
+
+The server that is about to be replaced is the only place the current bytes exist. Once it
+restarts, a byte-comparison against it is impossible forever, and "it looked right in the
+browser" is what remains.
+
+So a deploy request is paired with a capture of the same URLs against the running server
+beforehand, saved to disk. Afterwards the same URLs are fetched again and compared. That
+is the difference between a conformance test and a glance.
+
+This is not hypothetical: `tests/fixtures/seqtubemap/` holds five real *inputs* taken from
+the live server, and no matching documents — `pgb`'s five golden documents predate a change
+in how strands are named and no longer line up with them. The pairs were separable at the
+time and were not taken.
+
+## Considered and rejected
+
+**A staging environment.** The honest answer to the deploy cost, and out of reach: the
+data is multi-gigabyte and the machine is not ours to duplicate. Reconsider if either
+changes.
+
+**Live smoke tests in CI.** A scheduled job hitting the deployed server would catch drift,
+but it tests whatever happens to be deployed rather than the commit under review, turns an
+unrelated outage into a red build on someone's PR, and cannot run before a deploy — which
+is exactly when the question matters.
+
+**Deploying every merge to `main`.** Would make the deploy boundary meaningless and spend a
+colleague's time per PR. The batching is a cost, not a feature, but it is the right cost.
+
+**Standing up `pgb` against a local server in CI.** Two repositories in lockstep in a build,
+to test a compatibility that ADR 0001 already holds by construction and that the golden
+documents already pin byte for byte. The end-to-end check is worth running once per
+increment, not once per commit.
+
+## Consequences
+
+- **A deploy validates a batch, not an increment.** `git log release..main` is the batch,
+  and the deploy after increment B will also be the first to carry A's event-loop fix and
+  #21's capture. The promotion message should name what is in it, so a surprise has a list
+  of suspects rather than one assumed cause.
+- **The fixtures have to be kept honest, because they are load-bearing.** Where a fixture is
+  missing its oracle, that is a gap in the default rung and should be closed there rather
+  than deferred to a deploy. The two skipped real-input golden cases in
+  `tests/node/generate-svg.golden.test.mjs` are the current instance.
+- **Watch for an oracle that degenerates.** `tests/node/band-data.test.mjs` proves the band
+  data can rebuild the document by comparing the reconstruction against the render. After
+  increment B the document *is* emitted from the band data, so that comparison becomes a
+  tautology that still passes. The golden documents are what survive it.
+- **`vg` remains a real dependency of the default rung** until increment D removes the round
+  trip. Locally its absence skips; in CI it does not.

--- a/docs/perf/deploy-request.md
+++ b/docs/perf/deploy-request.md
@@ -1,5 +1,11 @@
 # What I need from the server
 
+> **Done, 2026-08-27 — kept for the record.** Both tasks below were carried out; the
+> readings are in [§6 of the findings](./seqtubemap-latency.md). Do not follow the steps
+> here again: they predate the `release` branch and say `git checkout main`, which is no
+> longer where the server lives. The standing procedure is
+> [`docs/releasing.md`](../releasing.md).
+
 Hi Cici — two things, and they both come off the same deploy. Probably 15 minutes.
 
 Anywhere below that says `<something>`, that's a placeholder for a real value on your end.

--- a/docs/perf/seqtubemap-plan.md
+++ b/docs/perf/seqtubemap-plan.md
@@ -21,7 +21,8 @@ Written 2026-08-27, at the end of the diagnosis phase.
 | Diagnosis | Complete. The upstream stage was measured 2026-08-27 (see Step 0) |
 | Grilling | Complete, 2026-08-27. Produced [`CONTEXT.md`](../../CONTEXT.md) and [ADR 0001](../adr/0001-additive-band-format.md) |
 | Built | Local harness (`perf/`), server-side stage timers (`main.py`) |
-| Changed in production behaviour | Nothing yet |
+| Changed on `main` | Increment A (PRs [#37](https://github.com/CAST-genomics/PangenomeAPI/pull/37), [#38](https://github.com/CAST-genomics/PangenomeAPI/pull/38)), the two test suites and CI, and #21's band capture |
+| Changed in production behaviour | **Nothing yet.** The server follows `release` ([`docs/releasing.md`](../releasing.md)), so none of the above is live until it is promoted. `git log release..main` is what is waiting |
 
 **The shape of the work is now settled.** Steps 0, 1 and 2 below are done; what remains is
 Step 3 (the build). The increments are A-E under *The roadmap*; A-D come from ADR 0001, and


### PR DESCRIPTION
Two commits: a new ADR, and a follow-up that points two stale documents at the `release` branch.

## ADR 0002 — the server is stood up only for claims the fixtures cannot carry

Both suites run from a bare checkout, and `tests/python/test_seqtubemap_endpoint.py` drives `/seqtubemap` end to end with **no graph data at all**, by planting a committed subgraph at the pipeline's own cache path. From the outside that looks like something is missing, and the obvious "fix" is to point the tests at a running server. It isn't missing — it's the decision, and it wasn't written down anywhere.

The ADR records three rungs and what each can prove:

- **fixtures** — the default oracle; covers the request path and the generator's output byte for byte, and in CI (`PANGENOME_TESTS_REQUIRE_ALL=1`) `vg` and panCT for real;
- **a local server** — rare, for looking at a real picture;
- **a live deploy** — the exception, and the only rung that can answer whether `pgb` accepts the output and what anything costs at production size.

Three cases earn a deploy: the client's parser must accept the output ([ADR 0001](docs/adr/0001-additive-band-format.md) makes `pgb` increment B's conformance test), the claim is about time or memory at production size, or the claim is about production data no fixture carries. Anything else ships on the suites.

It also records the step that expires: **the server about to be replaced is the only place the current bytes exist**, so a promotion is paired with a capture of the same URLs beforehand. That has already cost us once — `tests/fixtures/seqtubemap/` holds five real inputs with no matching documents.

Status is `proposed`, not `accepted`.

## The stale references

`docs/releasing.md` moved the server off `main` and onto `release`; two documents still describe the world before it.

- `docs/perf/deploy-request.md` was a one-shot request, already carried out, but the plan links it twice as though it were the procedure — and its steps say `git checkout main`. It gets a note marking it a record rather than instructions.
- The plan's "Where things stand" table said production behaviour was unchanged. Still true of the server, no longer true of `main`: increment A, both suites, CI and #21's capture have landed. The table now separates the two, which is the point of having a release branch.

Docs only — no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)