### PR TITLE
Ignore the .idea/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ __pycache__
 # OSX
 *.DS_Store*
 
+# editors
+.idea/
+
 # directory
 cache/
 extract_svg/


### PR DESCRIPTION
JetBrains IDEs write `.idea/` into the working tree, where it has been showing up as untracked noise in every `git status` during this work.

One line, in a new `# editors` group next to the OSX one. Deliberately **not** accompanied by `.vscode/` — nobody has hit that here, and this is the entry that was actually in the way.

## Care taken with placement

`.gitignore` has a load-bearing ordering property, called out in its own comment: `!tests/fixtures/**` must stay the last rule matching a fixture path, because `*.JSON*` and `*.svg*` above it would otherwise swallow the committed fixtures on a case-insensitive filesystem. The new entry goes well above that exemption and cannot match a path under `tests/fixtures/`.

Verified before and after:

- `.idea/` is now ignored
- the `.gfa`, `.svg` and `.json` fixtures under `tests/fixtures/` are still un-ignored and addable
- `git ls-files -i -c` returns an identical list either side of the change, so no already-tracked file becomes ignored

(That list is non-empty both before and after — `package.json` and friends match `*.JSON*` case-insensitively on macOS — but it is pre-existing and untouched by this.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)