### PR TITLE
Ask Cici for a second copy of the API, running main on its own port

### DIFF
--- a/docs/perf/test-deployment-request.html
+++ b/docs/perf/test-deployment-request.html
@@ -1,0 +1,296 @@
+<title>A Second Copy, For Testing</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Serif:ital,wght@0,400;0,600;1,400&display=swap">
+
+<style>
+  :root {
+    --paper:     #F4F5F2;
+    --surface:   #FFFFFF;
+    --sunk:      #EBEDE8;
+    --ink:       #12171C;
+    --ink-soft:  #46515B;
+    --ink-faint: #6E7A85;
+    --rule:      #D6DAD3;
+    --rule-firm: #B9BFB6;
+    --accent:      #0B6B63;
+    --accent-wash: #DDECEA;
+    --caution:      #8A6210;
+    --caution-wash: #F4EBD6;
+    --shadow: 0 1px 2px rgba(18,23,28,.05), 0 8px 24px -18px rgba(18,23,28,.28);
+
+    --measure: 64ch;
+    --step--1: clamp(.82rem, .80rem + .1vw, .88rem);
+    --step-0:  clamp(1.03rem, 1.0rem + .16vw, 1.13rem);
+    --step-1:  clamp(1.22rem, 1.13rem + .4vw, 1.44rem);
+    --step-2:  clamp(1.5rem, 1.3rem + .85vw, 2.0rem);
+    --step-3:  clamp(1.95rem, 1.55rem + 1.7vw, 2.85rem);
+
+    --sans:  "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, sans-serif;
+    --serif: "IBM Plex Serif", ui-serif, Georgia, Cambria, serif;
+    --mono:  "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --paper:#0E1317; --surface:#161C22; --sunk:#1B2229;
+      --ink:#E6EAE6; --ink-soft:#AEB9C1; --ink-faint:#808D96;
+      --rule:#2A333B; --rule-firm:#3D4851;
+      --accent:#48B7AA; --accent-wash:#14312F;
+      --caution:#D6A93F; --caution-wash:#312712;
+      --shadow: 0 1px 2px rgba(0,0,0,.4), 0 10px 30px -20px rgba(0,0,0,.8);
+    }
+  }
+  :root[data-theme="dark"] {
+    --paper:#0E1317; --surface:#161C22; --sunk:#1B2229;
+    --ink:#E6EAE6; --ink-soft:#AEB9C1; --ink-faint:#808D96;
+    --rule:#2A333B; --rule-firm:#3D4851;
+    --accent:#48B7AA; --accent-wash:#14312F;
+    --caution:#D6A93F; --caution-wash:#312712;
+    --shadow: 0 1px 2px rgba(0,0,0,.4), 0 10px 30px -20px rgba(0,0,0,.8);
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--serif);
+    font-size: var(--step-0);
+    line-height: 1.65;
+    margin: 0;
+    padding: 0 1.5rem 6rem;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 44rem; margin: 0 auto; }
+
+  header { padding: 4rem 0 0; }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: var(--step--1);
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    margin: 0 0 1.25rem;
+  }
+  h1 {
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: var(--step-3);
+    line-height: 1.05;
+    letter-spacing: -.025em;
+    text-wrap: balance;
+    margin: 0 0 1.5rem;
+  }
+  .lede { font-size: var(--step-1); line-height: 1.5; color: var(--ink-soft); margin: 0; }
+
+  h2 {
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: var(--step-2);
+    line-height: 1.15;
+    letter-spacing: -.02em;
+    text-wrap: balance;
+    margin: 3.25rem 0 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--rule-firm);
+  }
+  p { margin: 0 0 1.1rem; max-width: var(--measure); }
+  strong { font-weight: 600; }
+  em { font-style: italic; }
+  a { color: var(--accent); text-underline-offset: .18em; }
+  a:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 2px; }
+
+  code {
+    font-family: var(--mono); font-size: .87em;
+    background: var(--sunk); padding: .12em .38em; border-radius: 3px;
+    overflow-wrap: anywhere;
+  }
+  pre {
+    font-family: var(--mono); font-size: var(--step--1); line-height: 1.65;
+    background: var(--surface); border: 1px solid var(--rule);
+    border-left: 3px solid var(--accent);
+    border-radius: 3px; padding: 1rem 1.15rem;
+    overflow-x: auto; margin: 0 0 1.1rem;
+  }
+  pre code { background: none; padding: 0; font-size: inherit; }
+
+  .facts { list-style: none; margin: 0 0 1.1rem; padding: 0; display: flex; flex-direction: column; gap: .65rem; }
+  .facts li {
+    font-family: var(--sans); font-size: var(--step--1); line-height: 1.55;
+    color: var(--ink-soft);
+    padding-left: 1.6rem; position: relative; max-width: var(--measure);
+  }
+  .facts li::before {
+    content: ""; position: absolute; left: .35rem; top: .55em;
+    width: .45rem; height: .45rem; border-radius: 50%; background: var(--accent);
+  }
+  .facts strong { color: var(--ink); }
+
+  /* The steps are a real sequence, so they are numbered. */
+  .steps { counter-reset: step; display: flex; flex-direction: column; gap: 2.25rem; }
+  .step { display: grid; grid-template-columns: 2.5rem 1fr; gap: 0 1rem; }
+  .step::before {
+    counter-increment: step; content: counter(step);
+    font-family: var(--mono); font-size: var(--step--1); font-weight: 500;
+    color: var(--surface); background: var(--accent);
+    width: 1.75rem; height: 1.75rem; border-radius: 50%;
+    display: grid; place-items: center;
+    font-variant-numeric: tabular-nums;
+  }
+  .step h3 {
+    font-family: var(--sans); font-weight: 600; font-size: var(--step-1);
+    line-height: 1.3; letter-spacing: -.01em; margin: .1rem 0 .75rem;
+    text-wrap: balance;
+  }
+  .step > div > :last-child { margin-bottom: 0; }
+
+  .note {
+    border-left: 3px solid var(--caution); background: var(--caution-wash);
+    padding: 1.1rem 1.35rem; border-radius: 2px;
+    font-family: var(--sans); font-size: var(--step--1); line-height: 1.6;
+    margin: 0 0 1.1rem;
+  }
+  .note p { margin: 0 0 .6rem; max-width: none; }
+  .note p:last-child { margin-bottom: 0; }
+  .note .tag {
+    font-family: var(--mono); font-weight: 500; letter-spacing: .08em;
+    text-transform: uppercase; color: var(--caution); display: block; margin-bottom: .5rem;
+  }
+
+  .reassure {
+    background: var(--accent-wash); border-left: 3px solid var(--accent);
+    padding: 1.25rem 1.5rem; border-radius: 2px; margin: 0 0 1.1rem;
+  }
+  .reassure .facts li::before { background: var(--accent); }
+  .reassure .facts { margin: 0; }
+
+  footer {
+    margin-top: 4rem; padding-top: 1.25rem; border-top: 1px solid var(--rule-firm);
+    font-family: var(--sans); font-size: var(--step--1); color: var(--ink-faint);
+  }
+  @media (max-width: 34rem) { .step { grid-template-columns: 1fr; gap: .75rem; } }
+  @media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } }
+</style>
+
+<div class="wrap">
+
+  <header>
+    <p class="eyebrow">A request, about 20 minutes</p>
+    <h1>A second copy of the API, for testing before we go live</h1>
+    <p class="lede">Hi Cici — one thing to set up. Nothing here touches the live server.</p>
+  </header>
+
+  <h2>What I'm asking for</h2>
+  <p>A <strong>second copy of the API running alongside the live one</strong>, on a different port,
+  using the code from <code>main</code> instead of <code>release</code>.</p>
+  <p>That's the whole thing. It's the same deploy you already do, with two differences: it lives in
+  its own folder, and it answers on a different port number.</p>
+
+  <h2>Why</h2>
+  <p>There's a batch of work waiting to go live — 33 changes, the biggest being a rewrite of how the
+  sequence tube map gets built. It's been tested heavily, but all of that testing has been on my
+  laptop, where I don't have the real graph files or the <code>vg</code> program. There are parts of
+  the real pipeline I simply can't run here.</p>
+  <p>Before we make it live, I want to open the browser app, click on actual nodes, and see real
+  pictures come back — especially the big nodes that fail today. Right now roughly 4 in 10 give up
+  before they finish, and this work is meant to fix that. I'd like to find out whether it did
+  <em>before</em> it's in front of anyone else.</p>
+  <p>Once it's up I'll do that clicking myself. I just can't create the second copy.</p>
+
+  <h2>What it does and doesn't touch</h2>
+  <div class="reassure">
+    <ul class="facts">
+      <li><strong>It does not change the live server.</strong> Different folder, different port,
+      separate process.</li>
+      <li><strong>It only reads the graph files.</strong> The same ones the live server reads, and it
+      never writes to them.</li>
+      <li><strong>It uses less memory than the live one</strong>, not more — that's most of what this
+      work did. About 470 MB where the current code peaks around 2.4 GB on the same request.</li>
+      <li><strong>It can be killed at any time</strong> with no effect on the live server, and I'll
+      tell you when we're done with it.</li>
+    </ul>
+  </div>
+
+  <h2>The steps</h2>
+  <p>Anywhere below that says <code>&lt;something&gt;</code>, that's a placeholder for a real value on
+  your end. If a step doesn't work, stop and ping me rather than digging.</p>
+
+  <div class="steps">
+
+    <div class="step">
+      <div>
+        <h3>Make a second folder with the code in it</h3>
+        <p>Somewhere alongside the existing one — whatever you'd normally call it:</p>
+        <pre><code>git clone https://github.com/CAST-genomics/PangenomeAPI.git &lt;new-folder&gt;
+cd &lt;new-folder&gt;
+git checkout main</code></pre>
+        <p>It needs to be a <strong>separate folder from the live server's</strong>, not the same one
+        switched over. Two reasons: the live folder has to stay on <code>release</code> so nothing
+        accidentally goes live, and both copies write temporary files to the same place relative to
+        their own folder and delete them after each request — sharing a folder, they'd delete each
+        other's files partway through.</p>
+        <p>You shouldn't need to configure anything in the new folder. The settings that point at the
+        graph files are set once for your whole account, so a fresh copy picks them up on its own.</p>
+      </div>
+    </div>
+
+    <div class="step">
+      <div>
+        <h3>Install what it needs</h3>
+        <p>Same as the live one:</p>
+        <pre><code>npm ci</code></pre>
+        <p>If you install the Python packages per-folder rather than once for the machine, that too.</p>
+      </div>
+    </div>
+
+    <div class="step">
+      <div>
+        <h3>Start it the way you normally start the API — but on a different port</h3>
+        <p>This is the step I can't write for you, because I don't know how you run it. However you
+        normally do it, the only change is the port number: <strong>8100</strong> instead of 8000, or
+        any free port you prefer.</p>
+        <p>If you start it with a command that names the port, change the number. If it's a service
+        definition or a compose file, copy it and change the port and the name.</p>
+        <p>It also needs HTTPS, the same way the live one gets it — the browser app won't talk to a
+        copy without it. The certificate you already have covers any port on the same address, so
+        there's nothing new to obtain; it just needs the same certificate settings the live one uses.</p>
+      </div>
+    </div>
+
+    <div class="step">
+      <div>
+        <h3>Tell me the port number, and that it's running</h3>
+        <p>I'll check it myself from there and won't need anything else.</p>
+      </div>
+    </div>
+
+  </div>
+
+  <h2>What "working" looks like</h2>
+  <p>If you want to confirm it before handing it over, this should print <code>200</code>:</p>
+  <pre><code>curl -s -o /dev/null -w "%{http_code}\n" \
+  "https://pangenome-api.ucsd.edu:&lt;port&gt;/seqtubemap?chrom=chr8&amp;start=78771162&amp;end=78771252&amp;version=v2"</code></pre>
+  <p>It may take a minute or two the first time — it has to pull that region out of the graph, same
+  as the live server does the first time anyone asks for it. Anything other than <code>200</code>,
+  send me what you got.</p>
+
+  <h2>One thing worth knowing, unrelated to this</h2>
+  <div class="note">
+    <span class="tag">No action needed</span>
+    <p>While going through the code I noticed something that isn't caused by this work, but that this
+    work makes easier to hit. When two requests for the <em>same</em> region arrive at once and that
+    region hasn't been fetched before, both start fetching it and both write to the same file. One of
+    the changes waiting to go live makes the server handle requests at the same time rather than one
+    after another, so this becomes more likely than it is today.</p>
+    <p>It isn't a reason to hold anything up — it needs two people asking for the same new region
+    within seconds of each other. But you should hear it from me rather than meet it later. It's
+    written up as issue #54 if you ever want the detail.</p>
+  </div>
+
+  <h2>When we're done</h2>
+  <p>I'll tell you once I've clicked through enough to be confident. Then the second copy can be shut
+  down and its folder deleted, and we can talk about making the changes live properly — which is the
+  <code>release</code> branch procedure, not this.</p>
+
+  <footer>Also in the repository as <code>docs/perf/test-deployment-request.md</code>.</footer>
+
+</div>

