### PR TITLE
Illustrate the glossary on one real tube map

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,6 +11,12 @@ tools (GFA, `vg`, `tubemap.js`) spell it, that spelling is listed under _Avoid_:
 it stays correct *inside* the tool's own file format, and stops at this codebase's
 boundary.
 
+**Illustrated**: [`docs/lexicon.html`](./docs/lexicon.html) annotates one real tube
+map with **segment**, **strand**, **band**, **pivot strand**, **node** and
+**region**, so each word can be pointed at rather than only read. Rendered at
+<https://claude.ai/code/artifact/eb3ad4a1-d1cb-44b9-a3b8-7c6e7cc12726>. It is
+abridged *from* this file — where the two disagree, this file wins.
+
 ## Language
 
 **pangenome graph**:

--- a/docs/lexicon.html
+++ b/docs/lexicon.html
@@ -1,0 +1,348 @@
+<title>Seven Words for One Picture</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600&family=EB+Garamond:ital,wght@0,400;0,500;1,400&family=IBM+Plex+Mono:wght@400;500&display=swap">
+
+<style>
+  :root {
+    --paper:    #F7F7F4;
+    --ink:      #1A1D1A;
+    --ink-soft: #585E59;
+    --rule:     #D3D6D0;
+    --plate:    #FFFFFF;
+    --plate-ink:#1A1D1A;
+    --flag:     #8F3222;
+
+    --measure: 62ch;
+    --s--1: clamp(.80rem, .78rem + .10vw, .86rem);
+    --s-0:  clamp(1.06rem, 1.02rem + .18vw, 1.18rem);
+    --s-1:  clamp(1.26rem, 1.16rem + .45vw, 1.5rem);
+    --s-2:  clamp(1.5rem, 1.28rem + .95vw, 2.05rem);
+    --s-3:  clamp(2.0rem, 1.55rem + 2.0vw, 3.15rem);
+
+    --grotesk: "Archivo", ui-sans-serif, system-ui, -apple-system, sans-serif;
+    --serif:   "EB Garamond", ui-serif, Georgia, Cambria, serif;
+    --mono:    "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --paper: #121513; --ink: #E9EBE6; --ink-soft: #9BA29C; --rule: #2A2E2A;
+      --flag: #CC7259;
+    }
+  }
+  :root[data-theme="dark"] {
+    --paper: #121513; --ink: #E9EBE6; --ink-soft: #9BA29C; --rule: #2A2E2A;
+    --flag: #CC7259;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--serif);
+    font-size: var(--s-0);
+    line-height: 1.58;
+    margin: 0;
+    padding: 0 1.5rem 7rem;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 60rem; margin: 0 auto; }
+  .col { max-width: var(--measure); }
+
+  header { padding: 5rem 0 0; }
+  .eyebrow {
+    font-family: var(--grotesk);
+    font-size: var(--s--1);
+    font-weight: 500;
+    letter-spacing: .14em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+    margin: 0 0 1.5rem;
+  }
+  h1 {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: var(--s-3);
+    line-height: 1.04;
+    letter-spacing: -.015em;
+    text-wrap: balance;
+    margin: 0 0 1.5rem;
+    max-width: 18ch;
+  }
+  .lede { font-size: var(--s-1); line-height: 1.45; color: var(--ink-soft); margin: 0; max-width: 52ch; }
+
+  h2 {
+    font-family: var(--grotesk);
+    font-weight: 500;
+    font-size: var(--s-2);
+    line-height: 1.14;
+    letter-spacing: -.015em;
+    text-wrap: balance;
+    margin: 4rem 0 1.1rem;
+    padding-top: 1.1rem;
+    border-top: 1px solid var(--rule);
+  }
+  p { margin: 0 0 1.05rem; max-width: var(--measure); }
+  strong { font-weight: 500; }
+  em { font-style: italic; }
+  .term { font-family: var(--grotesk); font-weight: 500; font-size: .92em; }
+  code, .id { font-family: var(--mono); font-size: .84em; overflow-wrap: anywhere; }
+
+  /* ---------- the plate ---------- */
+
+  figure { margin: 2.5rem 0 0; }
+  .plate {
+    background: var(--plate);
+    color: var(--plate-ink);
+    border: 1px solid var(--rule);
+    padding: 1.25rem 1rem .75rem;
+    overflow-x: auto;
+  }
+  .plate svg { display: block; width: 100%; height: auto; min-width: 40rem; }
+  figcaption {
+    font-family: var(--grotesk);
+    font-size: var(--s--1);
+    line-height: 1.55;
+    color: var(--ink-soft);
+    margin-top: .9rem;
+    max-width: 68ch;
+  }
+  figcaption b { color: var(--ink); font-weight: 500; }
+
+  /* ---------- annotation type, inside the plate ---------- */
+
+  .a-word { font-family: var(--grotesk); font-size: 11px; font-weight: 600; letter-spacing: .01em; }
+  .a-gloss { font-family: var(--serif); font-size: 9.5px; font-style: italic; }
+  .a-lead { stroke: #1A1D1A; stroke-width: .7; fill: none; }
+  .a-frame { stroke: #1A1D1A; stroke-width: .7; fill: none; stroke-dasharray: 4 3; opacity: .45; }
+  .a-brace { stroke: #1A1D1A; stroke-width: .7; fill: none; }
+  .a-dim { fill: #585E59; }
+
+  /* ---------- the identifier breakdown ---------- */
+
+  .idfig { margin: 2.5rem 0 0; }
+  .idrow {
+    display: flex; flex-wrap: wrap; align-items: flex-end; gap: 0;
+    font-family: var(--mono); font-size: var(--s-1); letter-spacing: -.01em;
+  }
+  .idpart { display: flex; flex-direction: column; }
+  .idpart .val { padding: 0 .1em; }
+  .idpart .bar { height: 4px; border: 1px solid var(--ink); border-top: none; margin-top: .3rem; }
+  .idpart .cap {
+    font-family: var(--grotesk); font-size: var(--s--1); font-weight: 500;
+    letter-spacing: .08em; text-transform: uppercase; color: var(--ink-soft);
+    margin-top: .4rem;
+  }
+  .idsep { padding: 0 .05em; color: var(--ink-soft); }
+  .idtail { display: flex; flex-direction: column; opacity: .55; }
+  .idtail .bar { height: 4px; border: 1px dashed var(--ink); border-top: none; margin-top: .3rem; }
+
+  /* ---------- the table ---------- */
+
+  .scroll { overflow-x: auto; margin: 1.5rem 0 0; }
+  table { border-collapse: collapse; width: 100%; min-width: 40rem; }
+  caption {
+    caption-side: top; text-align: left;
+    font-family: var(--grotesk); font-size: var(--s--1); font-weight: 500;
+    letter-spacing: .1em; text-transform: uppercase; color: var(--ink-soft);
+    padding-bottom: .85rem;
+  }
+  th, td { text-align: left; padding: .7rem .9rem .7rem 0; border-bottom: 1px solid var(--rule); vertical-align: baseline; }
+  thead th {
+    font-family: var(--grotesk); font-size: var(--s--1); font-weight: 500;
+    letter-spacing: .07em; text-transform: uppercase; color: var(--ink-soft);
+    border-bottom: 1px solid var(--ink);
+  }
+  tbody th {
+    font-family: var(--grotesk); font-weight: 600; font-size: var(--s-0);
+    white-space: nowrap; padding-right: 1.5rem;
+  }
+  td { font-size: .95em; line-height: 1.5; }
+  .no { color: var(--flag); font-family: var(--grotesk); font-size: .9em; }
+  .no s { text-decoration-thickness: 1px; }
+
+  ul { margin: 0 0 1.05rem; padding-left: 1.1rem; max-width: var(--measure); }
+  li { margin-bottom: .5rem; }
+  li::marker { color: var(--ink-soft); }
+
+  footer {
+    margin-top: 4.5rem; padding-top: 1.1rem; border-top: 1px solid var(--rule);
+    font-family: var(--grotesk); font-size: var(--s--1); color: var(--ink-soft);
+  }
+  @media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } }
+</style>
+
+<div class="wrap">
+
+  <header>
+    <p class="eyebrow">PangenomeAPI · shared vocabulary</p>
+    <h1>Seven words for one picture</h1>
+    <p class="lede">Every term below names something you can point at. The drawing is real
+    output from the generator, not an illustration — six segments, four haplotypes, fourteen
+    bands.</p>
+  </header>
+
+  <figure>
+    <div class="plate">
+      <svg viewBox="-240 -95 800 315" role="img"
+           aria-label="A sequence tube map with six segment boxes and four coloured haplotype ribbons, annotated with the terms region, pivot strand, strand, band, segment, sequence tube map, and node.">
+
+        <!-- the node: everything the tube map draws is inside one -->
+        <rect class="a-frame" x="-14" y="-46" width="350" height="236" />
+
+        <!-- ============ real generator output, unaltered ============ -->
+        <g class="track"><rect x="0" y="65" width="48" height="15" style="fill: rgb(107, 174, 214); fill-opacity: 1;"></rect><rect x="101.28571428571429" y="90" width="26" height="15" style="fill: rgb(107, 174, 214); fill-opacity: 1;"></rect><rect x="189.14285714285714" y="65" width="136.28571428571425" height="15" style="fill: rgb(107, 174, 214); fill-opacity: 1;"></rect><rect x="0" y="50" width="325.4285714285714" height="15" style="fill: rgb(158, 202, 225); fill-opacity: 1;"></rect><rect x="0" y="35" width="127.28571428571429" height="15" style="fill: rgb(198, 219, 239); fill-opacity: 1;"></rect><rect x="189.14285714285714" y="-5" width="28" height="15" style="fill: rgb(198, 219, 239); fill-opacity: 1;"></rect><rect x="270.4285714285714" y="20" width="55" height="15" style="fill: rgb(198, 219, 239); fill-opacity: 1;"></rect><rect x="0" y="20" width="127.28571428571429" height="15" style="fill: rgb(252, 187, 161); fill-opacity: 1;"></rect><rect x="189.14285714285714" y="35" width="136.28571428571425" height="15" style="fill: rgb(252, 187, 161); fill-opacity: 1;"></rect><path d="M 47 65 C 74.64285714285714 65 74.64285714285714 90 102.28571428571429 90 V 105 C 74.64285714285714 105 74.64285714285714 80 47 80 Z" style="fill: rgb(107, 174, 214); fill-opacity: 1;"></path><path d="M 126.28571428571429 35 C 158.21428571428572 35 158.21428571428572 -5 190.14285714285714 -5 V 10 C 158.21428571428572 10 158.21428571428572 50 126.28571428571429 50 Z" style="fill: rgb(198, 219, 239); fill-opacity: 1;"></path><path d="M 126.28571428571429 20 C 158.21428571428572 20 158.21428571428572 35 190.14285714285714 35 V 50 C 158.21428571428572 50 158.21428571428572 35 126.28571428571429 35 Z" style="fill: rgb(252, 187, 161); fill-opacity: 1;"></path><path d="M 126.28571428571429 90 C 158.21428571428572 90 158.21428571428572 65 190.14285714285714 65 V 80 C 158.21428571428572 80 158.21428571428572 105 126.28571428571429 105 Z" style="fill: rgb(107, 174, 214); fill-opacity: 1;"></path><path d="M 216.14285714285714 -5 C 243.78571428571428 -5 243.78571428571428 20 271.4285714285714 20 V 35 C 243.78571428571428 35 243.78571428571428 10 216.14285714285714 10 Z" style="fill: rgb(198, 219, 239); fill-opacity: 1;"></path></g><g class="node"><path id="1" d="M 11 20 Q 11 11 20 11 L 47 11 Q 56 11 56 20 L 56 80 Q 56 89 47 89 L 20 89 Q 11 89 11 80 L 11 20" style="fill: rgb(255, 255, 255); fill-opacity: 0.4; stroke: rgb(0, 0, 0); stroke-width: 2px;"></path><path id="2" d="M 92.28571428571429 20 Q 92.28571428571429 11 101.28571428571429 11 L 126.28571428571429 11 Q 135.28571428571428 11 135.28571428571428 20 L 135.28571428571428 65 Q 135.28571428571428 74 126.28571428571428 74 L 101.28571428571428 74 Q 92.28571428571428 74 92.28571428571428 65 L 92.28571428571428 20" style="fill: rgb(255, 255, 255); fill-opacity: 0.4; stroke: rgb(0, 0, 0); stroke-width: 2px;"></path><path id="3" d="M 92.28571428571429 90 Q 92.28571428571429 81 101.28571428571429 81 L 123.28571428571429 81 Q 132.28571428571428 81 132.28571428571428 90 L 132.28571428571428 105 Q 132.28571428571428 114 123.28571428571428 114 L 101.28571428571428 114 Q 92.28571428571428 114 92.28571428571428 105 L 92.28571428571428 90" style="fill: rgb(255, 255, 255); fill-opacity: 0.4; stroke: rgb(0, 0, 0); stroke-width: 2px;"></path><path id="4" d="M 180.14285714285714 35 Q 180.14285714285714 26 189.14285714285714 26 L 216.14285714285714 26 Q 225.14285714285714 26 225.14285714285714 35 L 225.14285714285714 80 Q 225.14285714285714 89 216.14285714285714 89 L 189.14285714285714 89 Q 180.14285714285714 89 180.14285714285714 80 L 180.14285714285714 35" style="fill: rgb(255, 255, 255); fill-opacity: 0.4; stroke: rgb(0, 0, 0); stroke-width: 2px;"></path><path id="5" d="M 180.14285714285714 -5 Q 180.14285714285714 -14 189.14285714285714 -14 L 213.14285714285714 -14 Q 222.14285714285714 -14 222.14285714285714 -5 L 222.14285714285714 10 Q 222.14285714285714 19 213.14285714285714 19 L 189.14285714285714 19 Q 180.14285714285714 19 180.14285714285714 10 L 180.14285714285714 -5" style="fill: rgb(255, 255, 255); fill-opacity: 0.4; stroke: rgb(0, 0, 0); stroke-width: 2px;"></path><path id="6" d="M 261.4285714285714 20 Q 261.4285714285714 11 270.4285714285714 11 L 304.4285714285714 11 Q 313.4285714285714 11 313.4285714285714 20 L 313.4285714285714 80 Q 313.4285714285714 89 304.4285714285714 89 L 270.4285714285714 89 Q 261.4285714285714 89 261.4285714285714 80 L 261.4285714285714 20" style="fill: rgb(255, 255, 255); fill-opacity: 0.4; stroke: rgb(0, 0, 0); stroke-width: 2px;"></path></g><path d="M8 -36 L16 -26 L24 -36" stroke-width="0" fill="#FFFE3A" stroke="none"></path><path d="M297.8035714285714 -36 L305.8035714285714 -26 L313.8035714285714 -36" stroke-width="0" fill="#FFFE3A" stroke="none"></path><line x1="16" y1="-31" x2="305.8035714285714" y2="-31" stroke-width="4" stroke="#FFFE3A"></line><line x1="16" y1="-25" x2="308.4285714285714" y2="-25" stroke-width="1" stroke="black"></line><line x1="16" y1="-30" x2="16" y2="-20" stroke-width="1" stroke="black"></line><line x1="308.4285714285714" y1="-30" x2="308.4285714285714" y2="-20" stroke-width="1" stroke="black"></line><text text-anchor="start" x="16" y="-33" font-family="&quot;Courier New&quot;, &quot;Courier&quot;, &quot;Lucida Console&quot;, monospace" font-size="12px" fill="black">0</text>
+        <!-- ============ end generator output ============ -->
+
+        <!-- region -->
+        <path class="a-lead" d="M 40 -56 L 90 -34" />
+        <text class="a-word" x="16" y="-66">region</text>
+        <text class="a-gloss a-dim" x="16" y="-78">the chrom : start – end that was asked for</text>
+
+        <!-- pivot strand -->
+        <line class="a-lead" x1="-22" y1="27.5" x2="-2" y2="27.5" />
+        <text class="a-word" x="-26" y="25" text-anchor="end">pivot strand</text>
+        <text class="a-gloss a-dim" x="-26" y="37" text-anchor="end">GRCh38 — everything else is arranged around it</text>
+
+        <!-- segment -->
+        <line class="a-lead" x1="-22" y1="100" x2="90" y2="100" />
+        <text class="a-word" x="-26" y="97.5" text-anchor="end">segment</text>
+        <text class="a-gloss a-dim" x="-26" y="109.5" text-anchor="end">one stretch of sequence — here, ACGTCA</text>
+
+        <!-- strand -->
+        <line class="a-lead" x1="366" y1="42.5" x2="327" y2="42.5" />
+        <text class="a-word" x="370" y="40">strand</text>
+        <text class="a-gloss a-dim" x="370" y="52">one haplotype's whole route, end to end</text>
+
+        <!-- band, straight -->
+        <line class="a-lead" x1="366" y1="72.5" x2="327" y2="72.5" />
+        <text class="a-word" x="370" y="70">band</text>
+        <text class="a-gloss a-dim" x="370" y="82">one piece of one strand</text>
+
+        <!-- band, curved -->
+        <path class="a-lead" d="M 120 134 L 156 96" />
+        <text class="a-word" x="108" y="146" text-anchor="middle">band</text>
+        <text class="a-gloss a-dim" x="108" y="158" text-anchor="middle">a curve is one too</text>
+
+        <!-- sequence tube map -->
+        <path class="a-brace" d="M 0 166 L 0 172 L 325.43 172 L 325.43 166" />
+        <text class="a-word" x="162.7" y="186" text-anchor="middle">sequence tube map</text>
+
+        <!-- node -->
+        <line class="a-lead" x1="330" y1="190" x2="330" y2="197" />
+        <text class="a-word" x="336" y="206" text-anchor="end">node</text>
+        <text class="a-gloss a-dim" x="336" y="218" text-anchor="end">the whole picture is the inside of one</text>
+
+      </svg>
+    </div>
+    <figcaption>
+      Six segments, four haplotypes, fourteen bands — <code>spineNodes: 6, haplotypes: 3, seed: 1</code>
+      through the real generator. Look at the third ribbon from the top: it crosses the entire
+      picture as <b>one single band</b>, because it never changes lane. The salmon one takes
+      <b>three</b> — two straight runs and the curve between them. Both are exactly one strand,
+      and that is the whole distinction.
+    </figcaption>
+  </figure>
+
+  <h2>A strand's name is three things</h2>
+
+  <p class="col">Every strand is identified by a triple, and the triple is the whole of its identity.
+  A haplotype that appears in several fragments is still one strand.</p>
+
+  <figure class="idfig">
+    <div class="idrow">
+      <span class="idpart"><span class="val">HG10002</span><span class="bar"></span><span class="cap">assembly</span></span>
+      <span class="idsep">#</span>
+      <span class="idpart"><span class="val">1</span><span class="bar"></span><span class="cap">haplotype</span></span>
+      <span class="idsep">#</span>
+      <span class="idpart"><span class="val">chr1</span><span class="bar"></span><span class="cap">contig</span></span>
+      <span class="idtail"><span class="val">#0[9659985-9661740]</span><span class="bar"></span><span class="cap">vg's own tail</span></span>
+    </div>
+    <figcaption>
+      An <b>assembly</b> is one sequenced individual, contributing two strands per chromosome — one
+      per haplotype. The greyed tail is metadata <code>vg</code> appends on its own; it travels the
+      wire verbatim, because rewriting it would make our documents disagree with the tool that
+      produced them. We truncate back to the triple only where something is looked up, such as a
+      colour.
+    </figcaption>
+  </figure>
+
+  <h2>The words</h2>
+
+  <div class="scroll">
+    <table>
+      <caption>What each term points at, and the spelling it replaces</caption>
+      <thead>
+        <tr><th>Term</th><th>What it is in the picture</th><th>Not</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th>segment</th>
+          <td>One of the six outlined boxes. A stretch of sequence — typically tiny, most are
+          single-base variants.</td>
+          <td class="no"><s>node</s> — that word is taken</td>
+        </tr>
+        <tr>
+          <th>strand</th>
+          <td>One coloured ribbon, end to end. One haplotype's route through the picture,
+          identified by <span class="id">sample#haplotype#contig</span>.</td>
+          <td class="no"><s>track</s> <s>path</s> <s>walk</s></td>
+        </tr>
+        <tr>
+          <th>band</th>
+          <td>One piece of one strand — a straight run or a single curve. The atomic drawable.
+          A band count counts shapes, not genomes.</td>
+          <td class="no"><s>ribbon</s> — reads as the whole strand</td>
+        </tr>
+        <tr>
+          <th>pivot strand</th>
+          <td>The strand the layout arranges every other around. It fixes segment order and
+          orientation. GRCh38 where present.</td>
+          <td class="no">not merely "the first one"</td>
+        </tr>
+        <tr>
+          <th>node</th>
+          <td>Not visible here. The whole picture is the inside of one node — the coarse vertex
+          drawn in 3D, addressed as <span class="id">141452+</span>.</td>
+          <td class="no"><s>segment</s> — the finer thing</td>
+        </tr>
+        <tr>
+          <th>region</th>
+          <td>The yellow bar: a <span class="id">chrom, start, end</span> triple in GRCh38
+          coordinates. The address of every request.</td>
+          <td class="no">not the same as a node</td>
+        </tr>
+        <tr>
+          <th>sequence&nbsp;tube&nbsp;map</th>
+          <td>The whole drawing: a base-resolution picture of what is inside one node.</td>
+          <td class="no">—</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>Why the rejected words are listed</h2>
+
+  <p class="col">Each one is correct somewhere else, which is exactly why it causes trouble. A GFA
+  <span class="id">W</span> line calls a strand a walk; a <span class="id">P</span> line and
+  <code>vg</code>'s JSON call it a path; <code>tubemap.js</code> and the attributes in the emitted
+  document call it a track; the biology calls it a haplotype. Five spellings for one concept, all
+  of them right inside their own file format.</p>
+
+  <p class="col">The rule is that each stays correct <em>inside</em> the tool that uses it, and stops
+  at this codebase's boundary. That is why the document still carries
+  <span class="id">trackID</span> and <span class="id">trackName</span> — those are attribute names
+  in a format a client already parses — while everything we write about them says strand.</p>
+
+  <p class="col">The one that costs the most is <span class="term">node</span>. Both granularities
+  appear in the same URL: <span class="id">minigraphnode</span> names the coarse one, and the
+  picture it returns is made of the fine ones. That collision is the reason the distinction is
+  written down rather than left to context.</p>
+
+  <footer>
+    Drawing: <code>spineNodes: 6, haplotypes: 3, seqLen: 8, seed: 1</code> through
+    <code>perf/gen-vg-json.mjs</code> and <code>seqtubemap/render.mjs</code>. Definitions abridged
+    from <code>CONTEXT.md</code>, which is shared with <code>pgb</code> and is the authority.
+  </footer>
+
+</div>


### PR DESCRIPTION
Six of the seven words in `CONTEXT.md` name something you can point at, and until now none of them was ever pointed at.

**band** is the one that prompted this. Read cold, it sounds like it might mean a haplotype's whole run — which is what **strand** means. The two sit one entry apart in the glossary and a whole concept apart in the code, and no amount of careful prose fixes that as fast as one annotated picture does.

## What's here

`docs/lexicon.html` annotates a single sequence tube map with **segment**, **strand**, **band**, **pivot strand**, **node** and **region**, plus the strand identifier decomposed into assembly / haplotype / contig with `vg`'s appended tail greyed out. Then a table pairing each term with the spelling it replaces, and a short note on why five tools each have a different correct word for "strand".

**The drawing is real output, not an illustration.** `spineNodes: 6, haplotypes: 3, seqLen: 8, seed: 1` through `perf/gen-vg-json.mjs` and `seqtubemap/render.mjs`. Every annotation is positioned from that render's own band data, so each leader points at an element that actually exists at those coordinates. The only edit was stripping `trackID` / `trackName` / `pclai*`, which are invisible.

Two things the picture does that the prose could not:

- **`node` is drawn as a dashed frame around everything**, because it is the one term with nothing *inside* the picture to point at. The whole drawing is the inside of one node, and an enclosure is the only honest way to say that.
- **`band` is labelled twice** — once on a straight run, once on the curve beside it. "A curve is also a band" is precisely the fact that does not survive being written down.

The fixture makes the central point for free: the third ribbon crosses the entire picture as **one** band, while GRCh38 takes **three**. One strand either way.

## Where it sits

`CONTEXT.md` gains a pointer to it and remains the authority — the page says so in its own footer, and the commit says so too. Worth offering the same link to `pgb`'s copy of the glossary, which must not diverge from this one; that's a change in the other repo, so it isn't in this PR.

Stored as artifact source with no document wrapper, matching `docs/perf/seqtubemap-latency.html`.

Rendered: <https://claude.ai/code/artifact/eb3ad4a1-d1cb-44b9-a3b8-7c6e7cc12726>

## Docs only

No code, no tests, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)