### PR TITLE
Round the colour channels the document writes, as jsdom used to

### DIFF
--- a/seqtubemap/emit-document.mjs
+++ b/seqtubemap/emit-document.mjs
@@ -120,11 +120,31 @@ function css(declarations) {
 
 // The layout names colours as hex; a stylesheet says them as `rgb()`, and the
 // document has always carried the stylesheet's spelling.
+//
+// A channel is rounded to a whole number on the way out, because `pgb`'s grammar
+// matches `rgb\((\d+), (\d+), (\d+)\)` and refuses the whole document over a
+// single band it cannot read. A PCLAI scheme supplies its channels as floats —
+// the walks file carries them that way and `bandage_graph.py` parses them with
+// `float()` — so a region whose scheme holds e.g. 228.5 emits a colour no client
+// can parse. This is not new rounding: the emulated document rounded here too,
+// in jsdom's CSS serializer, half away from zero, and this reproduces that.
 function cssColor(color) {
   const hex = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color);
-  if (!hex) return color; // already `rgb(r, g, b)` — what a PCLAI scheme supplies
+  if (!hex) return wholeChannels(color); // already `rgb(r, g, b)` — what a PCLAI scheme supplies
   const [r, g, b] = hex.slice(1).map((pair) => parseInt(pair, 16));
   return `rgb(${r}, ${g}, ${b})`;
+}
+
+// `rgb(r, g, b)` with each channel a whole number in 0..255, as a stylesheet
+// would serialize it. Anything that is not that spelling is left alone.
+function wholeChannels(color) {
+  const rgb = /^rgb\(\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*\)$/.exec(String(color));
+  if (!rgb) return color;
+  const channels = rgb.slice(1).map((channel) => {
+    const value = Math.round(Number(channel));
+    return Math.min(255, Math.max(0, value));
+  });
+  return `rgb(${channels.join(", ")})`;
 }
 
 // A non-breaking space is written as an entity wherever it appears — in an

--- a/tests/node/document-conformance.test.mjs
+++ b/tests/node/document-conformance.test.mjs
@@ -19,7 +19,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { cases, goldenPath, repoRoot } from "./golden-cases.mjs";
-import { assertParseableByPgb, drawables, readBands } from "./pgb-parser.mjs";
+import { assertParseableByPgb, drawables, readBands, strandGroup } from "./pgb-parser.mjs";
 
 // Measured on the jsdom-era goldens, at commit 399db1e. `small-normal` had no
 // golden then — the mode was not deterministic enough to have one — so its count
@@ -171,4 +171,48 @@ test("a reversal draws shapes pgb cannot read, and this is where that is written
     `expected pgb's grammar to miss some of the ${counted} drawables, but it matched all of them`,
   );
   assert.throws(() => assertParseableByPgb(document), /are not bands pgb recognises/);
+});
+
+test("a PCLAI scheme with fractional channels still emits colours pgb can read", async () => {
+  // The live failure this test was written from: `pgb` refused a chr7 document
+  // whole, over 6 of its 1,626 drawables, because their strand's colour was
+  // `rgb(0, 228.5, 178.5)`. `pgb`'s grammar matches whole-number channels only,
+  // and a PCLAI scheme supplies floats — the walks file carries them that way and
+  // `bandage_graph.py` parses them with `float()`.
+  //
+  // The emulated document rounded them in jsdom's CSS serializer on the way out,
+  // so this never surfaced before #22; the emitter has to round them itself, and
+  // `cssColor` is where it does. No committed scheme holds a fractional channel,
+  // which is exactly why nothing caught it — so one is made here, from a real
+  // subgraph's own scheme, by putting every channel half a step off.
+  const { pclaiPath, realCases, regionOf, inputPath } = await import("./real-cases.mjs");
+  const { renderTubeMap } = await import("../../seqtubemap/render.mjs");
+
+  const name = realCases[0];
+  const scheme = JSON.parse(readFileSync(pclaiPath(name), "utf8"));
+  for (const entry of Object.values(scheme)) {
+    entry[0] = entry[0].map((channel) => channel + 0.5);
+  }
+
+  const { start, end } = regionOf(name);
+  const { document, bandData } = await renderTubeMap({
+    inputFile: inputPath(name),
+    start,
+    end,
+    nodeWidthOption: "compressed",
+    pclaiColorScheme: scheme,
+  });
+
+  // The scheme really did colour the picture, so the assertion below is about it.
+  assert.ok(
+    bandData.strands.some((strand) => /\.\d/.test(strand.color)),
+    "no strand carries a fractional colour, so this test is no longer about anything",
+  );
+
+  assert.doesNotMatch(
+    strandGroup(document),
+    /fill: rgb\([^)]*\.\d/,
+    "a band's colour reached the document with a fractional channel, which pgb cannot read",
+  );
+  assertParseableByPgb(document, bandData);
 });


### PR DESCRIPTION
The live trial of increment B refused its first real region. `pgb` threw `NonConformingDocument` over `chr7:55134330` — 6 of the document's 1,626 drawables were not bands it recognised — and `pgb` refuses the whole document when the counted and matched totals disagree, so nothing drew at all.

## The six

```
style="fill: rgb(0, 228.5, 178.5); fill-opacity: 1;" trackID="263" trackName="HG03098#1#CM092232.1#0[…]"
```

Fractional colour channels. `pgb`'s grammar is `rgb\((\d+), (\d+), (\d+)\)` — whole numbers only. Two strands were affected (trackID 263 and 105), 4 rects and 2 curves between them. The channels come from the walks file: `bandage_graph.py` parses them with `float()`, and `generateTrackColor` interpolates them straight into `rgb(...)`.

## Why it is new

The emulated document rounded them. `d3.style("fill", …)` set the property on a jsdom element, and jsdom's CSS serializer wrote it back rounded:

```
"rgb(0, 228.5, 178.5)"   -> "fill: rgb(0, 229, 179); fill-opacity: 1;"
"rgb(229.5, 163.5, 255)" -> "fill: rgb(230, 164, 255); fill-opacity: 1;"
```

(Confirmed by running jsdom 29 — release's pinned range — over those exact strings.) #22 deleted the emulation and with it a rounding step nobody knew was load-bearing. `cssColor` now rounds and clamps itself, half away from zero, which is the value cssstyle produced. Hex input is unchanged.

This is **not** #52: no reversal is involved, and every one of the six carries its `fill-opacity`, its `trackName` and a cubic path.

## Why nothing caught it

No committed scheme holds a fractional channel. The synthetic golden's are whole floats (`227.0`), which stringify as integers, and all five real subgraph fixtures are integers. `chr7` is the first region we have pointed at that is not.

The new test in `document-conformance.test.mjs` makes one: it renders the smallest real subgraph with that subgraph's own PCLAI scheme shifted half a step off every channel, and asserts both that no fractional channel reaches the document and that `pgb` accepts it. It fails without the fix.

## Verification

- `npm test`: 79 pass, 0 fail, 2 skipped — unchanged.
- Goldens byte-identical, for the same reason they missed the bug.
- Against the live response itself: 1620/1626 drawables match today, 1626/1626 with the channels rounded.

Cici needs to re-pull `main` and restart before the error card goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQLSZisy2XbiuZBWhddjnF