### PR TITLE
Bring the roadmap's status in line with what has merged

### DIFF
--- a/docs/seqtubemap-roadmap.md
+++ b/docs/seqtubemap-roadmap.md
@@ -29,8 +29,7 @@ Phase 0 and increment **A** are merged. **B** is half done.
 
 | | |
 | --- | --- |
-| Merged | [#14](https://github.com/CAST-genomics/PangenomeAPI/issues/14), [#15](https://github.com/CAST-genomics/PangenomeAPI/issues/15), [#16](https://github.com/CAST-genomics/PangenomeAPI/issues/16), [#17](https://github.com/CAST-genomics/PangenomeAPI/issues/17), [#18](https://github.com/CAST-genomics/PangenomeAPI/issues/18), [#19](https://github.com/CAST-genomics/PangenomeAPI/issues/19), [#20](https://github.com/CAST-genomics/PangenomeAPI/issues/20), [#21](https://github.com/CAST-genomics/PangenomeAPI/issues/21) |
-| On `fix/reorder-tracks-pivot-strand`, not yet merged | [#46](https://github.com/CAST-genomics/PangenomeAPI/issues/46), [#41](https://github.com/CAST-genomics/PangenomeAPI/issues/41) |
+| Merged | [#14](https://github.com/CAST-genomics/PangenomeAPI/issues/14), [#15](https://github.com/CAST-genomics/PangenomeAPI/issues/15), [#16](https://github.com/CAST-genomics/PangenomeAPI/issues/16), [#17](https://github.com/CAST-genomics/PangenomeAPI/issues/17), [#18](https://github.com/CAST-genomics/PangenomeAPI/issues/18), [#19](https://github.com/CAST-genomics/PangenomeAPI/issues/19), [#20](https://github.com/CAST-genomics/PangenomeAPI/issues/20), [#21](https://github.com/CAST-genomics/PangenomeAPI/issues/21), [#46](https://github.com/CAST-genomics/PangenomeAPI/issues/46), [#41](https://github.com/CAST-genomics/PangenomeAPI/issues/41) |
 | Frontier | **[#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22)** — its only blocker, #21, is closed |
 | Live | **Nothing.** The server follows `release`, so merging is not shipping; `git log release..main` is what is waiting |
 | Coverage gaps worth closing first | [#40](https://github.com/CAST-genomics/PangenomeAPI/issues/40) *(agent)* — see *Before #22* below |
@@ -246,7 +245,7 @@ which is how #46 sat undetected. They cover the mechanism; they do not cover the
 Three gaps, all ticketed — and the order among them matters, because one of them moves the
 documents the other two would baseline.
 
-- **[#46](https://github.com/CAST-genomics/PangenomeAPI/issues/46) — the reorder is wrong *(landed on `fix/reorder-tracks-pivot-strand`)*.**
+- **[#46](https://github.com/CAST-genomics/PangenomeAPI/issues/46) — the reorder is wrong *(merged, PR #47)*.**
   `reorderTracksForLayout` arrived in `0f69615` inside a commit about walk generation, with a
   three-point comment and a one-line body implementing one of the three. It decides which
   strand is the **pivot strand** — `createTubeMap` straightens `tracks[0]` and orients
@@ -263,7 +262,7 @@ documents the other two would baseline.
   whenever `minigraphnode` is set — produces output nothing pins. #21 added band-data coverage
   for it, not a golden document. Small, mechanical, and it closes a real hole under B.
 
-- **[#41](https://github.com/CAST-genomics/PangenomeAPI/issues/41) — the fetch-ceiling regime *(landed on `fix/reorder-tracks-pivot-strand`)*.** The two
+- **[#41](https://github.com/CAST-genomics/PangenomeAPI/issues/41) — the fetch-ceiling regime *(merged, PR #48)*.** The two
   skipped cases in `generate-svg.golden.test.mjs` wanted the regime that actually fails to be
   the regime under test. **This ticket was rewritten on 2026-08-28**; the version that asked
   for a naming decision, server access and a 12 MB commit rested on two claims that were then


### PR DESCRIPTION
Follow-up to #48. Docs only.

#46 and #41 are on `main` via PRs #47 and #48, but the roadmap still listed them under "On `fix/reorder-tracks-pivot-strand`, not yet merged" and named that branch — which is now deleted — in two more places. I wrote that status before the merges and did not revisit it after.

They move to the **Merged** row, and the two bullets cite the PR that carried each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)