### PR TITLE
Record the local endpoint harness, and check the documents against pgb's real parser

### DIFF
--- a/docs/perf/increment-b.md
+++ b/docs/perf/increment-b.md
@@ -154,6 +154,39 @@ unchanged.
 The reductions are ~14% rather than ~16.6% because these requests carry no `minigraphnode`, so
 every PCLAI attribute is the short literal `None`.
 
+## Checked against `pgb`'s own parser
+
+Everything above tests the document against *this* repository's statement of what `pgb`
+requires. On 2026-08-28 that statement was replaced by the real thing: `pgb` is checked out
+alongside, and `src/tubemap/parseBands.ts` and `parseSegmentBoxes.ts` were run directly over
+the five real subgraphs rendered by both the pre- and post-#22 code.
+
+**All five accepted, before and after.** And more than accepted — `pgb` recovers *bit-identical
+arrays* from the two sides:
+
+| fixture | bands | strands | geometry floats | recovered arrays |
+| --- | ---: | ---: | ---: | --- |
+| chr8 90 bp | 592 | 464 | 3,552 | identical |
+| chr1 600 bp | 8,089 | 369 | 48,534 | identical |
+| chr8 1.4 kb | 13,246 | 463 | 79,476 | identical |
+| chr1 8.0 kb | 35,020 | 383 | 210,120 | identical |
+| chr1 4.2 kb | 44,795 | 1,201 | 268,770 | identical |
+
+Compared element by element: `geometry`, `strandIds`, `bandDirections`, `bandCount`,
+`strandColors`, `strandNames`, `strandPlacements`, `strandScores`, `strandCount`, `content`,
+`centre`, and the segment boxes from `parseSegmentBoxes`. This is the bar the roadmap names as
+the strongest available — *"run the client's own parser over before and after, and diff the
+recovered arrays"* — met with the client's own code rather than a description of it.
+
+Two things came out of reading that parser, both recorded rather than acted on here:
+
+- `tests/node/pgb-parser.mjs` **was looser than the real gate** and has been tightened to
+  match. It had made `fill-opacity` and `trackName` optional; `pgb` requires both, literally.
+- A reversal draws shapes `pgb` cannot read at all, and its whole-document gate then refuses
+  the document rather than degrading it. Latent — no committed fixture draws a corner — and it
+  predates #22 in both directions. Filed as
+  [#52](https://github.com/CAST-genomics/PangenomeAPI/issues/52).
+
 ## What was not measured
 
 The endpoint on the server. `generate_svg` is 8.2 s of a 38.9 s 10 kb request there, against a

--- a/docs/perf/increment-b.md
+++ b/docs/perf/increment-b.md
@@ -130,9 +130,33 @@ What changed is what happens on a host that resolves the font differently, which
 mode had no golden before. It has one now: `small-normal.svg`, the only golden that carries
 segment labels and the finer 20 bp ruler.
 
+## Over HTTP, through the real endpoint
+
+Everything above is measured below HTTP. The same before-and-after was then run through two
+isolated API instances on ports 8100 and 8101 — real FastAPI handler, real caching branch,
+real Node subprocess — serving the five committed subgraphs. The method, and the one stand-in
+that limits what it proves, are in
+[`local-endpoint-harness.md`](./local-endpoint-harness.md).
+
+| region | TTFB before | TTFB after | speedup | bytes before | bytes after | change |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 90 bp | 0.646 s | **0.213 s** | 3.0× | 166,675 | 138,340 | −17.0% |
+| 600 bp | 0.982 s | **0.278 s** | 3.5× | 2,738,884 | 2,352,410 | −14.1% |
+| 1.4 kb | 1.226 s | **0.331 s** | 3.7× | 4,391,887 | 3,757,885 | −14.4% |
+| 8.0 kb | 2.376 s | **0.735 s** | 3.2× | 12,090,267 | 10,408,507 | −13.9% |
+| 4.2 kb | 2.561 s | **0.589 s** | 4.3× | 15,285,418 | 13,122,049 | −14.2% |
+
+All five response bodies are byte-identical to the pre-#22 ones once the three removals are
+deleted, with unchanged drawable counts, and all five satisfy `pgb`'s parsing contract. The
+endpoint's own stage timer puts the whole saving in `generate_svg` — every other stage is
+unchanged.
+
+The reductions are ~14% rather than ~16.6% because these requests carry no `minigraphnode`, so
+every PCLAI attribute is the short literal `None`.
+
 ## What was not measured
 
-The endpoint end to end. `generate_svg` is 8.2 s of a 38.9 s 10 kb request on the server, and
-what changed here is the part of it that is not layout; confirming the request-level number
-needs a deploy, and `release..main` is where that queue lives
+The endpoint on the server. `generate_svg` is 8.2 s of a 38.9 s 10 kb request there, against a
+graph this machine does not have and through a `vg` this machine cannot run; confirming the
+production number needs a deploy, and `release..main` is where that queue lives
 ([`releasing.md`](../releasing.md)).

--- a/docs/perf/local-endpoint-harness.html
+++ b/docs/perf/local-endpoint-harness.html
@@ -1,0 +1,894 @@
+<title>The 8100/8101 Harness</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Serif:ital,wght@0,400;0,600;1,400&display=swap">
+
+<style>
+  :root {
+    --paper:      #F4F5F2;
+    --surface:    #FFFFFF;
+    --sunk:       #EBEDE8;
+    --ink:        #12171C;
+    --ink-soft:   #4A5560;
+    --ink-faint:  #6E7A85;
+    --rule:       #D6DAD3;
+    --rule-firm:  #B9BFB6;
+
+    --after:      #0B6B63;
+    --after-wash: #DDECEA;
+    --before:     #9C5236;
+    --before-wash:#F2E4DC;
+    --caution:    #8A6210;
+    --caution-wash:#F4EBD6;
+
+    --shadow: 0 1px 2px rgba(18, 23, 28, .05), 0 8px 24px -16px rgba(18, 23, 28, .25);
+
+    --measure: 68ch;
+    --step--1: clamp(.80rem, .78rem + .1vw, .86rem);
+    --step-0:  clamp(1.0rem, .97rem + .15vw, 1.09rem);
+    --step-1:  clamp(1.19rem, 1.1rem + .4vw, 1.4rem);
+    --step-2:  clamp(1.5rem, 1.3rem + .9vw, 2.05rem);
+    --step-3:  clamp(2.0rem, 1.6rem + 1.9vw, 3.1rem);
+
+    --sans:  "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif;
+    --serif: "IBM Plex Serif", ui-serif, Georgia, Cambria, serif;
+    --mono:  "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --paper:      #0E1317;
+      --surface:    #161C22;
+      --sunk:       #1B2229;
+      --ink:        #E6EAE6;
+      --ink-soft:   #A9B4BC;
+      --ink-faint:  #808D96;
+      --rule:       #2A333B;
+      --rule-firm:  #3D4851;
+
+      --after:      #48B7AA;
+      --after-wash: #14312F;
+      --before:     #D08E6C;
+      --before-wash:#33211A;
+      --caution:    #D6A93F;
+      --caution-wash:#312712;
+
+      --shadow: 0 1px 2px rgba(0, 0, 0, .4), 0 10px 30px -18px rgba(0, 0, 0, .8);
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --paper:      #0E1317;
+    --surface:    #161C22;
+    --sunk:       #1B2229;
+    --ink:        #E6EAE6;
+    --ink-soft:   #A9B4BC;
+    --ink-faint:  #808D96;
+    --rule:       #2A333B;
+    --rule-firm:  #3D4851;
+
+    --after:      #48B7AA;
+    --after-wash: #14312F;
+    --before:     #D08E6C;
+    --before-wash:#33211A;
+    --caution:    #D6A93F;
+    --caution-wash:#312712;
+
+    --shadow: 0 1px 2px rgba(0, 0, 0, .4), 0 10px 30px -18px rgba(0, 0, 0, .8);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--serif);
+    font-size: var(--step-0);
+    line-height: 1.62;
+    margin: 0;
+    padding: 0 1.5rem 6rem;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 78rem; margin: 0 auto; }
+  .col  { max-width: var(--measure); }
+
+  /* ---------- masthead ---------- */
+
+  .masthead {
+    border-bottom: 2px solid var(--ink);
+    padding: 4.5rem 0 2rem;
+    margin-bottom: 3rem;
+  }
+  .kicker {
+    font-family: var(--mono);
+    font-size: var(--step--1);
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem 1.25rem;
+    margin: 0 0 1.5rem;
+  }
+  .kicker b { color: var(--after); font-weight: 500; }
+  h1 {
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: var(--step-3);
+    line-height: 1.02;
+    letter-spacing: -.025em;
+    text-wrap: balance;
+    margin: 0 0 1.25rem;
+    max-width: 20ch;
+  }
+  .standfirst {
+    font-size: var(--step-1);
+    line-height: 1.5;
+    color: var(--ink-soft);
+    max-width: 58ch;
+    margin: 0;
+  }
+  .standfirst em { color: var(--ink); font-style: italic; }
+
+  /* ---------- the safety banner ---------- */
+
+  .banner {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 1.25rem;
+    align-items: start;
+    background: var(--after-wash);
+    border-left: 3px solid var(--after);
+    padding: 1.25rem 1.5rem;
+    margin: 2.5rem 0 0;
+    border-radius: 2px;
+  }
+  .banner .tag {
+    font-family: var(--mono);
+    font-size: var(--step--1);
+    font-weight: 600;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--after);
+    white-space: nowrap;
+    padding-top: .15rem;
+  }
+  .banner p { margin: 0; font-size: var(--step--1); line-height: 1.6; color: var(--ink-soft); font-family: var(--sans); }
+  .banner p + p { margin-top: .5rem; }
+
+  /* ---------- sections ---------- */
+
+  section { margin-top: 4rem; }
+  .sec-head {
+    display: grid;
+    grid-template-columns: 3.25rem 1fr;
+    gap: 0 1rem;
+    align-items: baseline;
+    border-top: 1px solid var(--rule-firm);
+    padding-top: 1rem;
+    margin-bottom: 1.75rem;
+  }
+  .sec-num {
+    font-family: var(--mono);
+    font-size: var(--step--1);
+    font-weight: 600;
+    color: var(--after);
+    font-variant-numeric: tabular-nums;
+  }
+  h2 {
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: var(--step-2);
+    line-height: 1.12;
+    letter-spacing: -.02em;
+    text-wrap: balance;
+    margin: 0;
+    max-width: 26ch;
+  }
+  h3 {
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: var(--step-1);
+    line-height: 1.25;
+    letter-spacing: -.01em;
+    text-wrap: balance;
+    margin: 2.5rem 0 .75rem;
+  }
+  .sec-body { display: flex; flex-direction: column; gap: 1.1rem; }
+  .sec-body > * { margin: 0; }
+  p { max-width: var(--measure); }
+  strong { font-weight: 600; }
+  em { font-style: italic; }
+
+  a { color: var(--after); text-decoration-thickness: 1px; text-underline-offset: .18em; }
+  a:hover { text-decoration-thickness: 2px; }
+  a:focus-visible { outline: 2px solid var(--after); outline-offset: 3px; border-radius: 2px; }
+
+  code {
+    font-family: var(--mono);
+    font-size: .88em;
+    background: var(--sunk);
+    padding: .12em .38em;
+    border-radius: 3px;
+    overflow-wrap: anywhere;
+  }
+
+  ul { max-width: var(--measure); margin: 0; padding-left: 1.15rem; display: flex; flex-direction: column; gap: .5rem; }
+  li::marker { color: var(--ink-faint); }
+
+  /* ---------- the two-instance diagram ---------- */
+
+  .rig { margin: 2rem 0 0; }
+  .rig-shared {
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-radius: 3px;
+    padding: 1.1rem 1.25rem;
+    box-shadow: var(--shadow);
+  }
+  .rig-label {
+    font-family: var(--mono);
+    font-size: var(--step--1);
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin: 0 0 .75rem;
+  }
+  .chips { display: flex; flex-wrap: wrap; gap: .45rem; }
+  .chip {
+    font-family: var(--mono);
+    font-size: var(--step--1);
+    background: var(--sunk);
+    border: 1px solid var(--rule);
+    border-radius: 2px;
+    padding: .2rem .55rem;
+    color: var(--ink-soft);
+    white-space: nowrap;
+  }
+  .rig-stem {
+    width: 1px;
+    height: 2rem;
+    background: var(--rule-firm);
+    margin: 0 auto;
+  }
+  .rig-pair { display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: 1rem; }
+  .node {
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-top: 3px solid var(--rule-firm);
+    border-radius: 3px;
+    padding: 1.1rem 1.25rem 1.25rem;
+    box-shadow: var(--shadow);
+  }
+  .node.is-before { border-top-color: var(--before); }
+  .node.is-after  { border-top-color: var(--after); }
+  .node .port {
+    font-family: var(--mono);
+    font-size: var(--step-1);
+    font-weight: 600;
+    letter-spacing: -.01em;
+    font-variant-numeric: tabular-nums;
+    display: block;
+    margin-bottom: .1rem;
+  }
+  .node.is-before .port { color: var(--before); }
+  .node.is-after  .port { color: var(--after); }
+  .node .who {
+    font-family: var(--sans);
+    font-size: var(--step--1);
+    font-weight: 600;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    display: block;
+    margin-bottom: .9rem;
+  }
+  .node dl { margin: 0; display: grid; grid-template-columns: auto 1fr; gap: .35rem .75rem; font-size: var(--step--1); }
+  .node dt { font-family: var(--sans); color: var(--ink-faint); }
+  .node dd { margin: 0; font-family: var(--mono); color: var(--ink-soft); overflow-wrap: anywhere; }
+
+  /* ---------- tables ---------- */
+
+  .scroll { overflow-x: auto; margin: 0; -webkit-overflow-scrolling: touch; }
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    min-width: 42rem;
+    font-family: var(--sans);
+    font-size: var(--step--1);
+  }
+  caption {
+    caption-side: top;
+    text-align: left;
+    font-family: var(--mono);
+    font-size: var(--step--1);
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    padding-bottom: .75rem;
+  }
+  th, td { padding: .6rem .85rem; text-align: left; border-bottom: 1px solid var(--rule); vertical-align: top; }
+  thead th {
+    font-weight: 600;
+    font-size: var(--step--1);
+    letter-spacing: .04em;
+    color: var(--ink-faint);
+    border-bottom: 1px solid var(--rule-firm);
+    white-space: nowrap;
+  }
+  tbody tr:last-child td { border-bottom: none; }
+  .num { text-align: right; font-family: var(--mono); font-variant-numeric: tabular-nums; white-space: nowrap; }
+  .c-before { color: var(--before); }
+  .c-after  { color: var(--after); font-weight: 600; }
+  .gain {
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    color: var(--after);
+    background: var(--after-wash);
+    border-radius: 2px;
+    padding: .1rem .4rem;
+  }
+  .row-label { font-weight: 600; white-space: nowrap; }
+
+  /* ---------- code ---------- */
+
+  pre {
+    font-family: var(--mono);
+    font-size: var(--step--1);
+    line-height: 1.6;
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-left: 3px solid var(--rule-firm);
+    border-radius: 3px;
+    padding: 1rem 1.15rem;
+    overflow-x: auto;
+    margin: 0;
+    tab-size: 2;
+  }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  .pre-title {
+    font-family: var(--mono);
+    font-size: var(--step--1);
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin: 0 0 .6rem;
+  }
+
+  /* ---------- verdict ---------- */
+
+  .verdicts { display: grid; grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr)); gap: 1rem; }
+  .verdict {
+    border: 1px solid var(--rule);
+    border-radius: 3px;
+    padding: 1.15rem 1.25rem;
+    background: var(--surface);
+    display: flex;
+    flex-direction: column;
+    gap: .6rem;
+  }
+  .verdict h4 {
+    font-family: var(--sans);
+    font-size: var(--step-0);
+    font-weight: 600;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+  }
+  .verdict p { font-family: var(--sans); font-size: var(--step--1); line-height: 1.55; margin: 0; color: var(--ink-soft); max-width: none; }
+  .dot { width: .55rem; height: .55rem; border-radius: 50%; flex: none; }
+  .v-yes  { border-top: 3px solid var(--after); }
+  .v-yes  .dot { background: var(--after); }
+  .v-no   { border-top: 3px solid var(--caution); background: var(--caution-wash); }
+  .v-no   .dot { background: var(--caution); }
+  .v-nc   { border-top: 3px solid var(--rule-firm); }
+  .v-nc   .dot { background: var(--ink-faint); }
+
+  /* ---------- callout ---------- */
+
+  .note {
+    border-left: 3px solid var(--caution);
+    background: var(--caution-wash);
+    padding: 1.1rem 1.35rem;
+    border-radius: 2px;
+    font-family: var(--sans);
+    font-size: var(--step--1);
+    line-height: 1.6;
+    display: flex;
+    flex-direction: column;
+    gap: .6rem;
+  }
+  .note p { margin: 0; max-width: none; }
+  .note .tag {
+    font-family: var(--mono);
+    font-weight: 600;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--caution);
+  }
+
+  .standins { display: flex; flex-direction: column; gap: 0; }
+  .standin {
+    display: grid;
+    grid-template-columns: minmax(9rem, 12rem) 1fr;
+    gap: .35rem 1.5rem;
+    padding: 1.1rem 0;
+    border-bottom: 1px solid var(--rule);
+    align-items: baseline;
+  }
+  .standin:first-child { border-top: 1px solid var(--rule); }
+  .standin dt { font-family: var(--mono); font-size: var(--step--1); color: var(--ink); font-weight: 500; }
+  .standin dd { margin: 0; font-family: var(--sans); font-size: var(--step--1); line-height: 1.55; color: var(--ink-soft); }
+  .standin dd + dd { margin-top: .4rem; }
+  .cost { color: var(--caution); font-weight: 600; }
+
+  footer {
+    margin-top: 5rem;
+    border-top: 2px solid var(--ink);
+    padding-top: 1.5rem;
+    font-family: var(--mono);
+    font-size: var(--step--1);
+    color: var(--ink-faint);
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem 2rem;
+  }
+
+  @media (max-width: 40rem) {
+    .sec-head { grid-template-columns: 1fr; gap: .35rem; }
+    .standin { grid-template-columns: 1fr; }
+    .banner { grid-template-columns: 1fr; gap: .6rem; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
+  }
+</style>
+
+<div class="wrap">
+
+  <header class="masthead">
+    <p class="kicker">
+      <span>Method note</span>
+      <span>2026-08-28</span>
+      <span>Issue <b>#22</b></span>
+      <span>PangenomeAPI</span>
+    </p>
+    <h1>How <code style="font-size:.82em;background:none;padding:0">/seqtubemap</code> was driven on a laptop</h1>
+    <p class="standfirst">
+      Two isolated API instances, one on each side of the change, serving the same five regions
+      over HTTP — so the before-and-after could be measured <em>on the wire</em> rather than
+      inferred from a unit test. Then pgb's own parser was run over both sides, and it recovers
+      <em>bit-identical arrays</em>. This is the method, including the one stand-in that limits
+      what it proves.
+    </p>
+
+    <div class="banner">
+      <span class="tag">Isolation</span>
+      <div>
+        <p><strong>Production was never involved.</strong> The <code>release</code> branch — the one the
+        server follows — was not read, written, or deployed to. Both instances bound to
+        <code>127.0.0.1</code> on ports <strong>8100</strong> and <strong>8101</strong>; production is
+        <code>:8000</code> on <code>pangenome-api.ucsd.edu</code>.</p>
+        <p>Everything the harness created lives outside the repository, except one gitignored
+        <code>cache/</code> directory that was deleted afterwards. <code>git status</code> is clean.</p>
+      </div>
+    </div>
+  </header>
+
+  <section>
+    <div class="sec-head"><span class="sec-num">01</span><h2>Why this needs a harness at all</h2></div>
+    <div class="sec-body">
+      <p class="col">Serving one <code>/seqtubemap</code> request touches four things a developer machine
+      does not have. Docker would supply all of them at once, and <code>docker-compose.yml</code> exists
+      for exactly that — but this machine has no Docker daemon, so each was supplied separately.</p>
+
+      <div class="scroll">
+        <table>
+          <caption>What the endpoint wants, and why it is missing</caption>
+          <thead>
+            <tr><th>Dependency</th><th>Why it is missing here</th></tr>
+          </thead>
+          <tbody>
+            <tr><td class="row-label">The HPRC v2 <code>.gbz</code> graph</td><td>Multi-gigabyte, not distributable; lives on the server</td></tr>
+            <tr><td class="row-label"><code>vg</code>, called twice</td><td>vgteam ship a <strong>Linux</strong> static build; this host is darwin/arm64</td></tr>
+            <tr><td class="row-label"><code>panCT</code> + git config paths</td><td>A developer setup step, unset in this checkout</td></tr>
+            <tr><td class="row-label"><code>adaptagrams</code>, <code>ogdf-python</code></td><td>Compiled inside the Docker image, not on the host</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p class="col">The Python test suite already solves three of these — <code>conftest.py</code> stubs the
+      native libraries, finds or stubs panCT, and supplies the git config through git's environment
+      variables. What it cannot solve is <code>vg</code>, which is why four tests in
+      <code>test_seqtubemap_endpoint.py</code> skip on a machine without it. Those are precisely the tests
+      that render a real tube map.</p>
+
+      <p class="col"><strong>So before this harness, no part of <code>/seqtubemap</code> had ever run end to end
+      on this machine.</strong> The coverage came from CI, where <code>vg</code> is installed, and from the
+      Node-level tests that sit below HTTP.</p>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head"><span class="sec-num">02</span><h2>What “isolated instance” means, precisely</h2></div>
+    <div class="sec-body">
+      <p class="col">Two <code>uvicorn</code> processes, each serving <code>main:app</code> out of a different
+      checkout, both running at the same time. They share every harness piece deliberately: anything
+      shared is a constant across the comparison, and therefore cannot contribute to the difference.</p>
+
+      <div class="rig">
+        <div class="rig-shared">
+          <p class="rig-label">Shared by both — the controlled constants</p>
+          <div class="chips">
+            <span class="chip">venv · fastapi 0.141.1</span>
+            <span class="chip">uvicorn 0.52.4</span>
+            <span class="chip">panCT @ 03c406b</span>
+            <span class="chip">native stubs</span>
+            <span class="chip">empty data dir</span>
+            <span class="chip">the vg stand-in</span>
+            <span class="chip">5 committed .gfa fixtures</span>
+          </div>
+        </div>
+        <div class="rig-stem" aria-hidden="true"></div>
+        <div class="rig-pair">
+          <div class="node is-before">
+            <span class="port">:8101</span>
+            <span class="who">Before</span>
+            <dl>
+              <dt>Code</dt><dd>399db1e</dd>
+              <dt>Dir</dt><dd>git worktree</dd>
+              <dt>node_modules</dt><dd>5 packages, with jsdom + canvas</dd>
+            </dl>
+          </div>
+          <div class="node is-after">
+            <span class="port">:8100</span>
+            <span class="who">After</span>
+            <dl>
+              <dt>Code</dt><dd>e8e5bfe</dd>
+              <dt>Dir</dt><dd>the repository</dd>
+              <dt>node_modules</dt><dd>2 packages</dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+
+      <p class="col">A <code>git worktree</code> is what makes the “before” side honest. It is a second working
+      directory attached to the same repository, checked out at an arbitrary commit, with its own
+      untracked files — so <code>399db1e</code> gets its own <code>node_modules</code> containing the browser
+      emulation, without disturbing the main checkout or forcing a stash-and-reinstall between
+      measurements.</p>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head"><span class="sec-num">03</span><h2>The trick that removes the need for graph data</h2></div>
+    <div class="sec-body">
+      <p class="col">This is the part worth understanding, because it is not a test hook. It is a
+      <strong>production code path</strong>, used as intended.</p>
+
+      <div>
+        <p class="pre-title">main.py:735</p>
+        <pre><code>subgraph_cached = preprocess_gfa_subgraph_w_walk.exists()
+
+with stage_timing(stages, "subgraph_extract"):
+    if not subgraph_cached:
+        ...SubgraphMC(...); GenerateWalksMC(...)</code></pre>
+      </div>
+
+      <p class="col">If the extracted subgraph is already on disk, the endpoint skips extraction entirely —
+      no <code>.gbz</code>, no <code>gfabase</code>, no tabix lookups. That branch exists so a repeated region
+      is fast. It also means <strong>pre-placing a subgraph file is enough to make the rest of the pipeline
+      run.</strong></p>
+
+      <p class="col">The path it looks for is built from the query parameters, and the five fixtures in
+      <code>tests/fixtures/seqtubemap/</code> were copied out of the production server's own cache directory
+      <em>under the server's own filenames</em>. They drop straight in — and the region in each filename is
+      the region to request.</p>
+
+      <div>
+        <p class="pre-title">Five committed fixtures become five servable regions</p>
+        <pre><code>mkdir -p cache/seqtubemap/mc
+cp tests/fixtures/seqtubemap/*.gfa cache/seqtubemap/mc/</code></pre>
+      </div>
+
+      <p class="col">The second half of the same trick is issue #19: the <code>.walk.gz</code> derivatives are
+      opened the first time something reads one, rather than at import. A request with no
+      <code>minigraphnode</code> reads none — so <code>data.path</code> can point at an <strong>empty
+      directory</strong> and the app still boots and serves.</p>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head"><span class="sec-num">04</span><h2>The stand-ins, and what each one costs</h2></div>
+    <div class="sec-body">
+      <dl class="standins">
+        <div class="standin">
+          <dt>git config</dt>
+          <dd><code>tools.path</code> and <code>data.path</code> supplied through <code>GIT_CONFIG_COUNT</code> /
+          <code>KEY_n</code> / <code>VALUE_n</code> — the same mechanism <code>conftest.py</code> uses. Any
+          <code>git config --get</code> in a child process sees them.</dd>
+          <dd><strong>Cost: none.</strong> Nothing on disk changes; the developer's own config is untouched.</dd>
+        </div>
+        <div class="standin">
+          <dt>panCT</dt>
+          <dd>Cloned for real at <code>03c406b</code>, the commit CI pins. The logging in the
+          <code>[stage-timing]</code> line below is therefore panCT's own, not a placeholder's.</dd>
+          <dd><strong>Cost: none.</strong> This is the real dependency.</dd>
+        </div>
+        <div class="standin">
+          <dt>adaptagrams<br>ogdf_python</dt>
+          <dd>Two stub modules on <code>PYTHONPATH</code>. <code>main.py</code> imports them at module scope
+          through <code>bandage_graph</code>; they are the <em>3D graph layout</em> libraries, and nothing in
+          the <code>/seqtubemap</code> path calls them.</dd>
+          <dd><span class="cost">Cost:</span> <code>/json</code> was non-functional in these instances. It was
+          not exercised and no claim here covers it.</dd>
+        </div>
+        <div class="standin">
+          <dt>vg</dt>
+          <dd>A shell script first on <code>PATH</code>, implementing exactly the two invocations
+          <code>main.py</code> makes. See below — this is the one that matters.</dd>
+          <dd><span class="cost">Cost:</span> the GFA→JSON step is this repo's own derivation, not
+          <code>vg</code>'s. Detailed in section 06.</dd>
+        </div>
+      </dl>
+
+      <h3>The <code>vg</code> stand-in</h3>
+
+      <p class="col"><code>ConvertGfaToVg</code> and <code>ConvertVgToJson</code> each run
+      <code>subprocess.run</code> against <code>vg</code> unconditionally — there is no “skip if the output
+      exists” branch to exploit, the way there is for extraction. Without a <code>vg</code> on
+      <code>PATH</code>, a request cannot get past <code>gfa_to_vg</code>.</p>
+
+      <div>
+        <p class="pre-title">$S/bin/vg — deliberately outside the repository</p>
+        <pre><code>case "${1:-}" in
+  convert)   # vg convert -g &lt;in.gfa&gt;  -&gt; stdout   (main.py:464)
+    printf 'GFA_SHIM\t%s\n' "$(cd "$(dirname "$3")" &amp;&amp; pwd)/$(basename "$3")"
+    ;;
+  view)      # vg view -j &lt;in.vg&gt;      -&gt; stdout   (main.py:486)
+    gfa=$(awk -F'\t' '/^GFA_SHIM/{print $2; exit}' "$3")
+    out=$(mktemp -t vgshim); trap 'rm -f "$out"' EXIT
+    node "$REPO/perf/gfa-to-vg-json.mjs" "$gfa" "$out" &gt;/dev/null 2&gt;&amp;1
+    cat "$out"
+    ;;
+  *) echo "vg shim: unsupported invocation: $*" &gt;&amp;2; exit 64 ;;
+esac</code></pre>
+      </div>
+
+      <p class="col">The <code>.vg</code> protobuf is a private intermediate — nothing but <code>vg view</code>
+      ever reads it, and the endpoint deletes it afterwards — so <code>convert</code> need not produce one. It
+      writes a marker naming the GFA it was given; <code>view</code> reads that marker and converts the GFA
+      directly with <code>perf/gfa-to-vg-json.mjs</code>.</p>
+
+      <p class="col"><strong>It was verified before being trusted.</strong> Over the 90 bp fixture, the
+      stand-in's output is identical to the committed
+      <code>subgraph_chr8_78771162_78771252_v2_with_walk.json</code> — the very file the Node tests and the
+      band-data baselines are built from. The Node stage therefore received, over HTTP, exactly the input it
+      receives in <code>npm test</code>.</p>
+
+      <div class="note">
+        <p class="tag">Why it stays out of the repo</p>
+        <p>A file named <code>vg</code> that silently is not <code>vg</code> is a hazard. It should not be
+        findable by anyone who has not read this page, so the reproducible recipe is the only durable form
+        it takes.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head"><span class="sec-num">05</span><h2>What came back</h2></div>
+    <div class="sec-body">
+      <p class="col">Each region: one warm-up request, then three timed, best taken. <code>curl</code>'s
+      <code>%{time_starttransfer}</code> is TTFB; <code>%{size_download}</code> is the payload.</p>
+
+      <div class="scroll">
+        <table>
+          <caption>Five real subgraphs, both instances</caption>
+          <thead>
+            <tr>
+              <th>Region</th>
+              <th class="num">TTFB before</th>
+              <th class="num">TTFB after</th>
+              <th class="num">Speedup</th>
+              <th class="num">Bytes before</th>
+              <th class="num">Bytes after</th>
+              <th class="num">Change</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td class="row-label">90 bp</td><td class="num c-before">0.646 s</td><td class="num c-after">0.213 s</td><td class="num"><span class="gain">3.0×</span></td><td class="num c-before">166,675</td><td class="num c-after">138,340</td><td class="num">−17.0%</td></tr>
+            <tr><td class="row-label">600 bp</td><td class="num c-before">0.982 s</td><td class="num c-after">0.278 s</td><td class="num"><span class="gain">3.5×</span></td><td class="num c-before">2,738,884</td><td class="num c-after">2,352,410</td><td class="num">−14.1%</td></tr>
+            <tr><td class="row-label">1.4 kb</td><td class="num c-before">1.226 s</td><td class="num c-after">0.331 s</td><td class="num"><span class="gain">3.7×</span></td><td class="num c-before">4,391,887</td><td class="num c-after">3,757,885</td><td class="num">−14.4%</td></tr>
+            <tr><td class="row-label">8.0 kb</td><td class="num c-before">2.376 s</td><td class="num c-after">0.735 s</td><td class="num"><span class="gain">3.2×</span></td><td class="num c-before">12,090,267</td><td class="num c-after">10,408,507</td><td class="num">−13.9%</td></tr>
+            <tr><td class="row-label">4.2 kb</td><td class="num c-before">2.561 s</td><td class="num c-after">0.589 s</td><td class="num"><span class="gain">4.3×</span></td><td class="num c-before">15,285,418</td><td class="num c-after">13,122,049</td><td class="num">−14.2%</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p class="col">The endpoint's own stage timer attributes the saving. On the 90 bp region:</p>
+
+      <div>
+        <p class="pre-title">[stage-timing], 90 bp</p>
+        <pre><code>before:  total=0.796s  subgraph_extract=0.0s  gfa_to_vg=0.011s  vg_to_json=0.062s  generate_svg=0.723s
+after:   total=0.323s  subgraph_extract=0.0s  gfa_to_vg=0.010s  vg_to_json=0.059s  generate_svg=0.254s</code></pre>
+      </div>
+
+      <p class="col">Every stage but <code>generate_svg</code> is unchanged, which is exactly the expected
+      shape: the change touched the Node stage and nothing else.</p>
+
+      <h3>Conformance, checked on the response bodies</h3>
+
+      <p class="col">For all five regions the “after” body is byte-identical to the “before” body once
+      <code>color=</code>, <code>class="track{id}"</code> and <code>&lt;title&gt;&lt;/title&gt;</code> are
+      textually deleted from it. Drawable counts in <code>g.track</code> are unchanged — 592, 8,089, 13,246,
+      35,020, 44,795 — and the client's parsing contract passes on every one.
+      <code>nodewidthoption=normal</code>, the one path whose geometry could have shifted, is identical too,
+      with the same nine <code>&lt;text&gt;</code> elements. Neither server log holds an error, a traceback,
+      or a non-200.</p>
+
+      <p class="col">Byte reductions read ~14% here against ~16.6% measured on the fixtures, and the reason is
+      the absence of <code>minigraphnode</code>: with no PCLAI scheme every coordinate attribute is the short
+      literal <code>None</code>, so the removed attributes are a smaller share of a smaller document.</p>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head"><span class="sec-num">06</span><h2>Then the client's own parser</h2></div>
+    <div class="sec-body">
+      <p class="col"><strong><code>curl</code> stood in for pgb's fetch, not for pgb.</strong> It
+      retrieves the bytes; it does not parse them — and parsing is where compatibility actually
+      lives. That half was checked separately, and at first against this repository's <em>written
+      description</em> of what pgb requires, which is a weaker thing than it sounds.</p>
+
+      <p class="col">pgb is checked out on the same machine, so the description was replaced by the
+      code. <code>parseBands.ts</code> and <code>parseSegmentBoxes.ts</code> were run directly over
+      the five subgraphs as rendered by both sides. All ten documents were accepted — and more than
+      accepted:</p>
+
+      <div class="scroll">
+        <table>
+          <caption>pgb's recovered arrays, pre-change vs post-change</caption>
+          <thead>
+            <tr><th>Fixture</th><th class="num">Bands</th><th class="num">Strands</th><th class="num">Geometry floats</th><th>Recovered arrays</th></tr>
+          </thead>
+          <tbody>
+            <tr><td class="row-label">chr8 90 bp</td><td class="num">592</td><td class="num">464</td><td class="num">3,552</td><td class="c-after">identical</td></tr>
+            <tr><td class="row-label">chr1 600 bp</td><td class="num">8,089</td><td class="num">369</td><td class="num">48,534</td><td class="c-after">identical</td></tr>
+            <tr><td class="row-label">chr8 1.4 kb</td><td class="num">13,246</td><td class="num">463</td><td class="num">79,476</td><td class="c-after">identical</td></tr>
+            <tr><td class="row-label">chr1 8.0 kb</td><td class="num">35,020</td><td class="num">383</td><td class="num">210,120</td><td class="c-after">identical</td></tr>
+            <tr><td class="row-label">chr1 4.2 kb</td><td class="num">44,795</td><td class="num">1,201</td><td class="num">268,770</td><td class="c-after">identical</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p class="col">Compared element by element: <code>geometry</code>, <code>strandIds</code>,
+      <code>bandDirections</code>, <code>bandCount</code>, <code>strandColors</code>,
+      <code>strandNames</code>, <code>strandPlacements</code>, <code>strandScores</code>,
+      <code>strandCount</code>, <code>content</code>, <code>centre</code>, and the segment boxes.
+      The roadmap calls this the strongest available assertion — <em>run the client's own parser
+      over before and after, and diff the recovered arrays</em> — and it is now met with the
+      client's code rather than a description of it.</p>
+
+      <h3>Two things fell out of reading that parser</h3>
+
+      <p class="col"><strong>Our transcription was looser than the real gate.</strong> It made
+      <code>fill-opacity</code> and <code>trackName</code> optional; pgb requires both, literally —
+      <code>fill-opacity: 1;</code> is a hardcoded token inside the pattern. A lenient
+      transcription is worse than none, because it is false assurance about somebody else's gate.
+      It now mirrors pgb's own construction.</p>
+
+      <div class="note">
+        <p class="tag">Filed as #52</p>
+        <p><strong>A reversal draws shapes pgb cannot read</strong> — corners carry no
+        <code>trackName</code>, are quadratics where the grammar wants cubics, and neither they nor
+        a reversal's vertical rectangles carry the required <code>fill-opacity</code>. Because pgb
+        compares drawables <em>counted</em> against drawables <em>matched</em>, one unreadable shape
+        refuses the <em>whole document</em> — an error card, not a degraded picture.</p>
+        <p>Latent: no committed fixture draws a corner, and all five real subgraphs are entirely
+        rects and curves at <code>alpha: 1</code>. And it predates this change in both directions.
+        It now has a failing example in the test suite rather than a comment.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head"><span class="sec-num">07</span><h2>What this proves, and what it does not</h2></div>
+    <div class="sec-body">
+      <div class="verdicts">
+        <div class="verdict v-yes">
+          <h4><span class="dot" aria-hidden="true"></span>It proves</h4>
+          <p>That the post-change code serves <code>/seqtubemap</code> over real HTTP — real handler, real
+          caching branch, real Node subprocess; that the documents differ from the pre-change ones by
+          exactly the three removals; and that the saving sits where the change was made. A genuine A/B:
+          the instances differ only in the checkout they serve. And, separately from the harness, that
+          pgb's own parser recovers identical numbers from both sides.</p>
+        </div>
+        <div class="verdict v-no">
+          <h4><span class="dot" aria-hidden="true"></span>It does not prove</h4>
+          <p>Anything about the bytes real <code>vg</code> produces. That step ran through this repository's
+          own derivation, known to differ from <code>vg view -j</code> in at least subrange naming. It sits
+          <em>upstream</em> of the change, so it cannot mask a regression introduced here — but “production
+          will return exactly these bytes” is not supported. That evidence is CI, which installs
+          <code>vg</code> v1.75.0 and passed on PR #51.</p>
+        </div>
+        <div class="verdict v-nc">
+          <h4><span class="dot" aria-hidden="true"></span>It does not cover</h4>
+          <p><code>/json</code> and the 3D graph path, whose layout libraries were stubbed. Real subgraph
+          extraction, skipped by design. The PCLAI colouring path, which needs the minigraph walks file this
+          data directory does not contain.</p>
+        </div>
+      </div>
+
+      <p class="col" style="margin-top:1.5rem"><strong>Absolute timings are a developer laptop, not the
+      server.</strong> The ratios are the transferable part. Production's own baseline is unchanged and will
+      stay that way until something is promoted to <code>release</code>.</p>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head"><span class="sec-num">08</span><h2>Reproducing it</h2></div>
+    <div class="sec-body">
+      <p class="col">Set <code>S</code> to a scratch directory outside the repo and <code>REPO</code> to the
+      checkout. The full recipe, including the stand-in's source, is in
+      <code>docs/perf/local-endpoint-harness.md</code>.</p>
+
+      <div>
+        <p class="pre-title">Build the environment, then run it</p>
+        <pre><code>S=/tmp/seqtubemap-harness; REPO=$PWD; mkdir -p "$S"/{tools,data,stubs,bin}
+
+python3 -m venv "$S/venv"
+"$S/venv/bin/pip" install -r requirements-test.txt uvicorn
+git clone --quiet https://github.com/CAST-genomics/panCT.git "$S/tools/panCT"
+git -C "$S/tools/panCT" checkout --quiet 03c406b
+
+mkdir -p "$REPO/cache/seqtubemap/mc"
+cp "$REPO"/tests/fixtures/seqtubemap/*.gfa "$REPO/cache/seqtubemap/mc/"
+
+GIT_CONFIG_COUNT=2 \
+GIT_CONFIG_KEY_0=tools.path GIT_CONFIG_VALUE_0="$S/tools" \
+GIT_CONFIG_KEY_1=data.path  GIT_CONFIG_VALUE_1="$S/data" \
+PYTHONPATH="$S/stubs" VG_SHIM_REPO="$REPO" PATH="$S/bin:$PATH" \
+  "$S/venv/bin/uvicorn" main:app --host 127.0.0.1 --port 8100</code></pre>
+      </div>
+
+      <div class="scroll">
+        <table>
+          <caption>The five servable regions</caption>
+          <thead><tr><th>Region</th><th>Query</th></tr></thead>
+          <tbody>
+            <tr><td class="row-label">90 bp</td><td><code>chrom=chr8&amp;start=78771162&amp;end=78771252</code></td></tr>
+            <tr><td class="row-label">600 bp</td><td><code>chrom=chr1&amp;start=25331046&amp;end=25331646</code></td></tr>
+            <tr><td class="row-label">1.4 kb</td><td><code>chrom=chr8&amp;start=10079054&amp;end=10080461</code></td></tr>
+            <tr><td class="row-label">8.0 kb</td><td><code>chrom=chr1&amp;start=25301271&amp;end=25309238</code></td></tr>
+            <tr><td class="row-label">4.2 kb</td><td><code>chrom=chr1&amp;start=25331646&amp;end=25335796</code></td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p class="col">Requesting anything else — a region with no seeded <code>.gfa</code> — sends the endpoint
+      down the real extraction branch, which fails for want of the graph. That is correct behaviour, not a
+      harness fault.</p>
+    </div>
+  </section>
+
+  <section>
+    <div class="sec-head"><span class="sec-num">09</span><h2>What was left behind</h2></div>
+    <div class="sec-body">
+      <p class="col"><strong>Nothing in the repository.</strong> The seeded <code>cache/</code> directory was
+      deleted, the worktree removed, both <code>uvicorn</code> processes stopped and both ports confirmed
+      closed. <code>git status</code> is clean and <code>origin/release</code> is untouched.</p>
+      <p class="col">The harness itself — virtualenv, panCT clone, stubs, stand-in, captured documents and
+      server logs — lives in a session scratchpad, which is temporary. Section 08 is what makes it durable.</p>
+    </div>
+  </section>
+
+  <footer>
+    <span>Host: macOS 26.5.2 · arm64</span>
+    <span>Node v26.7.0 · Python 3.13.5</span>
+    <span>Method for docs/perf/increment-b.md</span>
+  </footer>
+
+</div>

--- a/docs/perf/local-endpoint-harness.md
+++ b/docs/perf/local-endpoint-harness.md
@@ -17,6 +17,9 @@ outside the repository, except one gitignored `cache/` directory that was delete
 
 The results are in [`increment-b.md`](./increment-b.md); this is the method.
 
+- Rendered version: <https://claude.ai/code/artifact/2f0fbe8f-187d-4cf2-b553-d71cfab68f08>
+- Source of the rendered version: [`local-endpoint-harness.html`](./local-endpoint-harness.html)
+
 ---
 
 ## 1. Why this needs a harness at all

--- a/docs/perf/local-endpoint-harness.md
+++ b/docs/perf/local-endpoint-harness.md
@@ -337,6 +337,12 @@ exactly the three removals and nothing else; and that the saving is where the ch
 It is a genuine A/B: the two instances differ only in the checkout they serve, because every
 stand-in is shared between them.
 
+> **`curl` stood in for `pgb`'s fetch, not for `pgb`.** It retrieves the bytes; it does not
+> parse them. The parsing side was checked separately, and afterwards properly: `pgb`'s own
+> `parseBands.ts` was run over the same documents and recovers bit-identical arrays from the
+> pre- and post-#22 sides. See [`increment-b.md`](./increment-b.md), "Checked against `pgb`'s
+> own parser".
+
 **Does not prove.** Anything about the bytes real `vg` produces. The GFA → vg-JSON step ran
 through this repository's own derivation, which is known to differ from `vg view -j` in at
 least the subrange-naming respect. That step sits entirely **upstream** of #22 — it feeds the

--- a/docs/perf/local-endpoint-harness.md
+++ b/docs/perf/local-endpoint-harness.md
@@ -1,0 +1,369 @@
+# Driving `/seqtubemap` locally — the harness behind #22's before-and-after
+
+On 2026-08-28, immediately after [#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22)
+merged, the endpoint was exercised for real on a developer machine: two isolated API
+instances, one running the code from before the change and one from after, serving the same
+five regions over HTTP so the difference could be measured on the wire rather than inferred
+from a unit test.
+
+This document records exactly how that was done, because the setup is not obvious, it is
+reproducible, and one part of it is a stand-in that materially limits what the results prove.
+
+**Nothing here touched production.** `release` — the branch the server follows
+([`releasing.md`](../releasing.md)) — was not read, written, or deployed to. Both instances
+bound to `127.0.0.1` on ports **8100** and **8101**; production is `:8000` on
+`pangenome-api.ucsd.edu`. Everything the harness created lives in a session scratchpad
+outside the repository, except one gitignored `cache/` directory that was deleted afterwards.
+
+The results are in [`increment-b.md`](./increment-b.md); this is the method.
+
+---
+
+## 1. Why this needs a harness at all
+
+`/seqtubemap` is not a pure function. Serving one request touches four things a developer
+machine does not have:
+
+| what the endpoint wants | why it is missing here |
+| --- | --- |
+| the multi-gigabyte HPRC v2 `.gbz` graph | not distributable; lives on the server |
+| the `vg` binary, twice (`main.py:464`, `:486`) | vgteam ship a **Linux** static build; this is darwin/arm64 |
+| `panCT`, and `tools.path` / `data.path` in git config | developer setup step, unset in this checkout |
+| `adaptagrams` and `ogdf-python` | compiled inside the Docker image (see the `Dockerfile`), not on the host |
+
+Docker would supply all four at once, and `docker-compose.yml` exists for exactly that. This
+machine has no Docker daemon, so each one was supplied separately.
+
+The Python test suite already solves three of these — `tests/python/conftest.py` stubs the
+native libraries, stubs or finds panCT, and supplies the git config through git's environment
+variables. What it *cannot* solve is `vg`, which is why
+`tests/python/test_seqtubemap_endpoint.py` skips four tests on a machine without it. Those are
+the very tests that render a real tube map. So on this machine, before this harness, **no part
+of `/seqtubemap` had ever run end to end** — the coverage came from CI, where `vg` is
+installed, and from the Node-level tests below HTTP.
+
+---
+
+## 2. What "isolated instance" means, precisely
+
+Two `uvicorn` processes, each serving `main:app` out of a different checkout:
+
+| | after | before |
+| --- | --- | --- |
+| port | `127.0.0.1:8100` | `127.0.0.1:8101` |
+| working directory | the repository | a `git worktree` at `399db1e` |
+| code | post-#22 (`e8e5bfe`) | pre-#22, with `jsdom` and `canvas` reinstalled |
+| `node_modules` | 2 packages | 5 packages |
+| `./cache/seqtubemap/mc/` | its own, seeded | its own, seeded |
+
+They shared the harness pieces — one virtualenv, one panCT checkout, one stub directory, one
+empty data directory, one `vg` stand-in — deliberately: anything shared is a constant across
+the comparison and therefore cannot contribute to the difference.
+
+A `git worktree` is what makes the "before" side honest. It is a second working directory
+attached to the same repository, checked out at an arbitrary commit, with its own untracked
+files — so `399db1e` gets its own `node_modules` containing the browser emulation, without
+disturbing the main checkout or requiring a stash-and-reinstall dance between measurements.
+Both servers were up at the same time.
+
+---
+
+## 3. The trick that removes the need for graph data
+
+This is the part worth understanding, because it is not a test hook — it is a **production
+code path**, used as intended.
+
+`main.py:735` reads:
+
+```python
+subgraph_cached = preprocess_gfa_subgraph_w_walk.exists()
+
+with stage_timing(stages, "subgraph_extract"):
+    if not subgraph_cached:
+        ...SubgraphMC(...); GenerateWalksMC(...)
+```
+
+If the extracted subgraph is already on disk, the endpoint skips extraction entirely — no
+`.gbz`, no `gfabase`, no `gbz-base`, no tabix walk lookups. That branch exists so a repeated
+region is fast. It also means that **pre-placing a subgraph file is enough to make the rest of
+the pipeline run**.
+
+The path it looks for is built from the query parameters (`main.py:728`):
+
+```
+./cache/seqtubemap/mc/subgraph_{chrom}_{start}_{end}_{version}_with_walk.gfa
+```
+
+And the five fixtures in [`tests/fixtures/seqtubemap/`](../../tests/fixtures/seqtubemap/) were
+copied out of the production server's own cache directory, under the server's own filenames —
+`subgraph_chr8_78771162_78771252_v2_with_walk.gfa` and four others. They drop into that path
+without being renamed, and the region in the filename *is* the region to request.
+
+So:
+
+```sh
+mkdir -p cache/seqtubemap/mc
+cp tests/fixtures/seqtubemap/*.gfa cache/seqtubemap/mc/
+```
+
+turns five committed fixtures into five servable regions. The `cache/` directory is gitignored
+(`.gitignore:26`).
+
+The second half of the same trick is [#19](https://github.com/CAST-genomics/PangenomeAPI/issues/19):
+the `.walk.gz` derivatives are opened by `WalkDerivative` the first time something reads one
+(`main.py:85`), rather than at import. A request with no `minigraphnode` reads none, so
+`data.path` can point at an **empty directory** and the app still boots and serves.
+
+---
+
+## 4. The five stand-ins
+
+### 4.1 `tools.path` and `data.path`, without touching your git config
+
+`main.py` shells out to `git config --get` for both, at import. Rather than writing them into
+`.git/config` — a mutation of the developer's checkout that would outlive the experiment —
+they were supplied through git's environment configuration, the same mechanism `conftest.py`
+uses:
+
+```sh
+export GIT_CONFIG_COUNT=2
+export GIT_CONFIG_KEY_0=tools.path  GIT_CONFIG_VALUE_0="$S/tools"
+export GIT_CONFIG_KEY_1=data.path   GIT_CONFIG_VALUE_1="$S/data"
+```
+
+Any `git config --get` in a child process sees these; nothing on disk changes.
+
+### 4.2 panCT — real, not stubbed
+
+```sh
+git clone https://github.com/CAST-genomics/panCT.git "$S/tools/panCT"
+git -C "$S/tools/panCT" checkout 03c406b
+```
+
+`03c406b` is the commit CI pins (`.github/workflows/ci.yml`, `PANCT_COMMIT`). `main.py` does
+`sys.path.append(tool_path)` and imports `Region` and `getLogger` from it. Using the real thing
+rather than `conftest`'s placeholder means the logging in the `[stage-timing]` line below is
+panCT's own.
+
+### 4.3 `adaptagrams` and `ogdf_python` — stubbed, and this has a cost
+
+Two files on `PYTHONPATH`:
+
+```python
+# ogdf_python.py
+import types
+ogdf = types.SimpleNamespace()
+def cppinclude(*a, **k):
+    return None
+```
+
+```python
+# adaptagrams.py — stand-in: the real one is compiled in the Docker image
+```
+
+`main.py` imports `bandage_graph` and `adaptagrams_converter` at module scope, which import
+these. They are the **3D graph layout** libraries, used by `/json`, and nothing in the
+`/seqtubemap` path calls them.
+
+**The cost:** in these instances `/json` was non-functional. That endpoint was not exercised
+and no claim here covers it.
+
+### 4.4 The `vg` stand-in — the one that limits the conclusions
+
+`ConvertGfaToVg` and `ConvertVgToJson` (`main.py:447-489`) each run `subprocess.run` against
+`vg`, unconditionally — there is no "skip if the output exists" branch to exploit, the way
+there is for extraction. Without a `vg` on `PATH` the request cannot proceed past `gfa_to_vg`.
+
+So a shell script named `vg` was put first on `PATH`, implementing exactly the two invocations
+`main.py` makes and nothing else:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+REPO="${VG_SHIM_REPO:?VG_SHIM_REPO must point at the checkout to use}"
+case "${1:-}" in
+  convert)   # vg convert -g <in.gfa>  -> stdout   (main.py:464)
+    printf 'GFA_SHIM\t%s\n' "$(cd "$(dirname "$3")" && pwd)/$(basename "$3")"
+    ;;
+  view)      # vg view -j <in.vg>      -> stdout   (main.py:486)
+    gfa=$(awk -F'\t' '/^GFA_SHIM/{print $2; exit}' "$3")
+    out=$(mktemp -t vgshim); trap 'rm -f "$out"' EXIT
+    node "$REPO/perf/gfa-to-vg-json.mjs" "$gfa" "$out" >/dev/null 2>&1
+    cat "$out"
+    ;;
+  *) echo "vg shim: unsupported invocation: $*" >&2; exit 64 ;;
+esac
+```
+
+The `.vg` protobuf is a private intermediate — nothing but `vg view` ever reads it, and the
+endpoint deletes it afterwards — so `convert` does not need to produce one. It writes a marker
+line naming the GFA it was given, and `view` reads that marker and converts the GFA directly,
+using [`perf/gfa-to-vg-json.mjs`](../../perf/gfa-to-vg-json.mjs), this repository's own
+GFA → vg-JSON derivation.
+
+**It was verified before being trusted.** Run over the 90 bp fixture, the shim's output is
+`JSON.stringify`-identical to the committed `subgraph_chr8_78771162_78771252_v2_with_walk.json`
+— which is the file the Node-level tests and the band-data baselines are built from. The Node
+stage therefore received, over HTTP, exactly the input it receives in `npm test`.
+
+**What it is not.** It is not `vg`. `tests/fixtures/seqtubemap/README.md` is explicit that the
+committed `.json` files "were not produced by `vg`", and the roadmap records a known
+divergence: real `vg view -j` appends a subrange to a path covering part of a contig
+(`CHM13#0#chr8#0[9659985-9661740]`) and this shim never does. See §7 for what that costs.
+
+The stand-in deliberately lives **outside the repository**, in a scratchpad. A file named `vg`
+that silently is not `vg` is a hazard, and it should not be findable by anyone who has not read
+this section.
+
+### 4.5 The virtualenv
+
+`python3 -m venv`, then `pip install -r requirements-test.txt` plus `uvicorn`. Resolved to
+fastapi 0.141.1, starlette 1.6.0, uvicorn 0.52.4, pysam 0.24.0, numpy 2.5.2, on Python 3.13.5.
+Node was the system v26.7.0. Host: macOS 26.5.2, arm64.
+
+The repo's own `docker-compose.yml` runs `fastapi dev`; `uvicorn main:app` was used instead
+because it is one dependency rather than the `fastapi[standard]` bundle, and the app object is
+the same either way.
+
+---
+
+## 5. Reproducing it
+
+Set `S` to a scratch directory outside the repo, and `REPO` to the checkout.
+
+```sh
+S=/tmp/seqtubemap-harness; REPO=$PWD; mkdir -p "$S"/{tools,data,stubs,bin}
+
+# 1. environment
+python3 -m venv "$S/venv"
+"$S/venv/bin/pip" install -r requirements-test.txt uvicorn
+git clone --quiet https://github.com/CAST-genomics/panCT.git "$S/tools/panCT"
+git -C "$S/tools/panCT" checkout --quiet 03c406b
+printf 'import types\nogdf = types.SimpleNamespace()\ndef cppinclude(*a, **k):\n    return None\n' > "$S/stubs/ogdf_python.py"
+printf '# stand-in for the compiled library\n' > "$S/stubs/adaptagrams.py"
+
+# 2. the vg stand-in from §4.4, saved as "$S/bin/vg", then: chmod +x "$S/bin/vg"
+
+# 3. seed the cache from the committed fixtures
+mkdir -p "$REPO/cache/seqtubemap/mc"
+cp "$REPO"/tests/fixtures/seqtubemap/*.gfa "$REPO/cache/seqtubemap/mc/"
+
+# 4. run it
+cd "$REPO"
+GIT_CONFIG_COUNT=2 \
+GIT_CONFIG_KEY_0=tools.path GIT_CONFIG_VALUE_0="$S/tools" \
+GIT_CONFIG_KEY_1=data.path  GIT_CONFIG_VALUE_1="$S/data" \
+PYTHONPATH="$S/stubs" VG_SHIM_REPO="$REPO" PATH="$S/bin:$PATH" \
+  "$S/venv/bin/uvicorn" main:app --host 127.0.0.1 --port 8100 --log-level info
+```
+
+Then, from another shell:
+
+```sh
+curl -s -o /tmp/out.svg -w '%{http_code} %{time_starttransfer}s %{size_download}\n' \
+  'http://127.0.0.1:8100/seqtubemap?chrom=chr8&start=78771162&end=78771252&version=v2'
+```
+
+The five servable regions are the five fixture filenames:
+
+| region | query |
+| --- | --- |
+| 90 bp | `chrom=chr8&start=78771162&end=78771252` |
+| 600 bp | `chrom=chr1&start=25331046&end=25331646` |
+| 1.4 kb | `chrom=chr8&start=10079054&end=10080461` |
+| 8.0 kb | `chrom=chr1&start=25301271&end=25309238` |
+| 4.2 kb | `chrom=chr1&start=25331646&end=25335796` |
+
+For the "before" side, add a worktree and give it the browser emulation back:
+
+```sh
+git worktree add "$S/before" 399db1e
+cd "$S/before" && npm install          # restores jsdom + canvas from that commit's manifest
+mkdir -p "$S/before/cache/seqtubemap/mc"
+cp "$REPO"/tests/fixtures/seqtubemap/*.gfa "$S/before/cache/seqtubemap/mc/"
+# same uvicorn line, but --port 8101, VG_SHIM_REPO="$S/before", run from "$S/before"
+```
+
+**Requesting anything else** — a region with no seeded `.gfa` — sends the endpoint down the
+real extraction branch, which fails for want of the graph. That is correct behaviour, not a
+harness fault.
+
+---
+
+## 6. What was measured
+
+Each region: one warm-up request, then three timed, best taken. `curl`'s
+`%{time_starttransfer}` is TTFB; `%{size_download}` is the payload.
+
+| region | TTFB before | TTFB after | speedup | bytes before | bytes after | change |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 90 bp | 0.646 s | **0.213 s** | 3.0× | 166,675 | 138,340 | −17.0% |
+| 600 bp | 0.982 s | **0.278 s** | 3.5× | 2,738,884 | 2,352,410 | −14.1% |
+| 1.4 kb | 1.226 s | **0.331 s** | 3.7× | 4,391,887 | 3,757,885 | −14.4% |
+| 8.0 kb | 2.376 s | **0.735 s** | 3.2× | 12,090,267 | 10,408,507 | −13.9% |
+| 4.2 kb | 2.561 s | **0.589 s** | 4.3× | 15,285,418 | 13,122,049 | −14.2% |
+
+The endpoint's own `[stage-timing]` line attributes the saving. On the 90 bp region:
+
+```
+before: total=0.796s subgraph_extract=0.0s gfa_to_vg=0.011s vg_to_json=0.062s generate_svg=0.723s
+after:  total=0.323s subgraph_extract=0.0s gfa_to_vg=0.010s vg_to_json=0.059s generate_svg=0.254s
+```
+
+Every stage but `generate_svg` is unchanged, which is the expected shape: #22 touched the Node
+stage and nothing else.
+
+**Conformance, checked on the response bodies.** For all five regions, the "after" body is
+byte-identical to the "before" body once `color=`, `class="track{id}"` and `<title></title>`
+are textually deleted from it. Drawable counts in `g.track` are unchanged — 592, 8,089, 13,246,
+35,020, 44,795 — and `tests/node/pgb-parser.mjs`, which states `pgb`'s parsing contract, passes
+on every one. `nodewidthoption=normal`, the one path whose geometry could have shifted, is
+identical too, with the same nine `<text>` elements.
+
+Neither server log contains an error, a traceback, or a non-200 response.
+
+**Byte reductions are ~14% here against ~16.6% measured on the fixtures**, and the reason is
+the absence of `minigraphnode`: with no PCLAI scheme every `pclaiX`/`pclaiY`/`pclaiScore` is
+the short literal `None`, so the removed attributes are a smaller share of a smaller document.
+
+---
+
+## 7. What this proves, and what it does not
+
+**Proves.** That the post-#22 code serves `/seqtubemap` over real HTTP, through the real
+FastAPI handler, the real caching branch and the real Node subprocess; that the documents it
+returns satisfy `pgb`'s parsing contract; that they differ from the pre-#22 documents by
+exactly the three removals and nothing else; and that the saving is where the change was made.
+It is a genuine A/B: the two instances differ only in the checkout they serve, because every
+stand-in is shared between them.
+
+**Does not prove.** Anything about the bytes real `vg` produces. The GFA → vg-JSON step ran
+through this repository's own derivation, which is known to differ from `vg view -j` in at
+least the subrange-naming respect. That step sits entirely **upstream** of #22 — it feeds the
+Node stage, and #22 changed only what happens after — so it cannot mask a regression introduced
+by this change. But an absolute claim of the form "production will return exactly these bytes"
+is not supported by this harness. The evidence for that is CI, which installs `vg` v1.75.0 and
+runs `tests/python/test_seqtubemap_endpoint.py` for real; those tests passed on
+[PR #51](https://github.com/CAST-genomics/PangenomeAPI/pull/51).
+
+**Does not cover.** `/json` and the 3D graph path, whose layout libraries were stubbed. Real
+subgraph extraction, which was skipped by design. The PCLAI colouring path, which needs the
+minigraph walks file — a request with `minigraphnode` set would have gone looking for a walk
+derivative that this data directory does not contain.
+
+**Absolute timings are a developer laptop, not the server.** The ratios are the transferable
+part. Production's own baseline is [`seqtubemap-latency.md`](./seqtubemap-latency.md) §1, and
+it will not move until something is promoted to `release`.
+
+---
+
+## 8. What was left behind
+
+Nothing in the repository. The seeded `cache/` directory was deleted, the `git worktree` was
+removed, both `uvicorn` processes were stopped and both ports confirmed closed. `git status`
+is clean and `origin/release` is untouched at `33105e3`.
+
+The harness itself — virtualenv, panCT clone, stubs, `vg` stand-in, captured documents and
+server logs — lives in a session scratchpad, which is temporary. §5 is what makes it
+reproducible; that is deliberately the only durable form it takes, so that a script named `vg`
+which is not `vg` never sits in a checkout waiting to be found.

--- a/docs/seqtubemap-roadmap.md
+++ b/docs/seqtubemap-roadmap.md
@@ -11,6 +11,7 @@ This is the **build** document. Its companions:
 | [`docs/adr/0001`](./adr/0001-additive-band-format.md) | the decision, and the alternatives that were rejected |
 | [`docs/perf/seqtubemap-latency.md`](./perf/seqtubemap-latency.md) | the measurements, §1-9 |
 | [`docs/perf/increment-b.md`](./perf/increment-b.md) | what **B** actually bought, before and after |
+| [`docs/perf/local-endpoint-harness.md`](./perf/local-endpoint-harness.md) | how to drive `/seqtubemap` on a machine with no graph data and no `vg` |
 | [`docs/adr/0002`](./adr/0002-when-the-server-is-stood-up.md) | when the server gets stood up, and when it does not |
 | [`docs/perf/seqtubemap-plan.md`](./perf/seqtubemap-plan.md) | which skill drives each phase |
 | [`docs/releasing.md`](./releasing.md) | why merging is not shipping |

--- a/tests/node/document-conformance.test.mjs
+++ b/tests/node/document-conformance.test.mjs
@@ -14,11 +14,12 @@
 // `pgb` sizes its buffers from that count; if it moves, the picture moved.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readdirSync, readFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { cases, goldenPath, repoRoot } from "./golden-cases.mjs";
-import { assertParseableByPgb, drawables } from "./pgb-parser.mjs";
+import { assertParseableByPgb, drawables, readBands } from "./pgb-parser.mjs";
 
 // Measured on the jsdom-era goldens, at commit 399db1e. `small-normal` had no
 // golden then — the mode was not deterministic enough to have one — so its count
@@ -114,8 +115,60 @@ test("nothing in the render path can reach the browser emulation", () => {
 test("a document that lost the run pgb matches on is caught", () => {
   // The conformance check has to be able to fail. This is the exact regression
   // the increment was most at risk of: the attributes still all present, still
-  // all correct, and no longer contiguous.
+  // all correct, and no longer contiguous. `pgb` matches the fill run with one
+  // regular expression, so an attribute inserted into the middle of it does not
+  // break one band — it breaks every band, and `pgb` refuses the document whole.
   const golden = readFileSync(goldenPath(cases[0]), "utf8");
   const reordered = golden.replace(/ trackID="(\d+)"/g, ' class="track$1" trackID="$1"');
-  assert.throws(() => assertParseableByPgb(reordered), /pgb matches on|class attribute/);
+  assert.throws(() => assertParseableByPgb(reordered), /are not bands pgb recognises/);
+});
+
+test("a reversal draws shapes pgb cannot read, and this is where that is written down", async () => {
+  // A standing incompatibility between what the layout can draw and what the
+  // client can read, filed as
+  // [#52](https://github.com/CAST-genomics/PangenomeAPI/issues/52). It predates #22
+  // — nothing in that change touched it — and it is pinned here rather than left as
+  // a comment, because a latent refusal of the *whole document* is worth having a
+  // failing example of.
+  //
+  // Three things about a reversal are off `pgb`'s grammar at once: its corners
+  // carry no `trackName`, its corners are built from quadratics where the grammar
+  // wants cubics, and neither its corners nor its vertical rectangles carry the
+  // `fill-opacity: 1;` the grammar requires. Any one of them makes the matched
+  // count disagree with the counted drawables, which `pgb` refuses outright.
+  //
+  // No committed fixture contains a reversal, so one is made here the way
+  // band-data.test.mjs makes it: by sending a single strand backwards through
+  // three segments of the smoke fixture.
+  const { renderTubeMap } = await import("../../seqtubemap/render.mjs");
+  const inputFile = join(mkdtempSync(join(tmpdir(), "tubemap-reversal-")), "inverted.json");
+  const vg = JSON.parse(readFileSync(join(repoRoot, "tests", "fixtures", "tiny-vg.json"), "utf8"));
+  const mapping = vg.path[1].mapping;
+  vg.path[1].mapping = [
+    ...mapping.slice(0, 2),
+    ...mapping.slice(2, 5).reverse().map((step) => ({ position: { ...step.position, is_reverse: true } })),
+    ...mapping.slice(5),
+  ];
+  writeFileSync(inputFile, JSON.stringify(vg), "utf8");
+
+  const { document, bandData } = await renderTubeMap({
+    inputFile,
+    start: 0,
+    end: 69,
+    nodeWidthOption: "compressed",
+  });
+
+  // The layout really did draw the shapes in question.
+  assert.ok(
+    bandData.bands.some((band) => band.kind === "corner"),
+    "the inverted input drew no corners, so this test is no longer about anything",
+  );
+
+  // And `pgb`'s grammar cannot account for every drawable in the group.
+  const { counted, matched } = readBands(document);
+  assert.ok(
+    matched.length < counted,
+    `expected pgb's grammar to miss some of the ${counted} drawables, but it matched all of them`,
+  );
+  assert.throws(() => assertParseableByPgb(document), /are not bands pgb recognises/);
 });

--- a/tests/node/pgb-parser.mjs
+++ b/tests/node/pgb-parser.mjs
@@ -1,59 +1,125 @@
-// What `pgb` requires of a `/seqtubemap` document, written down on this side.
+// What `pgb` requires of a `/seqtubemap` document, restated on this side.
 //
 // #22 removed the browser emulation and emitted the document from band data
-// instead, **against an unchanged client**. That is what makes the increment
-// safe to ship alone, and it is a constraint rather than an aspiration: the
-// frontend is this ticket's conformance test in production, so a bad deploy
-// surfaces as an error card rather than as a diff nobody ran. This file is the
-// same check, run before the deploy.
+// instead, **against an unchanged client**. That is what makes the increment safe
+// to ship alone, and it is a constraint rather than an aspiration: the frontend is
+// this ticket's conformance test in production, so a bad deploy surfaces as an
+// error card rather than as a diff nobody ran. This file is the same check, run
+// before the deploy.
 //
-// It is *not* a copy of `parseBands.ts`. Two implementations of a parser that
-// must agree is precisely the failure mode this whole effort exists to remove,
-// and the real cross-repo test is #25's, which runs `pgb`'s own parser over
-// fixtures committed here. What this asserts is the narrower thing #22 promised
-// not to break, in the terms `pgb` states it:
+// It is *not* a copy of `parseBands.ts`, and the real cross-repo test is still
+// [#25](https://github.com/CAST-genomics/PangenomeAPI/issues/25)'s, which runs
+// `pgb`'s own parser in `pgb`'s CI over fixtures committed here. Two parsers that
+// must agree is the failure mode this whole effort exists to remove. What this
+// asserts is the narrower thing: that a document satisfies the grammar `pgb`
+// matches on, so a change to the emitter cannot quietly stop producing one.
 //
-//   1. Bands live in `g.track`, and a band is a `<rect>` or a `<path>`. `pgb`
-//      counts them to size its buffers, so the count is part of the contract.
-//   2. Every band carries its fill style, its `trackID` and — unless it is a
-//      corner, which has never had one — its `trackName`, **contiguous and in
-//      that order**. `pgb` matches that run with one regular expression; an
-//      attribute inserted into the middle of it breaks every band.
-//   3. `trackID` runs 0..n-1 with no gaps, because `pgb` indexes tables by it
-//      and rejects the whole document otherwise.
+// **The grammar below is transcribed from `pgb/src/tubemap/parseBands.ts`, read on
+// 2026-08-28.** It was verified the same day by running that file over all five
+// real subgraphs, before and after #22: `pgb` accepted every one and recovered
+// bit-identical arrays from both sides. An earlier version of this file was looser
+// than the real thing in two ways — it made `fill-opacity` and `trackName`
+// optional — which made it pass documents `pgb` would refuse outright. Leniency
+// here is worse than useless: it is false assurance about somebody else's gate.
 //
-// And what the client ignores, which #22 stopped writing: the `color=`
-// duplicating the colour already in `style=`, the `class="track{id}"`
-// duplicating `trackID`, and the empty `<title>` on every band and segment box.
-// Those are asserted absent too — not because their return would break `pgb`,
-// but because they are 16.6% of the payload and their absence is what this
-// increment bought.
+// What `pgb` requires, in its own terms:
+//
+//   1. Bands live in `g.track` — everything before `<g class="node"`. A band is a
+//      `<rect>` or a `<path>`, and `pgb` **counts** them with `countOccurrences`.
+//   2. Every counted drawable must match the grammar. If fewer match than were
+//      counted, `pgb` throws `NonConformingDocument` and **refuses the whole
+//      document** — "a half-drawn map looks like a correct map of different data".
+//   3. The fill run is exact: `style="fill: rgb(R, G, B); fill-opacity: 1;"`
+//      followed immediately by `trackID`, then `trackName`, which must be
+//      non-empty. Nothing may come between them.
+//   4. `trackID` runs 0..n-1 with no gaps, and stays within Uint16.
+//   5. A `<rect>` is exactly `THICKNESS` (15) tall with positive width.
+//
+// Note what `pgb` deliberately tolerates, because it is the reason #22 could ship
+// at all: between `trackName` and the PCLAI attributes it matches `[^>]*?` rather
+// than naming `class` and `color`, "so a document that adds an attribute there
+// still parses". Removing those two attributes was invisible to it for the same
+// reason. Strand names are likewise opaque strings — `pgb` never splits on `#`, so
+// `vg`'s phase-block and subrange tails ride through verbatim.
+//
+// **A shape this layout can draw and `pgb` cannot read.** A reversal's corners and
+// vertical rectangles carry no `fill-opacity`, a corner carries no `trackName`, and
+// a corner's path is built from quadratics where the grammar wants cubics. Any one
+// of those makes the count in rule 2 disagree and refuses the document whole. No
+// committed fixture contains a reversal, and none of the five real subgraphs draws
+// a single corner — so this is latent rather than live, and it predates #22
+// entirely. It is
+// [#52](https://github.com/CAST-genomics/PangenomeAPI/issues/52), and
+// `document-conformance.test.mjs` pins it with a synthetic reversal.
 import assert from "node:assert/strict";
 
-// The run `pgb`'s parseBands matches: fill, optional opacity, id, optional name.
-// A corner carries no name and a reversal's vertical rectangle no opacity, so
-// both are optional — but nothing may come between them.
-const BAND_ATTRIBUTES =
-  /style="fill: rgb\(\d+, \d+, \d+\);( fill-opacity: [^;"]+;)?" trackID="(\d+)"( trackName="[^"]*")?/;
+/** `pgb`'s own number pattern (documentGrammar.ts), so the two cannot disagree. */
+const N = "(-?[\\d.]+(?:[eE]-?\\d+)?)";
 
-/** The `<g class="track">` group's contents, which is where the bands are. */
+/**
+ * The run `pgb` matches on, verbatim from `parseBands.ts`.
+ *
+ * `fill-opacity: 1;` is a required literal and `trackName` must be non-empty —
+ * both are load-bearing, and both were wrong here before 2026-08-28.
+ */
+const FILL =
+  'style="fill: rgb\\((\\d+), (\\d+), (\\d+)\\); fill-opacity: 1;" trackID="(\\d+)"' +
+  ' trackName="([^"]+)"' +
+  '(?:[^>]*? pclaiX="([^"]*)" pclaiY="([^"]*)" pclaiScore="([^"]*)")?';
+
+const RECT = `<rect x="${N}" y="${N}" width="${N}" height="${N}" ${FILL}`;
+const PATH =
+  `<path d="M ${N} ${N} C ${N} ${N} ${N} ${N} ${N} ${N} V ${N} ` +
+  `C ${N} ${N} ${N} ${N} ${N} ${N} Z" ${FILL}`;
+
+const ELEMENT = new RegExp(`(?:${RECT})|(?:${PATH})`, "g");
+
+/** Every band in a tube map is this tall; `pgb` refuses any other height. */
+const THICKNESS = 15;
+
+/** Largest strand id `pgb`'s Uint16 instance buffer can hold. */
+const MAX_STRAND_ID = 65535;
+
+/**
+ * The bands `pgb` can read out of a document, and how many drawables were there
+ * to read. When the two disagree, `pgb` refuses the document whole.
+ */
+export function readBands(document) {
+  const trackGroup = strandGroup(document);
+  const counted =
+    countOccurrences(trackGroup, "<rect") + countOccurrences(trackGroup, "<path");
+
+  const matched = [];
+  ELEMENT.lastIndex = 0;
+  let match;
+  while ((match = ELEMENT.exec(trackGroup)) !== null) {
+    const isRect = match[1] !== undefined;
+    matched.push(
+      isRect
+        ? { isRect, height: +match[4], width: +match[3], id: +match[8], name: match[9] }
+        : { isRect, id: +match[31], name: match[32] },
+    );
+  }
+  return { counted, matched };
+}
+
+/** The `<g class="track">` slice — everything before the segment boxes, as `pgb` cuts it. */
 export function strandGroup(document) {
-  return group(document, "track");
-}
-
-/** The `<g class="node">` group's contents, which is where the segment boxes are. */
-export function segmentGroup(document) {
-  return group(document, "node");
-}
-
-// Neither group nests another, so the first `</g>` after the open is its close.
-function group(document, name) {
-  const open = `<g class="${name}">`;
+  const open = '<g class="track">';
   const start = document.indexOf(open);
-  assert.notEqual(start, -1, `the document has no g.${name} group`);
+  assert.notEqual(start, -1, "the document has no g.track group");
+  // `pgb` slices at `<g class="node"`, not at the group's own close.
+  const end = document.indexOf('<g class="node"');
+  return document.slice(start + open.length, end === -1 ? undefined : end);
+}
+
+/** The `<g class="node">` slice, which is where the segment boxes are. */
+export function segmentGroup(document) {
+  const start = document.indexOf('<g class="node">');
+  assert.notEqual(start, -1, "the document has no g.node group");
   const end = document.indexOf("</g>", start);
-  assert.notEqual(end, -1, `the document's g.${name} group is not closed`);
-  return document.slice(start + open.length, end);
+  assert.notEqual(end, -1, "the document's g.node group is not closed");
+  return document.slice(start + '<g class="node">'.length, end);
 }
 
 /** Every drawable element of the strand group, as its opening tag. */
@@ -61,27 +127,50 @@ export function drawables(document) {
   return [...strandGroup(document).matchAll(/<(?:rect|path)\b[^>]*>/g)].map(([tag]) => tag);
 }
 
+function countOccurrences(text, needle) {
+  let total = 0;
+  let at = text.indexOf(needle);
+  while (at !== -1) {
+    total += 1;
+    at = text.indexOf(needle, at + needle.length);
+  }
+  return total;
+}
+
 /**
- * Throw unless `pgb` can parse this document.
+ * Throw unless `pgb` would accept this document.
  *
  * @param {string} document
- * @param {object} [bandData] the render's band data, when the caller has it —
- *   the drawable count is checked against it, which is the closest thing to
- *   `pgb`'s own whole-document check that this side can run.
+ * @param {object} [bandData] the render's band data, when the caller has it — the
+ *   drawable count is checked against it as well, which catches an emitter that
+ *   drops a band and a parser that skips one in the same pass.
  */
 export function assertParseableByPgb(document, bandData) {
-  const elements = drawables(document);
-  assert.ok(elements.length > 0, "no bands in the document's strand group");
+  assert.ok(document.includes("<svg"), "the response is not an SVG document");
+  assert.match(document, /viewBox="[^"]+"/, "the document declares no viewBox");
+
+  const { counted, matched } = readBands(document);
+  assert.ok(counted > 0, "the document draws no bands at all; its g.track group is empty");
+
+  // `pgb`'s whole-document gate, and the reason a single unreadable shape is not a
+  // cosmetic problem: it refuses everything rather than draw a partial map.
+  assert.equal(
+    matched.length,
+    counted,
+    `of the ${counted} drawables in g.track, ${counted - matched.length} are not bands pgb ` +
+      "recognises, and pgb refuses a document whole when that count disagrees. " +
+      REVERSAL_GAP,
+  );
 
   const ids = new Set();
-  for (const element of elements) {
-    const match = BAND_ATTRIBUTES.exec(element);
-    assert.ok(
-      match,
-      "a band does not carry the fill-style / trackID / trackName run pgb matches on:\n  " +
-        element.slice(0, 240),
-    );
-    ids.add(Number(match[2]));
+  for (const band of matched) {
+    assert.ok(band.name.length > 0, "a band carries an empty trackName");
+    assert.ok(band.id <= MAX_STRAND_ID, `a band carries trackID ${band.id}, above pgb's Uint16 ceiling`);
+    if (band.isRect) {
+      assert.equal(band.height, THICKNESS, `a rect band is ${band.height} units tall, not ${THICKNESS}`);
+      assert.ok(band.width > 0, `a rect band is ${band.width} units wide; width must be positive`);
+    }
+    ids.add(band.id);
   }
 
   for (let id = 0; id < ids.size; id += 1) {
@@ -89,10 +178,10 @@ export function assertParseableByPgb(document, bandData) {
   }
 
   // The three things the client ignores, and that the emitter stopped writing.
-  // The title check is by *place* rather than document-wide: what went is the
-  // empty title on every band and every segment box, and a title carrying text
-  // is a different element — upstream hangs the sequence of a read's mismatch on
-  // one, which this fork never draws but the emitter can still write.
+  // Checked by *place*: what went is the empty title on every band and every
+  // segment box, and a title carrying text is a different element — upstream hangs
+  // a read's mismatch sequence on one, which this fork never draws but the emitter
+  // can still write.
   for (const [name, contents] of [
     ["g.track", strandGroup(document)],
     ["g.node", segmentGroup(document)],
@@ -105,9 +194,22 @@ export function assertParseableByPgb(document, bandData) {
 
   if (bandData) {
     assert.equal(
-      elements.length,
+      counted,
       bandData.bands.length,
       "the strand group's drawable count is not the band count",
     );
   }
 }
+
+/**
+ * Why a document carrying a reversal would be refused — quoted into the failure
+ * above, because that is where somebody will meet it.
+ *
+ * This is a standing incompatibility between what the layout can draw and what the
+ * client can read. It predates #22 and #22 did not change it either way.
+ */
+export const REVERSAL_GAP =
+  "The known cause is a reversal: its corners carry no trackName and are built from " +
+  "quadratics where pgb's grammar wants cubics, and neither its corners nor its vertical " +
+  "rectangles carry the `fill-opacity: 1;` the grammar requires. No committed fixture " +
+  "contains one, and none of the five real subgraphs draws a corner. This is issue #52.";


### PR DESCRIPTION
Follow-up to #22 (PR #51). Two commits: the write-up of how the endpoint was driven locally, and the verification that replaced our *description* of `pgb`'s contract with `pgb`'s actual code.

## 1. `docs/perf/local-endpoint-harness.md`

The before-and-after in `increment-b.md` gained an over-HTTP half: two isolated API instances, pre- and post-#22, on ports 8100 and 8101, serving the five committed subgraphs. That setup is not obvious — the endpoint wants a multi-gigabyte graph, a Linux-only `vg`, panCT, and two libraries that exist only inside the Docker image — and one part of it is a stand-in that limits what the results prove. Both facts are worth writing down rather than leaving in a terminal.

The document records what each stand-in was and what it cost, the production caching branch (`main.py:735`) that removes the need for graph data, the `vg` stand-in and its verified agreement with the committed fixture JSON, a reproducible recipe, and an explicit section on what this does **not** prove.

The stand-in named `vg` deliberately stays out of the repository — a file with that name which is not `vg` is a hazard. The recipe is the durable form.

| region | TTFB before | TTFB after | bytes before | bytes after |
| --- | ---: | ---: | ---: | ---: |
| 90 bp | 0.646 s | 0.213 s | 166,675 | 138,340 |
| 600 bp | 0.982 s | 0.278 s | 2,738,884 | 2,352,410 |
| 1.4 kb | 1.226 s | 0.331 s | 4,391,887 | 3,757,885 |
| 8.0 kb | 2.376 s | 0.735 s | 12,090,267 | 10,408,507 |
| 4.2 kb | 2.561 s | 0.589 s | 15,285,418 | 13,122,049 |

## 2. Checked against `pgb`'s real parser

`curl` stood in for `pgb`'s **fetch**, not for `pgb` — it retrieves bytes, it does not parse them. The parsing half was checked against this repo's written statement of the contract, which is weaker than it sounds. `pgb` is checked out alongside, so the statement was replaced by the thing itself: `parseBands.ts` and `parseSegmentBoxes.ts` run directly over all five real subgraphs as rendered by **both** sides.

**All accepted, and `pgb` recovers bit-identical arrays from the two sides** — `geometry` (610,452 floats in total), `strandIds`, `bandDirections`, `bandCount`, `strandColors`, `strandNames`, `strandPlacements`, `strandScores`, `strandCount`, `content`, `centre`, and the segment boxes. That is the bar the roadmap names as the strongest available, met with the client's own code.

### `tests/node/pgb-parser.mjs` was looser than the real gate

It made `fill-opacity` and `trackName` optional. `pgb` requires both, literally — `fill-opacity: 1;` is a hardcoded token inside the pattern and `trackName` must be non-empty. A lenient transcription is worse than none: it is false assurance about somebody else's gate. It now mirrors `pgb`'s `FILL` / `RECT` / `PATH` construction, its `NUMBER` pattern, and its count-the-drawables whole-document rule.

### A reversal draws shapes `pgb` refuses — filed as #52

Corners carry no `trackName`, are built from quadratics where the grammar wants cubics, and neither corners nor a reversal's vertical rectangles carry the required `fill-opacity`. Because `pgb` compares drawables *counted* against drawables *matched*, one unreadable shape refuses the **whole document**.

Latent — no committed fixture draws a corner, and all five real subgraphs are entirely rects and curves at `alpha: 1` — and it predates #22 in both directions. It now has a failing example in `document-conformance.test.mjs` rather than a comment.

## Testing

80 Node tests (2 skipped), 11 Python (5 skipped, all needing `vg`). The one behaviour change in the suite is the tightened grammar, which is why the negative test's expected message moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)