### PR TITLE
Make the strand order a function of the subgraph, not of vg

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,13 +35,30 @@ _Avoid_: node (this codebase's meaning), and `vg`'s "node". A GFA `S` line is a
 segment in the GFA, which is the one place the word already agrees.
 
 **strand**:
-One haplotype's route through a **sequence tube map**, named
-`sample#haplotype#contig` and coloured by its shipped PCLAI RGB.
+One haplotype's route through a **sequence tube map**, identified by the triple
+`sample#haplotype#contig` and coloured by its shipped PCLAI RGB. The triple is
+the whole of a strand's identity: one haplotype fragmented across a **region**
+contributes several GFA `W` lines but remains one strand.
 _Avoid_: track, path, walk. This one concept has five spellings across the
 pipeline — a GFA `W` line calls it a walk, a GFA `P` line and `vg` JSON call it a
 path, `tubemap.js` and the emitted `trackID`/`trackName` attributes call it a
 track, and the biology calls it a haplotype. Each is correct in its own format;
 none of them is what this codebase calls it.
+_Avoid_ also: treating `vg`'s longer spelling as the name. `vg` appends its own
+phase block and subrange to the triple — `sample#haplotype#contig#0[9659985-9661740]`
+— and that string travels the wire verbatim, because rewriting it would make this
+codebase's documents disagree with the tool that produced them. It is `vg`
+metadata riding on the identity, not part of it; the codebase truncates back to
+the triple only where it looks something up, such as a PCLAI colour.
+
+**pivot strand**:
+The **strand** the layout arranges every other strand around — it fixes segment
+order and orientation, and the rest are threaded against it. **GRCh38** where
+present. Which strand this is changes the picture, not the data: the same
+**subgraph** laid out around a different pivot draws the same **segments** and
+the same **strands** in a different arrangement, at a different size.
+_Avoid_: leaving it implicit. A pivot chosen by whatever order the strands
+happened to arrive in is a picture that moves for reasons the reader cannot see.
 
 **band**:
 The atomic drawable of a **sequence tube map**: one **strand** crossing one
@@ -68,4 +85,5 @@ the graph — one per haplotype.
 **GRCh38**:
 The linear reference the graphs are built against and every **region** is
 expressed in. Present in the graph as **strands** of its own, and treated
-specially wherever strands are merged.
+specially wherever strands are merged — and, as the **pivot strand**, wherever
+they are laid out.

--- a/docs/seqtubemap-roadmap.md
+++ b/docs/seqtubemap-roadmap.md
@@ -1,6 +1,6 @@
 # `/seqtubemap` rework — the roadmap
 
-The execution sequence for the `/seqtubemap` plumbing work: sixteen tickets, what each
+The execution sequence for the `/seqtubemap` plumbing work: eighteen tickets, what each
 delivers, what gates it, and what has to be true before it is called done.
 
 This is the **build** document. Its companions:
@@ -14,9 +14,14 @@ This is the **build** document. Its companions:
 | [`docs/perf/seqtubemap-plan.md`](./perf/seqtubemap-plan.md) | which skill drives each phase |
 | [`docs/releasing.md`](./releasing.md) | why merging is not shipping |
 | [`docs/perf/deploy-request.md`](./perf/deploy-request.md) | the ask that unblocked [#16](https://github.com/CAST-genomics/PangenomeAPI/issues/16) — a record now, not a procedure |
+| [`tests/fixtures/seqtubemap/README.md`](../tests/fixtures/seqtubemap/README.md) | the five real subgraphs, and what they do and do not pin |
 | [#13](https://github.com/CAST-genomics/PangenomeAPI/issues/13) | the spec these tickets decompose |
 
-Written 2026-08-27 at the end of the grilling and ticketing phase; updated 2026-08-28.
+Written 2026-08-27 at the end of the grilling and ticketing phase; updated 2026-08-28, twice
+— the second time after a grilling session on [#41](https://github.com/CAST-genomics/PangenomeAPI/issues/41)
+measured its premises and found them false. That re-sequenced the coverage work ahead of
+[#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22) and added two tickets; see
+*Before #22*.
 
 ## Where this stands
 
@@ -25,9 +30,10 @@ Phase 0 and increment **A** are merged. **B** is half done.
 | | |
 | --- | --- |
 | Merged | [#14](https://github.com/CAST-genomics/PangenomeAPI/issues/14), [#15](https://github.com/CAST-genomics/PangenomeAPI/issues/15), [#16](https://github.com/CAST-genomics/PangenomeAPI/issues/16), [#17](https://github.com/CAST-genomics/PangenomeAPI/issues/17), [#18](https://github.com/CAST-genomics/PangenomeAPI/issues/18), [#19](https://github.com/CAST-genomics/PangenomeAPI/issues/19), [#20](https://github.com/CAST-genomics/PangenomeAPI/issues/20), [#21](https://github.com/CAST-genomics/PangenomeAPI/issues/21) |
-| Frontier | **[#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22)** — its only blocker, #21, is closed |
+| Frontier | **[#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22)** — its only blocker, #21, is closed. **[#46](https://github.com/CAST-genomics/PangenomeAPI/issues/46)** is unblocked and should go first; see below |
 | Live | **Nothing.** The server follows `release`, so merging is not shipping; `git log release..main` is what is waiting |
-| Coverage gaps worth closing first | [#40](https://github.com/CAST-genomics/PangenomeAPI/issues/40) *(agent)*, [#41](https://github.com/CAST-genomics/PangenomeAPI/issues/41) *(human)* — see *Before #22* below |
+| Coverage gaps worth closing first | [#46](https://github.com/CAST-genomics/PangenomeAPI/issues/46) *(human)*, then [#40](https://github.com/CAST-genomics/PangenomeAPI/issues/40) and [#41](https://github.com/CAST-genomics/PangenomeAPI/issues/41) *(both agent)* — see *Before #22* below |
+| Housekeeping, unblocked, no document changes | [#45](https://github.com/CAST-genomics/PangenomeAPI/issues/45) *(agent)* |
 
 ---
 
@@ -68,7 +74,9 @@ only consumer, can parse the XML back into the numbers the layout already held i
                         │                      │                         └── #23 floats ── #24 ?format=bands ── #25 contract test
                         │                      │
                         │                      ├── #40 pclai golden        (ready-for-agent)
-                        │                      ├── #41 real-input goldens  (ready-for-human)
+                        │                      │
+                        │                      ├── #46 fix the reorder ── #41 fetch-ceiling band data
+                        │                      │   (ready-for-human)       (ready-for-agent)
                         │                      │
                         │                      └── #26 delete vg ── #27 no disk
                         │
@@ -76,13 +84,19 @@ only consumer, can parse the XML back into the numbers the layout already held i
 
 #15 declare the fork ✅────── #21
 #16 timings + fixtures ✅──── #26
+#45 strip the debug logging — unblocked, touches no document
 #E  batch GenerateWalksMC — no ticket yet, no ADR behind it
 ```
 
 **The frontier is [#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22)**, and nothing blocks it. Edges are GitHub's native issue
 dependencies, so a ticket whose blockers are all closed is grabbable without consulting this
-document — which is why the two coverage tickets hanging off #18 are worth reading before
+document — which is why the coverage tickets hanging off #18 are worth reading before
 grabbing #22 rather than after.
+
+**[#46](https://github.com/CAST-genomics/PangenomeAPI/issues/46) is also unblocked, and it is the one to take first.** It is not on #22's
+critical path, but it changes the arrangement of every real document the server produces, so
+anything baselined before it lands is baselined against a layout that is about to move. #41
+is blocked on it for exactly that reason.
 
 ---
 
@@ -216,7 +230,7 @@ in production: a bad deploy surfaces as an error card, not as a diff nobody ran.
 > **If the compatibility constraint cannot be held, stop and escalate.** Do not work around
 > it. The no-client-change property is the entire reason B is safe to ship alone.
 
-### Before #22 — the goldens are the only thing that crosses the boundary
+### Before #22 — what the left-hand side of the diff actually covers
 
 #22 re-baselines the golden documents deliberately, and its acceptance criterion is that
 **the diff is only those three removals**. That is a claim about a diff, so it is worth
@@ -224,23 +238,57 @@ asking what the left-hand side covers before making it — because a golden crea
 change cannot police the change, and after B nothing else in the repository pins output
 against what the jsdom pipeline produced.
 
-Two gaps, both already ticketed:
+The answer, as of 2026-08-28: less than it looks. The committed goldens are synthetic, and
+they pass byte-identically **through a change that reorders every strand in the picture** —
+which is how #46 sat undetected. They cover the mechanism; they do not cover the regime.
+
+Three gaps, all ticketed — and the order among them matters, because one of them moves the
+documents the other two would baseline.
+
+- **[#46](https://github.com/CAST-genomics/PangenomeAPI/issues/46) — the reorder is wrong *(ready-for-human, take this first)*.**
+  `reorderTracksForLayout` arrived in `0f69615` inside a commit about walk generation, with a
+  three-point comment and a one-line body implementing one of the three. It decides which
+  strand is the **pivot strand** — `createTubeMap` straightens `tracks[0]` and orients
+  everything else against it — and today that is decided by a stable-sort tiebreak on
+  sequence length. Measured: CHM13 lands at index **455 of 464** where the comment promises
+  second, and GRCh38 leads only because it happens to tie for longest.
+
+  It is human-labelled because it changes the arrangement of every real document the server
+  emits. It does *not* re-baseline the synthetic goldens — those pass byte-identically either
+  way, which is a useful signal about how little of the real regime they cover.
 
 - **[#40](https://github.com/CAST-genomics/PangenomeAPI/issues/40) — PCLAI colour scheme *(ready-for-agent)*.** Every committed golden invokes
   the five-argument form of the generator, so the colour scheme branch — live in production
   whenever `minigraphnode` is set — produces output nothing pins. #21 added band-data coverage
   for it, not a golden document. Small, mechanical, and it closes a real hole under B.
-- **[#41](https://github.com/CAST-genomics/PangenomeAPI/issues/41) — real-input goldens *(ready-for-human)*.** The two skipped cases in
-  `generate-svg.golden.test.mjs` want documents for the fetch-ceiling regions. It is
-  human-labelled for three reasons that have not changed: it needs a decision about which
-  strand-naming convention is canonical, server access to recapture whichever side loses, and
-  a call on repository weight — a self-baselined fetch-ceiling document measures **~12 MB**.
 
-A cheaper third option exists and is *not* #41: self-baselining the two **small** real
-subgraphs — `chr8_78771162` at 0.16 MB and `chr1_25331046` at 2.61 MB — with the current
-pre-B generator. That pins B against real strand names and 8,000 bands without claiming
-anything about `pgb`'s documents, so it needs neither the decision nor the access. It does
-not close #41.
+- **[#41](https://github.com/CAST-genomics/PangenomeAPI/issues/41) — the fetch-ceiling regime *(ready-for-agent, blocked by #46)*.** The two
+  skipped cases in `generate-svg.golden.test.mjs` want the regime that actually fails to be
+  the regime under test. **This ticket was rewritten on 2026-08-28**; the version that asked
+  for a naming decision, server access and a 12 MB commit rested on two claims that were then
+  measured and found false.
+
+  What the measurement found: the committed 90 bp `.gfa` reproduces `pgb`'s golden **exactly**
+  — 291 paths, 726 rects, identical viewBox, identical strand names — once the #46 reorder is
+  taken out, which was added after that golden was captured. The naming difference across the
+  five goldens is `vg`'s own spelling (`sample#hap#contig#phaseblock`, plus a subrange for a
+  partial walk) seen at three different dates, not a convention anyone chose. Only two
+  fixtures genuinely mismatch, and it is the walk count that says so: 383 walks for 378
+  strands, and 1,201 for 464, against goldens from before `0f69615` allowed multiple walks per
+  assembly.
+
+  So the pin is **self-baselined band data in this repository**, which is what ADR 0001 makes
+  canonical anyway — no server access, no 12 MB, and no decision left to make. The full
+  measurement is in `tests/fixtures/seqtubemap/README.md` and in the comment on the issue.
+
+> **Do not reach for `perf/gfa-to-vg-json.mjs --names=bare`.** The old #41 offered it as the
+> lever for "restoring the older naming convention". On the 90 bp fixture the suffixed names
+> are the ones that match `pgb`'s golden character for character, so it would break a pair
+> that already works.
+
+`pgb`'s five goldens are not this repository's oracle and never were captured as one. They
+pin `pgb`'s parser, which is the job they were built for. What crosses the boundary is
+[#25](https://github.com/CAST-genomics/PangenomeAPI/issues/25)'s contract test.
 
 ---
 
@@ -313,6 +361,26 @@ correct wherever the upstream time lives.
 
 ---
 
+## Housekeeping — not an increment
+
+### [#45](https://github.com/CAST-genomics/PangenomeAPI/issues/45) — Strip the debug instrumentation *(ready-for-agent)*
+
+`0f69615` left debugging aids in the render path and they still run on every request: a
+`setInterval` memory logger in `generate-svg.mjs`, a `tracks[0].name` line in `render.mjs`,
+and a `t(label)` stage timer calling `process.memoryUsage()` at ~20 points through
+`createTubeMap`. `main.py` pipes the child's stderr into the server log, so all of it reaches
+production.
+
+The `[stage-timing]` line from [#16](https://github.com/CAST-genomics/PangenomeAPI/issues/16)
+already does this job properly, in one line per request, from the Python side. And
+`process.memoryUsage()` is a Node global in a file that is a declared fork of a *browser*
+library.
+
+Unblocked, touches no document, and `npm test` must stay byte-identical through it — if a
+golden moves, something else went with it.
+
+---
+
 ## Closed — do not reopen
 
 Each of these cost a grilling round. Reopening costs another.
@@ -345,6 +413,17 @@ shared vocabulary with the PCLAI chart and the 3D graph.
 - **Does anything depend on the intermediate `.gfa` / `.vg` / `.json` files existing on
   disk?** They are deleted after every response, which suggests purely internal. Confirm with
   Cici before [#27](https://github.com/CAST-genomics/PangenomeAPI/issues/27).
+- **Does `perf/gfa-to-vg-json.mjs` agree with real `vg view -j`?** It is now known *not* to,
+  in at least one way: `vg` appends a subrange to a path covering part of a contig
+  (`CHM13#0#chr8#0[9659985-9661740]` in `pgb`'s 1.4 kb golden) and the shim never does. The
+  `.gfa` is the source of truth and the shim is this repository's own derivation from it, so
+  baselines taken through it pin the layout but say nothing about the wire. Confirming it
+  needs somebody who can run `vg`, and it wants its own ticket.
+- **Does a reference strand lose its PCLAI colour in a subrange region?** `truncateTrackName`
+  keeps the first three `#`-fields, so a three-field name carrying a subrange —
+  `GRCh38#0#chr8[10078919-10080674]` — passes through with the bracket attached, and
+  `getPclaiEntry` uses it as the scheme lookup key. Found while measuring #46, not confirmed
+  against a live scheme.
 - **Two documents in `pgb` make a forward claim** — that
   [#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22) ships byte-compatible. Verified
   against the real regex and the real conformance gate, but describing code that does not exist

--- a/seqtubemap/band-data.mjs
+++ b/seqtubemap/band-data.mjs
@@ -32,6 +32,19 @@
 //             colour sits on the strand.
 //   segments  one entry per drawn segment box, in document order.
 //   document  the picture's dimensions, including the viewBox string.
+//
+// Strand ids are dense and positional. A strand's `id` is the position the
+// layout gave it (reorderTracksForLayout in tubemap.js), it reaches the client
+// as the document's `trackID`, and the client indexes tables by it: `pgb`'s
+// parseBands rejects the whole document with "trackID must run from 0 upward
+// with no gaps" if the set of ids is not exactly 0..n-1.
+//
+// Nothing about the layout guarantees that on its own. `createTubeMap` splices
+// hidden strands out of the array *after* ids are assigned, so a strand dropped
+// there would leave a hole, and the failure would surface in the other
+// repository as an unparseable document rather than here. `assertDenseStrandIds`
+// is what turns the accident into a checked invariant; see the test in
+// tests/node/band-data.test.mjs.
 
 // The margins the document is given around the layout's extent: 50 px of slack
 // on the width and height, and 20 px of headroom above the topmost shape.
@@ -130,11 +143,36 @@ export class BandCollector {
 
   /** Everything this render produced. Plain data - no DOM, no live references. */
   data() {
+    assertDenseStrandIds(this.strands);
     return {
       strands: this.strands,
       bands: this.bands,
       segments: this.segments,
       document: this.document,
     };
+  }
+}
+
+/**
+ * Throw unless the strand ids are exactly 0..n-1.
+ *
+ * Checked here rather than left to the client, because here the layout that
+ * produced the hole is still in scope: a document that fails this is one `pgb`
+ * refuses outright, and a failure in this repository names the cause.
+ *
+ * A strand may hold more than one row - a recolouring gives it a second - so it
+ * is the *set* of ids that must be dense, not the row count.
+ */
+export function assertDenseStrandIds(strands) {
+  const ids = new Set(strands.map((strand) => strand.id));
+  for (let id = 0; id < ids.size; id += 1) {
+    if (!ids.has(id)) {
+      const highest = Math.max(...ids);
+      throw new Error(
+        `strand ids must run from 0 upward with no gaps: ${ids.size} strands, ` +
+          `numbered up to ${highest}, with ${id} missing. ` +
+          "A strand was dropped after reorderTracksForLayout numbered it.",
+      );
+    }
   }
 }

--- a/seqtubemap/tubemap.js
+++ b/seqtubemap/tubemap.js
@@ -3970,22 +3970,110 @@ export function vgExtractTracks(vg, pathSourceTrackId, haplotypeSourceTrackID) {
   return result;
 }
 
-// Reorder tracks before layout so:
-//  1. GRCh38 is always first, CHM13 always second — these become the layout
-//     pivot/anchor in switchNodeOrientation() and generateNodeOrder(), so a
-//     full-length, consistent reference backbone keeps layout deterministic
-//     regardless of what order vg happens to emit paths in.
-//  2. All walks belonging to the same assembly+haplotype+contig (e.g. multiple
-//     W-line fragments of one contig) sit directly next to each other, so
-//     they get threaded into the layout against each other rather than
-//     against unrelated tracks in between.
-//  3. Everything else is ordered by total sequence length, longest first —
-//     a longer anchor produces fewer synthetic "no node" filler segments
-//     in generateLaneAssignment(), which is what drives shape-count blowup.
+// The `sample#haplotype#contig` triple that identifies a strand (CONTEXT.md),
+// recovered from whatever `vg` spelled the path.
+//
+// `vg` appends a phase block and a subrange of its own — a strand can arrive as
+// `HG00097#1#CM094064.1#0[9826071-9827826]`, and a reference contig as
+// `GRCh38#0#chr8[10078919-10080674]`, where the subrange rides on a three-field
+// name and so survives truncateTrackName(). Several W-line fragments of one
+// haplotype differ only in that tail, so the tail is exactly what has to come
+// off to see that they are one strand.
+function strandIdentity(name) {
+  if (!name) return "";
+  return name.split("#").slice(0, 3).join("#").split("[")[0];
+}
+
+// The strands the layout is arranged around, in the order it wants them.
+const PIVOT_SAMPLES = ["GRCh38", "CHM13"];
+
+// Reorder strands before layout so that:
+//
+//  1. GRCh38's walks come first and CHM13's second — by group, not by index: a
+//     reference contig can itself be fragmented, and GRCh38 occupies the first
+//     three positions in the 4.2 kb fixture. `createTubeMap` straightens `tracks[0]`
+//     and both switchNodeOrientation() and generateNodeOrder() arrange every
+//     other strand against it, so `tracks[0]` is the *pivot strand*
+//     (CONTEXT.md). Left to `vg`'s emission order the pivot is whichever strand
+//     happened to be written first, which means the picture a reader sees moves
+//     for reasons invisible in the data.
+//
+//  2. All walks of one strand sit together. A haplotype fragmented across the
+//     region arrives as several W lines — 1,201 walks for 464 strands in the
+//     4.2 kb fixture — and they lay out against each other rather than against
+//     unrelated strands in between.
+//
+//  3. Everything else runs by total sequence length, longest first: a longer
+//     anchor produces fewer synthetic "no node" filler segments in
+//     generateLaneAssignment(), which is what drives shape-count blowup.
+//
+//  4. Ties break on identity, not on arrival, and the walks *within* a strand
+//     run in graph order rather than arrival order. Length alone leaves the
+//     order of equal-length strands decided by `vg` — which is the
+//     non-determinism (1) exists to remove, and in a region where GRCh38 is
+//     merely *tied* for longest it is what decides whether GRCh38 is the pivot
+//     at all. Together these make the whole order a function of the subgraph,
+//     so the same subgraph lays out identically however `vg` emitted it.
+//
+// Ids are reassigned to the new positions, and this is load-bearing beyond
+// layout: a strand id reaches the client as the document's `trackID`, and the
+// client requires those to run from 0 upward with no gaps. See the invariant
+// note in band-data.mjs.
+//
+// The strand objects are the caller's, and their `id` is written in place.
 export function reorderTracksForLayout(tracks) {
-  const sorted = [...tracks].sort((a, b) => b.sequence.length - a.sequence.length);
+  const groups = new Map();
+  for (const track of tracks) {
+    const identity = strandIdentity(track.name);
+    let group = groups.get(identity);
+    if (group === undefined) {
+      group = { identity, sample: identity.split("#")[0], length: 0, tracks: [] };
+      groups.set(identity, group);
+    }
+    group.tracks.push(track);
+    group.length += track.sequence.length;
+  }
+
+  // Samples the layout wants up front sort ahead of everything else, in the
+  // order they are listed; every other sample shares the rank after them.
+  const rank = (group) => {
+    const at = PIVOT_SAMPLES.indexOf(group.sample);
+    return at === -1 ? PIVOT_SAMPLES.length : at;
+  };
+
+  const ordered = [...groups.values()].sort(
+    (a, b) =>
+      rank(a) - rank(b) ||
+      b.length - a.length ||
+      compareText(a.identity, b.identity),
+  );
+
+  // Within a strand, its walks run in graph order: the fragments of one contig
+  // enter the layout the way they lie along the graph, not the way `vg` listed
+  // them. Segment ids ascend along the reference in these graphs, so the first
+  // segment orders the fragments; the whole visit is the tiebreak, because two
+  // fragments starting at one segment still have to have an order.
+  const sorted = ordered.flatMap((group) =>
+    group.tracks.length === 1
+      ? group.tracks
+      : [...group.tracks].sort(
+          (a, b) =>
+            firstSegment(a) - firstSegment(b) ||
+            compareText(a.sequence.join(","), b.sequence.join(",")),
+        ),
+  );
   sorted.forEach((track, i) => { track.id = i; });
   return sorted;
+}
+
+/** The id of the first segment a strand visits, as a number to sort by. */
+function firstSegment(track) {
+  return Number(forward(track.sequence[0]));
+}
+
+/** A total order on two strings, so that a sort using it never has to fall through. */
+function compareText(a, b) {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 // remove redundant nodes

--- a/tests/fixtures/seqtubemap/README.md
+++ b/tests/fixtures/seqtubemap/README.md
@@ -6,8 +6,15 @@ document in `src/tubemap/__tests__/fixtures/`.
 
 Until these landed, those golden documents pinned only the client side: `pgb` could check
 that its parser read a tube map correctly, but nothing could check that this repository
-produced that tube map in the first place. With the inputs committed, the pair becomes an
-end-to-end fixture — feed the `.gfa` in, expect the golden document out.
+produced that tube map in the first place.
+
+They were committed in the hope that the pair would become an end-to-end fixture — feed
+the `.gfa` in, expect the golden document out. That is not what they turned out to be, and
+the reason is worth reading before relying on them: see
+[How these relate to `pgb`'s golden documents](#how-these-relate-to-pgbs-golden-documents--checked-2026-08-28)
+below. The short version is that the inputs are sound and the goldens are snapshots of
+three different states of this pipeline, so the pin that runs in CI is self-baselined here
+rather than borrowed from the other repository.
 
 ## Provenance
 
@@ -104,34 +111,79 @@ across all five. Every walk's node ids resolve into the node set. For the 90 bp 
 464 strand names the layout emits are identical — as a set — to the 464 in its golden
 document.
 
-**What is not.** Nobody has diffed these against real `vg view -j` output, because nobody
-here can run `vg`. Treat them as a development convenience, not as the wire truth, until
-somebody with the binary confirms them.
+**What is not — and one place they are now known to differ.** Nobody has diffed these
+against real `vg view -j` output, because nobody here can run `vg`. One difference is
+already visible without running it: `vg` appends a subrange to a path that covers part of
+a contig, which is why `pgb`'s 1.4 kb golden carries
+`CHM13#0#chr8#0[9659985-9661740]`. This script never emits a subrange, and the `N` in its
+`--names=fragment` form is a fragment counter it invents rather than `vg`'s phase block.
+The two coincide on the fixtures whose walks are unfragmented, and that is luck rather than
+agreement.
 
-## Two conventions — the goldens disagree with each other
+So: a development convenience, not the wire truth. Anything asserting a cross-repo contract
+should run on `.json` a real `vg` produced.
 
-While checking the naming above, the five golden documents in `pgb` turned out **not to be
-one homogeneous set**:
+## How these relate to `pgb`'s golden documents — checked, 2026-08-28
 
-| golden | strand names | form |
-| --- | ---: | --- |
-| `stm-chr8-78771162-78771252.svg` (90 bp) | 463 of 464 suffixed | `sample#hap#contig#N` |
-| the other four | 0 suffixed | `sample#hap#contig` |
+An earlier version of this file claimed the five golden documents disagreed with each
+other about strand naming, and that the 90 bp golden's graph carried "about two more
+segments per strand" than the `.gfa` here. **Both claims were wrong**, and issue #41 was
+written on top of them. What follows is what a measurement found instead.
 
-The suffixed form is the newer one — it is what "allow multiple walks per asm" (`0f69615`)
-produces, and the 90 bp document is the most recently captured. So four of the five goldens
-predate a change in how this pipeline names strands.
+**The 90 bp pair matches.** Rendering the committed 90 bp `.gfa` with
+`reorderTracksForLayout` disabled — the state of the layout on the day the golden was
+captured — reproduces the golden exactly where it counts:
 
-The geometry differs too, and by more than naming. Rendering the 90 bp fixture through
-`generate-svg.mjs` gives 82 `<path>` and 517 `<rect>` against the golden's 291 and 726, and
-a viewBox 3,795 wide against 4,717 — the golden's graph carries about two more segments per
-strand than the `.gfa` committed here for the same region does.
+| | this fixture | `pgb`'s golden |
+| --- | ---: | ---: |
+| `<path>` | 291 | 291 |
+| `<rect>` | 726 | 726 |
+| viewBox | `0 -95 4717.4285714285725 7115` | `0 -95 4717.4285714285725 7115` |
 
-**This matters for increment B**, which plans to use these pairs as an end-to-end oracle:
-feed the `.gfa` in, expect the golden out. That does not hold today for the pair anyone
-would reach for first. Either the goldens need recapturing from the current server, or the
-`.gfa` inputs do. `perf/gfa-to-vg-json.mjs --names=bare` reproduces the older naming if the
-older documents turn out to be the ones worth keeping.
+The two documents share their first 210 bytes, and the strand name at the first
+divergence is identical on both sides (`NA21309#2#CM092102.1#0`). The divergence itself is
+a *colour*: the golden was captured with a PCLAI colour scheme (129 distinct fills, 92
+grey fallbacks) which is not committed here. So the input, the graph, the geometry and the
+naming all agree; only the third input to a render is missing.
+
+**The naming difference was never a convention split.** `vg` names a W-line path
+`sample#hap#contig#phaseblock`, and appends a subrange when the walk covers part of a
+contig. All three forms in the goldens are that one rule seen at different times:
+
+| golden | committed | example name |
+| --- | --- | --- |
+| 600 bp, node 5514, node 5520 | Aug 17, Aug 20 | `HG00097#1#CM094060.1` |
+| 90 bp | Aug 18 | `HG00097#1#CM094064.1#0` |
+| chr8 1.4 kb | Aug 25 | `CHM13#0#chr8#0[9659985-9661740]` |
+
+`truncateTrackName` used to strip the tail inside `vgExtractTracks` and no longer does
+(`0f69615`). The wire now carries `vg`'s spelling verbatim and the codebase truncates only
+where it looks something up — see **strand** in [`CONTEXT.md`](../../../CONTEXT.md).
+**Do not reach for `perf/gfa-to-vg-json.mjs --names=bare` to "fix" this.** On the 90 bp
+fixture the suffixed names are the ones that match; bare names would break a pair that
+works.
+
+**Two fixtures genuinely do not match their goldens**, and it is the walk count that says
+so, not the naming:
+
+| fixture | `W` lines | strands | golden's strands |
+| --- | ---: | ---: | ---: |
+| chr8 90 bp | 464 | 464 | 464 |
+| chr1 600 bp | 369 | 369 | 369 |
+| chr8 1.4 kb | 463 | 463 | 463 |
+| **chr1 8.0 kb** (node 5514) | **383** | 378 | 378 |
+| **chr1 4.2 kb** (node 5520) | **1201** | 464 | 464 |
+
+The last two carry `0f69615`'s multiple-walks-per-assembly output; their goldens come from
+the one-walk-per-assembly era that preceded it. Those are the two whose tests are skipped
+in `tests/node/generate-svg.golden.test.mjs`.
+
+**These goldens are not this repository's oracle.** They were captured from `pgb`, at
+various dates, from at least three different states of this pipeline — and
+`docs/adr/0001-additive-band-format.md` makes the band data canonical and the document
+derived. The table above is a dated cross-check that the two repositories agreed at a
+point in time, which is the useful thing a captured document can say. The pin that runs in
+CI is self-baselined band data in this repository. See #41.
 
 ## A note on `.gitignore`
 

--- a/tests/node/reorder-tracks.test.mjs
+++ b/tests/node/reorder-tracks.test.mjs
@@ -1,0 +1,164 @@
+// The order the layout arranges strands in, and the invariant that order carries.
+//
+// `reorderTracksForLayout` decides which strand becomes the **pivot strand**
+// (CONTEXT.md) — `createTubeMap` straightens `tracks[0]` and orients everything
+// else against it — so this function decides the arrangement of every picture
+// /seqtubemap returns. Before this file existed it was a one-line sort by
+// sequence length whose comment claimed three properties it did not implement:
+// GRCh38 landed first only when it happened to tie for longest and a stable sort
+// happened to keep it there, and CHM13 landed at index 455 of 464.
+//
+// It also renumbers the strands, and that renumbering is a cross-repo contract:
+// the ids reach `pgb` as the document's `trackID`, and `pgb` rejects a document
+// whose ids are not dense. The last test here is the one that fails on this side
+// rather than in the other repository.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { assertDenseStrandIds } from "../../seqtubemap/band-data.mjs";
+import { repoRoot } from "./golden-cases.mjs";
+
+const fixtureDir = join(repoRoot, "tests", "fixtures", "seqtubemap");
+
+/**
+ * The layout, loaded the way `render.mjs` loads it: config first, then a window,
+ * and only then the module. Nothing here renders — the reorder is pure — but
+ * `tubemap.js` reaches for both at import time.
+ */
+async function layout() {
+  const { JSDOM } = await import("jsdom");
+  globalThis["__sequence_tube_map_config"] ??= {
+    defaultHaplotypeColorPalette: { mainPalette: "reds", auxPalette: "blues" },
+    defaultReadColorPalette: { mainPalette: "reds", auxPalette: "blues" },
+    defaultGraphColorPalette: { mainPalette: "reds", auxPalette: "blues" },
+    nodeIntervalThreshold: 150,
+    coloredNodes: [],
+    DATA_SOURCES: [],
+    BACKEND_URL: "",
+  };
+  if (!globalThis.window) {
+    const dom = new JSDOM(`<!DOCTYPE html><body><svg id="mysvg"></svg></body>`);
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+  }
+  return import("../../seqtubemap/tubemap.js");
+}
+
+/** Every committed real subgraph, as the strands the layout would be handed. */
+async function realSubgraphs() {
+  const { vgExtractTracks } = await layout();
+  return readdirSync(fixtureDir)
+    .filter((name) => name.endsWith(".json"))
+    .map((name) => ({
+      name: name.replace(/^subgraph_|_v2_with_walk\.json$/g, ""),
+      strands: vgExtractTracks(JSON.parse(readFileSync(join(fixtureDir, name), "utf8")), 0, 1),
+    }));
+}
+
+/** The `sample#haplotype#contig` triple, which is the whole of a strand's identity. */
+function identity(name) {
+  return name.split("#").slice(0, 3).join("#").split("[")[0];
+}
+
+/** One strand per walk, in the shape the reorder reads. */
+function strandsNamed(...names) {
+  return names.map((name, index) => ({ id: index, name, sequence: new Array(name.length).fill("1") }));
+}
+
+test("GRCh38 is the pivot strand, whatever order vg emitted", async () => {
+  const { reorderTracksForLayout } = await layout();
+  for (const { name, strands } of await realSubgraphs()) {
+    const ordered = reorderTracksForLayout(strands);
+    assert.ok(ordered[0].name.startsWith("GRCh38#"), `${name} pivots on ${ordered[0].name}`);
+  }
+});
+
+test("GRCh38 pivots even when it is not the longest strand", async () => {
+  // The regression the old sort could not survive: length alone made the pivot a
+  // matter of which strand vg wrote first among the equal-longest, and a shorter
+  // GRCh38 lost outright.
+  const { reorderTracksForLayout } = await layout();
+  const ordered = reorderTracksForLayout(
+    strandsNamed("HG00097#1#CM094064.1#0", "NA21309#2#CM092102.1#0", "GRCh38#0#chr8"),
+  );
+  assert.equal(ordered[0].name, "GRCh38#0#chr8");
+  assert.deepEqual(
+    ordered.slice(1).map((strand) => strand.name),
+    ["HG00097#1#CM094064.1#0", "NA21309#2#CM092102.1#0"],
+  );
+});
+
+test("CHM13's walks follow GRCh38's, both grouped rather than interleaved", async () => {
+  const { reorderTracksForLayout } = await layout();
+  for (const { name, strands } of await realSubgraphs()) {
+    const ordered = reorderTracksForLayout(strands).map((strand) => identity(strand.name));
+    const reference = ordered.filter((id) => id.startsWith("GRCh38#") || id.startsWith("CHM13#"));
+    // The references occupy the front of the list, GRCh38's walks then CHM13's.
+    assert.deepEqual(ordered.slice(0, reference.length), reference, `${name} interleaves the references`);
+    const firstChm13 = reference.findIndex((id) => id.startsWith("CHM13#"));
+    assert.ok(firstChm13 > 0, `${name} has no CHM13 after GRCh38`);
+    assert.ok(
+      reference.slice(0, firstChm13).every((id) => id.startsWith("GRCh38#")),
+      `${name} puts CHM13 before a GRCh38 walk`,
+    );
+  }
+});
+
+test("every walk of one strand sits with the rest of that strand", async () => {
+  // A haplotype fragmented across the region arrives as several W lines — 1,201
+  // walks for 464 strands in the 4.2 kb fixture. They lay out against each other
+  // only if they are adjacent.
+  const { reorderTracksForLayout } = await layout();
+  for (const { name, strands } of await realSubgraphs()) {
+    const ordered = reorderTracksForLayout(strands).map((strand) => identity(strand.name));
+    const started = new Set();
+    let current = null;
+    for (const id of ordered) {
+      if (id === current) continue;
+      assert.ok(!started.has(id), `${name} resumes ${id} after leaving it`);
+      started.add(id);
+      current = id;
+    }
+  }
+});
+
+test("the order does not depend on the order vg emitted", async () => {
+  // The property the old sort claimed and did not have. Reversing the input is
+  // enough to show it: under a stable sort by length alone, every tie flips.
+  const { reorderTracksForLayout } = await layout();
+  for (const { name, strands } of await realSubgraphs()) {
+    const forwards = reorderTracksForLayout([...strands]).map((strand) => strand.name);
+    const backwards = reorderTracksForLayout([...strands].reverse()).map((strand) => strand.name);
+    assert.deepEqual(backwards, forwards, `${name} lays out differently when vg emits in another order`);
+  }
+});
+
+test("strand ids are renumbered dense from zero", async () => {
+  // `pgb` indexes its tables by trackID and rejects a document whose ids have a
+  // gap, so this is the wire contract, not an implementation detail.
+  const { reorderTracksForLayout } = await layout();
+  for (const { name, strands } of await realSubgraphs()) {
+    const ordered = reorderTracksForLayout(strands);
+    assert.deepEqual(
+      ordered.map((strand) => strand.id),
+      ordered.map((_, index) => index),
+      `${name} numbers its strands with a gap`,
+    );
+  }
+});
+
+test("band data refuses to report a strand table with a hole in it", () => {
+  // `createTubeMap` splices hidden strands out *after* the reorder numbered
+  // them. Nothing sets `hidden` in this pipeline today, so the guard is what
+  // makes a future one fail here rather than in `pgb`.
+  assert.doesNotThrow(() => assertDenseStrandIds([{ id: 0 }, { id: 1 }, { id: 2 }]));
+  // A recoloured strand contributes a second row, so it is the set of ids that
+  // must be dense and not the row count.
+  assert.doesNotThrow(() => assertDenseStrandIds([{ id: 0 }, { id: 0 }, { id: 1 }]));
+  assert.throws(
+    () => assertDenseStrandIds([{ id: 0 }, { id: 2 }]),
+    /must run from 0 upward with no gaps: 2 strands, numbered up to 2, with 1 missing/,
+  );
+});


### PR DESCRIPTION
Closes #46.

`reorderTracksForLayout` arrived with a three-point comment and a one-line body implementing one of the three. Only the length sort was there — so GRCh38 led the list by a stable-sort accident, and CHM13 landed at index 455 of 464. Since `tracks[0]` **is** the pivot strand (`CONTEXT.md`) — the one `createTubeMap` straightens and orients every other strand against — the determinism the comment promised was exactly the property the function did not have.

## What changed

- GRCh38's walks come first and CHM13's second, **by group** rather than by index: a reference contig can itself be fragmented, and GRCh38 occupies the first three positions in the 4.2 kb fixture.
- All walks of one strand sit together, keyed on the `sample#haplotype#contig` triple with `vg`'s phase-block and subrange tail stripped.
- The rest run by total sequence length, longest first.
- Every tie breaks on something in the data, including the order of walks *within* one strand, so the same subgraph lays out identically however `vg` emitted it.
- `assertDenseStrandIds` makes the strand-id renumbering a checked invariant here. Those ids reach `pgb` as the document's `trackID` and `pgb` rejects a document whose ids are not dense; `createTubeMap` splices hidden strands out *after* numbering, so a future filter there would produce a hole. It now fails in this repository rather than as an unparseable document in the other one.
- `CONTEXT.md` carries **pivot strand** as a term, and sharpens **strand** to say the triple is the whole of a strand's identity.

## Measured cost

The fix costs shapes, and the ticket's premise that the length-sort win "is real and worth keeping" does not survive contact:

| fixture | before | after |
| --- | --- | --- |
| chr8 90 bp | 590 bands | 592 |
| chr8 1.4 kb | 11,586 | 13,246 |
| chr1 4.2 kb | 34,937 | 44,795 |

Grouping and the pivot-first constraint claw back most of what the length sort bought. Determinism was the point — a picture that moves for reasons invisible in the data is worse than a larger one — but #41 should baseline against these numbers rather than the smaller ones its rewrite assumes.

## Tests

New `tests/node/reorder-tracks.test.mjs`, run against all five committed real subgraphs: GRCh38 pivots everywhere; GRCh38 pivots even when it is not longest; the references are grouped and ordered; every walk of a strand is adjacent to the rest; reversing the input does not change the output; ids are dense from zero; and the dense-id guard rejects a hole. Full suite green — 37 pass, 0 fail, 3 pre-existing skips.

## Known edges

- The determinism test reverses the input. Reversal flips every tie under a stable sort, which catches this bug, but a seeded shuffle would be a stronger proof.
- `strandIdentity` strips `vg`'s subrange bracket; no committed fixture carries one (0 of 1,201 names in the 4.2 kb fixture), so that path is correct but unexercised. `truncateTrackName` still has the bracket bug the ticket lists as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)