--- a/docs/perf/test-deployment-request.md
+++ b/docs/perf/test-deployment-request.md
@@ -1,0 +1,132 @@
+# A second copy of the API, for testing before we go live
+
+Hi Cici — one thing to set up, and I think it's about 20 minutes. Nothing here touches the
+live server.
+
+Anywhere below that says `<something>`, that's a placeholder for a real value on your end.
+If a step doesn't work, stop and ping me rather than digging.
+
+---
+
+## What I'm asking for
+
+A **second copy of the API running alongside the live one**, on a different port, using the
+code from `main` instead of `release`.
+
+That's the whole thing. It's the same deploy you already do, with two differences: it lives
+in its own folder, and it answers on a different port number.
+
+## Why
+
+There's a batch of work waiting to go live — 33 commits, the biggest being a rewrite of how
+the sequence tube map gets built. It's tested heavily, but all of that testing has been on
+my laptop, where I don't have the real graph files or the `vg` program. There are parts of
+the real pipeline I simply cannot run here.
+
+Before we make it live, I want to open the browser app, click on actual nodes, and see real
+pictures come back. Especially the big nodes that currently fail — right now roughly 4 in 10
+give up before they finish, and this work is supposed to fix that. I'd like to find out
+whether it did *before* it's in front of anyone else.
+
+Once it's up I'll do that clicking myself. I just can't create the second copy.
+
+## What it does and doesn't touch
+
+- **It does not change the live server.** Different folder, different port, separate process.
+- **It only reads the graph files.** Same ones the live server reads; it never writes to them.
+- **It uses less memory than the live one**, not more — that's most of what this work did. The
+  measurement is about 470 MB where the current code peaks around 2.4 GB on the same request.
+- **It can be killed at any time** with no effect on the live server, and I'll tell you when
+  we're done with it.
+
+---
+
+## The steps
+
+### 1. Make a second folder with the code in it
+
+Somewhere alongside the existing one — whatever you'd normally call it:
+
+```sh
+git clone https://github.com/CAST-genomics/PangenomeAPI.git <new-folder>
+cd <new-folder>
+git checkout main
+```
+
+It needs to be a **separate folder from the live server's**, not the same one switched over.
+Two reasons: the live folder has to stay on `release` so nothing accidentally goes live, and
+both copies write temporary files to the same place *relative to their own folder* and delete
+them after each request — if they shared a folder they'd delete each other's files partway
+through.
+
+You shouldn't need to configure anything in the new folder. The settings that point at the
+graph files are set once for your whole account, so a fresh copy picks them up on its own.
+
+### 2. Install what it needs
+
+Same as the live one:
+
+```sh
+npm ci
+```
+
+(If you install the Python packages per-folder rather than once for the machine, that too.)
+
+### 3. Start it, the way you normally start the API — but on a different port
+
+This is the step I can't write for you, because I don't know how you run it. However you
+normally do it, the only change is the port number: **8100** instead of 8000, or any free port
+you prefer.
+
+- If you start it with a command that names the port, change the number.
+- If it's a service definition or a compose file, copy it, change the port and the name.
+
+It also needs HTTPS, the same way the live one gets it — the browser app won't talk to a copy
+without it. The certificate you already have covers any port on the same address, so there's
+nothing new to obtain; it just needs the same certificate settings the live one uses.
+
+### 4. Tell me two things
+
+- The port number you used.
+- That it's running.
+
+I'll check it myself from there and won't need anything else.
+
+---
+
+## What "working" looks like
+
+If you want to confirm it before handing it over, this should print `200`:
+
+```sh
+curl -s -o /dev/null -w "%{http_code}\n" \
+  "https://pangenome-api.ucsd.edu:<port>/seqtubemap?chrom=chr8&start=78771162&end=78771252&version=v2"
+```
+
+It may take a minute or two the first time — it has to pull that region out of the graph,
+same as the live server does the first time anyone asks for it. Anything other than `200`,
+send me what you got.
+
+---
+
+## One thing worth knowing, unrelated to this request
+
+While going through the code I noticed something that isn't caused by this work but that this
+work makes easier to hit. When two requests for the *same* region arrive at once and that
+region hasn't been fetched before, both of them start fetching it and both write to the same
+file. One of the changes waiting to go live makes the server handle requests at the same time
+rather than one after another, so this becomes more likely than it is today.
+
+I don't think it's a reason to hold anything up — it needs two people asking for the same new
+region within seconds of each other. But you should hear it from me rather than meet it later.
+It's written up as
+[issue #54](https://github.com/CAST-genomics/PangenomeAPI/issues/54) if you ever want the
+detail; there's nothing for you to do about it.
+
+---
+
+## When we're done
+
+I'll tell you once I've clicked through enough to be confident. Then the second copy can be
+shut down and its folder deleted, and we can talk about making the changes live properly —
+which is the `release` branch procedure in [`releasing.md`](../releasing.md), not this.

--- a/docs/perf/test-deployment-request.md
+++ b/docs/perf/test-deployment-request.md
@@ -3,6 +3,9 @@
 Hi Cici — one thing to set up, and I think it's about 20 minutes. Nothing here touches the
 live server.
 
+- Rendered version, which is the one to send her: <https://claude.ai/code/artifact/ccfbbb63-c362-4cab-977d-78664278a6df>
+- Source of the rendered version: [`test-deployment-request.html`](./test-deployment-request.html)
+
 Anywhere below that says `<something>`, that's a placeholder for a real value on your end.
 If a step doesn't work, stop and ping me rather than digging.
 


### PR DESCRIPTION
Everything in `release..main` has been tested below HTTP, or against a stand-in for `vg`, on a machine with no graph files. What none of it has done is **put a picture in front of a person**.

Before promoting 33 commits — including [#46](https://github.com/CAST-genomics/PangenomeAPI/issues/46), which deliberately changes the arrangement of every strand in every document — it is worth opening `pgb` against the real thing and clicking real nodes. Especially the large ones that time out today: `fetchDocument.ts` gives up at 90 s and roughly 4 in 10 nodes never make it, which is the number this work was supposed to move.

That needs a second copy of the API running from `main`, which only Cici can create. This is the request.

## What's in it

`docs/perf/test-deployment-request.md`, with `test-deployment-request.html` beside it — the same Markdown-plus-rendered-HTML convention `seqtubemap-latency.md` already uses, with the artifact URL recorded in the Markdown so a re-publish updates that page rather than forking a second one.

Written for someone who programs but is not a systems person: what it is, why, what it does not touch, and the ways it differs from the deploy she already does — **its own folder, a different port, and leaving the live one alone.** That is genuinely the whole of it; an earlier draft of this ask made it sound like a project, and it isn't one.

It deliberately **does not prescribe how to start the process**, because that's hers and I don't know whether it's systemd, a compose file, or a terminal. Guessing would have produced confident wrong instructions.

The one caution that earns its place is the folder: both copies write temporary files to the same path *relative to their own directory* and delete them after each request, so sharing a directory would have them deleting each other's files mid-request. Everything else is her normal deploy.

## Also links #54

[#54](https://github.com/CAST-genomics/PangenomeAPI/issues/54) is the extraction race found while reading the caching branch for this: `subgraph_cached` tests `exists()`, which is neither atomic nor a test for completeness, and nothing serialises two requests for the same uncached region. Pre-existing, and not hers to fix — but [#20](https://github.com/CAST-genomics/PangenomeAPI/issues/20) makes it reachable in a way it wasn't before, and #20 is in this promotion. The note tells her plainly, with no action attached, so she doesn't meet it cold as a corrupt cache file.

## Docs only

No code, no tests, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)