### PR TITLE
Stop one wedged request from breaking every uncached region

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,7 +83,7 @@ class MissingWalkDerivative(RuntimeError):
 
 
 class WalkDerivative:
-    """One tabix-indexed walk derivative, opened the first time it is read.
+    """One tabix-indexed walk derivative, opened the first time a thread reads it.
 
     Stands in for the `pysam.TabixFile` the call sites used to be handed: they
     call `fetch` and nothing else. The open is deferred because these files are
@@ -93,35 +93,49 @@ class WalkDerivative:
     now a `MissingWalkDerivative` on the request that needed it, naming the file
     and what wanted it, instead of a crash before the first request.
 
-    The handle is kept, so a file is opened once per process rather than once
-    per request. Endpoints run in FastAPI's threadpool, hence the lock.
+    **One handle per thread, and that is load-bearing.** A `pysam.TabixFile` is
+    one htslib file handle with one seek position, and pysam does not support
+    reading it from two threads at once. `fetch` compounds that: it returns a
+    lazy iterator, so the handle stays in use for as long as the *caller* takes
+    to consume it — `GenerateWalksMC` holds one open per `S` line, for minutes on
+    a large region — and no lock this class could take around `fetch` would cover
+    that. Endpoints run in FastAPI's threadpool, so two requests really do
+    overlap. Sharing one handle across them interleaved the seeks and left the
+    handle broken for the life of the process: after it, every request that read
+    a walk derivative failed, while cached requests, which read none, went on
+    working. `threading.local` gives each threadpool thread its own handle, which
+    is the granularity pysam actually supports. The pool is small and long-lived,
+    so this is a handful of handles, still opened once each rather than per
+    request.
     """
 
     def __init__(self, path, purpose):
         self.path = Path(path)
         self.purpose = purpose
-        self._tabix_file = None
-        self._lock = threading.Lock()
+        self._per_thread = threading.local()
 
     def fetch(self, *args, **kwargs):
         return self._open().fetch(*args, **kwargs)
 
     def _open(self):
-        with self._lock:
-            if self._tabix_file is None:
-                try:
-                    self._tabix_file = pysam.TabixFile(str(self.path))
-                except (OSError, ValueError) as error:
-                    # pysam raises for both the file and its tabix index, and
-                    # says only "could not open" — the path and the caller are
-                    # what makes it actionable.
-                    raise MissingWalkDerivative(
-                        f"{self.path} could not be opened, and it is needed to "
-                        f"{self.purpose}. It is a team-generated walk derivative: "
-                        f"put it, and its tabix index, in the directory named by "
-                        f"`git config data.path`. ({error})"
-                    ) from error
-        return self._tabix_file
+        # No lock: the attribute lives on this thread's `threading.local`, so
+        # there is nothing here for another thread to race with.
+        tabix_file = getattr(self._per_thread, "tabix_file", None)
+        if tabix_file is None:
+            try:
+                tabix_file = pysam.TabixFile(str(self.path))
+            except (OSError, ValueError) as error:
+                # pysam raises for both the file and its tabix index, and
+                # says only "could not open" — the path and the caller are
+                # what makes it actionable.
+                raise MissingWalkDerivative(
+                    f"{self.path} could not be opened, and it is needed to "
+                    f"{self.purpose}. It is a team-generated walk derivative: "
+                    f"put it, and its tabix index, in the directory named by "
+                    f"`git config data.path`. ({error})"
+                ) from error
+            self._per_thread.tabix_file = tabix_file
+        return tabix_file
 
 
 @app.exception_handler(MissingWalkDerivative)
@@ -243,9 +257,16 @@ def PreprocessMCSubgraphV1(gfa_preprocessed, gfa_postprocessed, mc_mapped_walks,
         subgfa_postprocess.write(f"L\t{link[1]}\t{link[2]}\t{link[3]}\t{link[4]}\t{link[5]}\n")
 
 def GenerateWalksMC(preprocess_gfa_subgraph_no_walk, preprocess_gfa_subgraph_w_walk, mc_mapped_walks_v2, log):
-    
     """
     Add W lines to minigraph cactus subgraph .gfa
+
+    Written under a temporary name and renamed into place only once the W lines
+    are down. The `W` lines are written last, after every `S` and `L` line, so a
+    run that fails partway leaves a *structurally valid GFA describing a graph
+    with no paths in it* — which the cache took for a finished extraction, and
+    which the renderer can only fail on. `os.replace` is atomic within a
+    directory, and the temporary is made in the destination's own directory so
+    that it is: either the finished file is there or nothing is.
 
     Parameters
     ----------
@@ -256,7 +277,23 @@ def GenerateWalksMC(preprocess_gfa_subgraph_no_walk, preprocess_gfa_subgraph_w_w
         mc_mapped_walks_v2: WalkDerivative
             minigraph cactus walk file
     """
-    
+    destination = Path(preprocess_gfa_subgraph_w_walk)
+    # Distinct per thread as well as per process: two requests for the same
+    # uncached region run concurrently on the threadpool (#54), and each must
+    # write its own file rather than interleave into one.
+    partial = destination.with_name(
+        f"{destination.name}.partial-{os.getpid()}-{threading.get_ident()}"
+    )
+    try:
+        _write_walks_mc(preprocess_gfa_subgraph_no_walk, partial, mc_mapped_walks_v2, log)
+    except BaseException:
+        partial.unlink(missing_ok=True)
+        raise
+    os.replace(partial, destination)
+
+
+def _write_walks_mc(preprocess_gfa_subgraph_no_walk, preprocess_gfa_subgraph_w_walk, mc_mapped_walks_v2, log):
+    """The body of `GenerateWalksMC`, writing wherever it is pointed."""
     gfa_no_walk = open(preprocess_gfa_subgraph_no_walk, "r")
     gfa_w_walk = open(preprocess_gfa_subgraph_w_walk, "w")
     strand_translation = {"+":">", "-":"<"}
@@ -385,7 +422,56 @@ def GenerateWalksMC(preprocess_gfa_subgraph_no_walk, preprocess_gfa_subgraph_w_w
                 walk_start = sorted_coords_final[q][0][0]
                 walk_end = sorted_coords_final[q][-1][1]
                 gfa_w_walk.write(f"W\t{sample}\t{haplo}\t{contig}\t{walk_start}\t{walk_end}\t{write_walk}\n")
-            
+
+    gfa_w_walk.close()
+    gfa_no_walk.close()
+
+
+def subgraph_has_walks(gfa_subgraph):
+    """True when this extracted subgraph carries at least one `W` line.
+
+    What "already extracted" has to mean, in place of "the file is there".
+    A GFA with no walks names no strands, so the renderer has nothing to draw
+    and every stage after it fails — and because the file exists, a cache keyed
+    on existence pins that failure for good rather than retrying it. This is the
+    check that tells a finished extraction from an abandoned one, and it clears
+    entries left behind before `GenerateWalksMC` wrote atomically.
+
+    Read from the end of the file: `W` lines are written after every `S` and `L`
+    line, so a subgraph that has any ends with one, and this stays constant-time
+    on a subgraph of any size.
+    """
+    gfa_subgraph = Path(gfa_subgraph)
+    if not gfa_subgraph.exists():
+        return False
+    # Comfortably more than the longest `W` line these subgraphs produce, so the
+    # window always spans a whole line when there is one to find.
+    window = 1 << 16
+    with open(gfa_subgraph, "rb") as handle:
+        handle.seek(max(0, gfa_subgraph.stat().st_size - window))
+        tail = handle.read()
+    return b"\nW\t" in tail or tail.startswith(b"W\t")
+
+
+def stage_failed(stage, region, detail):
+    """The error a failed pipeline stage raises, naming itself.
+
+    A stage that failed used to reach the client as a bare 500 from
+    `FileResponse`, over a file no stage ever wrote — which says nothing about
+    which stage failed, and reaches the browser as "Failed to fetch", because an
+    unhandled exception is rendered outside the CORS middleware and so arrives
+    with no CORS headers on it. Raised as an `HTTPException` it passes through
+    that middleware like any other response, so the browser can show what
+    happened. 502 rather than 500: every one of these stages is an external tool
+    — gbz-base, `vg`, Node — and the failure is theirs.
+    """
+    message = (
+        f"the {stage} stage failed for {region.chrom}:{region.start}-{region.end}: {detail}"
+    )
+    api_log.error(message)
+    return HTTPException(status_code=502, detail=message)
+
+
 def SeqTubeGfaProcessor(preprocess_gfa_subgraph, postprocess_gfa_subgraph, pathnumoption):
     """
     rewrite gfa to fit the input requirements of sequence tube map. Output of this function is 
@@ -444,6 +530,27 @@ def SeqTubeGfaProcessor(preprocess_gfa_subgraph, postprocess_gfa_subgraph, pathn
 
     return
 
+def _stage_succeeded(proc, described_as):
+    """Whether an external tool succeeded, and what it said when it did not.
+
+    Every one of these helpers captures the tool's stderr and has always thrown
+    it away, so a stage that failed left the server with a False and the
+    operator with nothing. The message is what turns "it returns 500" into a
+    cause; `stage_failed` points the client at it.
+    """
+    if proc.returncode == 0:
+        return True
+    stderr = (proc.stderr or b"").decode("utf-8", "replace").strip()
+    # The last few lines: these tools print progress before they print the
+    # problem, and the tail is the part that says what went wrong.
+    tail = "\n".join(stderr.splitlines()[-20:])
+    api_log.error(
+        f"`{described_as}` exited {proc.returncode}"
+        + (f", stderr:\n{tail}" if tail else " and said nothing on stderr")
+    )
+    return False
+
+
 def ConvertGfaToVg(gfa_file, vg_file):
     """
     convert .gfa to .vg with vg convert
@@ -463,8 +570,8 @@ def ConvertGfaToVg(gfa_file, vg_file):
     
     cmd = ["vg", "convert", "-g", gfa_file]
     with open(vg_file, "wb") as out:
-        proc = subprocess.run(cmd, stdout=out)
-    return proc.returncode == 0
+        proc = subprocess.run(cmd, stdout=out, stderr=subprocess.PIPE)
+    return _stage_succeeded(proc, "vg convert -g")
     
 def ConvertVgToJson(vg_file, json_file):
     """
@@ -486,7 +593,7 @@ def ConvertVgToJson(vg_file, json_file):
     cmd = ["vg", "view", "-j", vg_file]
     with open(json_file, "wb") as out:
         proc = subprocess.run(cmd, stdout=out, stderr=subprocess.PIPE)
-    return proc.returncode == 0
+    return _stage_succeeded(proc, "vg view -j")
 
 def GenerateSeqTubeMapSvg(json_file, svg_file, start, end, nodewidthoption, pclai_color_scheme = None):
     """
@@ -520,7 +627,7 @@ def GenerateSeqTubeMapSvg(json_file, svg_file, start, end, nodewidthoption, pcla
         cmd.append(json.dumps(pclai_color_scheme))
     proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-    return proc.returncode == 0
+    return _stage_succeeded(proc, "node generate-svg.mjs")
 
 def SubgraphMini(query_region, gfa_preprocessed, reference_gfa, log):
     # check gbz.db file and create subgraph
@@ -732,7 +839,11 @@ def seqtubemap(
     seqtubemap_svg = Path(f"./cache/seqtubemap/mc/subgraph_{chrom}_{str(start)}_{str(end)}_path{pathnumoption}_{version}.svg")
       
     stages = {}
-    subgraph_cached = preprocess_gfa_subgraph_w_walk.exists()
+    # A cache hit is a subgraph with walks in it, not merely a file at the path:
+    # see subgraph_has_walks. An entry that fails this is re-extracted rather
+    # than served, so an extraction that died halfway costs one retry instead of
+    # breaking its region until somebody deletes the file by hand.
+    subgraph_cached = subgraph_has_walks(preprocess_gfa_subgraph_w_walk)
 
     with stage_timing(stages, "subgraph_extract"):
         if not subgraph_cached:
@@ -745,14 +856,32 @@ def seqtubemap(
                 background_tasks.add_task(delete_files, [preprocess_gfa_subgraph_no_walk])
             else:
                 log.error(f"Invalid graph version {version}(valid versions: \"v1\" or \"v2\")")
-    
+
+    # Checked rather than assumed, and checked the same way for a fresh
+    # extraction and a cached one: everything downstream reads this file, and a
+    # subgraph with no walks in it fails every one of those stages in turn, each
+    # for a reason further from the cause.
+    if not subgraph_has_walks(preprocess_gfa_subgraph_w_walk):
+        raise stage_failed(
+            "subgraph_extract",
+            query_region,
+            f"{preprocess_gfa_subgraph_w_walk.name} carries no W lines, so the "
+            "subgraph names no strands. Either the region yielded no walks, or "
+            "the extraction did not finish.",
+        )
+
     # TODO update SeqTubeGfaProcessor; pathnumoption = compressed is currently not supported
     # with stage_timing(stages, "gfa_process"):
         # SeqTubeGfaProcessor(preprocess_gfa_subgraph, postprocess_gfa_subgraph, pathnumoption)
     with stage_timing(stages, "gfa_to_vg"):
-        ConvertGfaToVg(preprocess_gfa_subgraph_w_walk, vg_subgraph)
+        converted_to_vg = ConvertGfaToVg(preprocess_gfa_subgraph_w_walk, vg_subgraph)
+    if not converted_to_vg:
+        raise stage_failed("gfa_to_vg", query_region, "`vg convert -g` exited non-zero")
+
     with stage_timing(stages, "vg_to_json"):
-        ConvertVgToJson(vg_subgraph, json_subgraph)
+        converted_to_json = ConvertVgToJson(vg_subgraph, json_subgraph)
+    if not converted_to_json:
+        raise stage_failed("vg_to_json", query_region, "`vg view -j` exited non-zero")
     
     with stage_timing(stages, "get_pclai_color_scheme"):
         pclai_color_scheme = None
@@ -764,7 +893,14 @@ def seqtubemap(
                 pclai_color_scheme = GetPclaiColorScheme(minigraphnode, minigraph_walks_v2_updated, log)
             
     with stage_timing(stages, "generate_svg"):
-        GenerateSeqTubeMapSvg(json_subgraph, seqtubemap_svg, start, end, nodewidthoption, pclai_color_scheme)
+        rendered = GenerateSeqTubeMapSvg(json_subgraph, seqtubemap_svg, start, end, nodewidthoption, pclai_color_scheme)
+    if not rendered or not seqtubemap_svg.exists():
+        raise stage_failed(
+            "generate_svg",
+            query_region,
+            "the Node render exited non-zero or wrote no document; its stderr is "
+            "in the log above",
+        )
 
     def size_mb(path):
         return round(path.stat().st_size / 1048576, 2) if path.exists() else None

--- a/tests/python/test_endpoints_do_not_block_the_event_loop.py
+++ b/tests/python/test_endpoints_do_not_block_the_event_loop.py
@@ -56,6 +56,16 @@ FAST_REQUEST = (
 )
 
 
+# What a stage has to leave behind for the pipeline to carry on: a `W` line, so
+# the extracted subgraph counts as one with walks in it
+# (`main.py:subgraph_has_walks`), and a truthy return, so the stage counts as
+# having succeeded. Both are checked now — a stage that produces nothing is a
+# 502 naming itself rather than a 500 three stages later
+# (tests/python/test_pipeline_failures.py) — and a stand-in has to satisfy the
+# same contract as the real thing or it is standing in for something else.
+STAND_IN_OUTPUT = b"H\tVN:Z:1.1\nS\t1\tACGT\nW\tHG1\t1\tchr1\t0\t4\t>1\n"
+
+
 def _stage_writing_its_output(stalls_for=None):
     """Stand in for one pipeline stage: write the output path it was handed.
 
@@ -67,7 +77,8 @@ def _stage_writing_its_output(stalls_for=None):
     def stage(*args, **kwargs):
         if stalls_for is not None:
             time.sleep(stalls_for)
-        Path(args[1]).write_bytes(b"stand-in for a pipeline stage's output\n")
+        Path(args[1]).write_bytes(STAND_IN_OUTPUT)
+        return True
 
     return stage
 

--- a/tests/python/test_pipeline_failures.py
+++ b/tests/python/test_pipeline_failures.py
@@ -1,0 +1,291 @@
+"""What the endpoint does when a stage of the pipeline does not produce anything.
+
+Written from a live failure. During the `increment-b` trial the server wedged:
+a shared `pysam` handle broke (see `test_walk_derivatives.py`), and from then on
+every extraction died partway through `GenerateWalksMC`. Two things made that
+one hour of guessing rather than one look at a response:
+
+* the half-written subgraph stayed on disk, and the cache took a *file at the
+  path* for a finished extraction — so the affected regions kept failing at
+  0.3 s, deterministically, long after the wedge was cleared and even across a
+  restart, while every other region worked;
+* the failure reached the client as a bare 500 from `FileResponse`, over a file
+  no stage ever wrote. In the browser that is "Failed to fetch", because an
+  unhandled exception is rendered outside the CORS middleware and arrives with
+  no CORS headers on it. Nothing in it named a stage.
+
+So: a cache hit means a subgraph with walks in it, an interrupted extraction
+leaves nothing behind, and a stage that fails says which stage it was.
+
+None of these tests needs `vg`, Node, or a pangenome: each stands in for the
+stage it is not about, the way
+`test_endpoints_do_not_block_the_event_loop.py` does.
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "seqtubemap"
+
+# The same 90 bp subgraph the endpoint test uses, and the same reason: the
+# endpoint builds exactly this filename from the query below.
+CHROM, START, END, VERSION = "chr8", 78771162, 78771252, "v2"
+SUBGRAPH = FIXTURES / f"subgraph_{CHROM}_{START}_{END}_{VERSION}_with_walk.gfa"
+REQUEST = {"chrom": CHROM, "start": START, "end": END, "version": VERSION}
+
+
+@pytest.fixture
+def cache(main_module, tmp_path):
+    """A working directory holding the cache the endpoint reads, and chdir into it.
+
+    Every path the endpoint builds is relative to the process's working
+    directory (`main.py:812`), so a test that wants to control the cache has to
+    own the working directory too.
+    """
+    cache_dir = tmp_path / "cache" / "seqtubemap" / "mc"
+    cache_dir.mkdir(parents=True)
+    (tmp_path / "seqtubemap").symlink_to(REPO_ROOT / "seqtubemap")
+
+    previous = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        yield cache_dir
+    finally:
+        os.chdir(previous)
+
+
+@pytest.fixture
+def no_extraction(main_module, monkeypatch):
+    """Stand in for the two extraction stages, which need the multi-GB graph.
+
+    They become no-ops, so whatever the test put in the cache is what the rest
+    of the pipeline sees.
+    """
+    monkeypatch.setattr(main_module, "SubgraphMC", lambda *args, **kwargs: None)
+    monkeypatch.setattr(main_module, "GenerateWalksMC", lambda *args, **kwargs: None)
+
+
+def _walkless_copy_of(subgraph: Path) -> str:
+    """The fixture subgraph with its `W` lines dropped.
+
+    Exactly the artifact a failed extraction leaves: a structurally valid GFA,
+    every `H`, `S` and `L` line present, and no paths in it — because
+    `GenerateWalksMC` writes the walks last, after the whole segment section.
+    """
+    lines = subgraph.read_text().splitlines(keepends=True)
+    kept = [line for line in lines if not line.startswith("W\t")]
+    assert len(kept) < len(lines), "the fixture has no W lines to drop"
+    return "".join(kept)
+
+
+# --- what counts as an extracted subgraph -----------------------------------
+
+
+def test_a_subgraph_with_walks_is_cached(main_module):
+    assert main_module.subgraph_has_walks(SUBGRAPH)
+
+
+def test_a_subgraph_with_no_walks_is_not_cached(main_module, tmp_path):
+    """The check that tells a finished extraction from an abandoned one."""
+    walkless = tmp_path / "no_walks_with_walk.gfa"
+    walkless.write_text(_walkless_copy_of(SUBGRAPH))
+
+    assert not main_module.subgraph_has_walks(walkless)
+
+
+def test_an_absent_subgraph_is_not_cached(main_module, tmp_path):
+    assert not main_module.subgraph_has_walks(tmp_path / "not-here.gfa")
+
+
+def test_an_empty_subgraph_is_not_cached(main_module, tmp_path):
+    """The zero-byte case, which is what an extraction that died early leaves."""
+    empty = tmp_path / "empty_with_walk.gfa"
+    empty.write_bytes(b"")
+
+    assert not main_module.subgraph_has_walks(empty)
+
+
+def test_walks_are_found_however_large_the_segment_section(main_module, tmp_path):
+    """The read is from the end of the file, so size must not decide the answer.
+
+    A megabyte of `S` lines in front of the walks stands in for a real subgraph,
+    where the segment section dwarfs everything: a check that read only the head
+    of the file, or only a fixed prefix, would call this uncached.
+    """
+    large = tmp_path / "large_with_walk.gfa"
+    large.write_text("H\tVN:Z:1.1\n" + "S\t1\tACGT\n" * 200000 + "W\tHG1\t1\tchr8\t0\t4\t>1\n")
+    assert large.stat().st_size > 1 << 20
+
+    assert main_module.subgraph_has_walks(large)
+
+
+# --- an interrupted extraction leaves nothing behind ------------------------
+
+
+class _WalkDerivativeFailingAfter:
+    """A stand-in walk derivative that breaks partway, as the wedged handle did."""
+
+    def __init__(self, fail_on_call):
+        self.fail_on_call = fail_on_call
+        self.calls = 0
+
+    def fetch(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls >= self.fail_on_call:
+            raise OSError("could not create iterator for region")
+        return iter(())
+
+
+def test_an_interrupted_extraction_leaves_no_subgraph(main_module, tmp_path):
+    """Not a walk-less one, and not a partial file either: nothing.
+
+    This is the defect that outlived the wedge. The `W` lines are written after
+    every `S` and `L` line, so a run that fails midway had already written a
+    complete-looking segment section — and the next request read that as an
+    extraction it did not have to repeat.
+    """
+    no_walk = tmp_path / "subgraph_no_walk.gfa"
+    no_walk.write_text("H\tVN:Z:1.1\n" + "S\t1\tACGT\nS\t2\tGGTC\nS\t3\tTTTA\n")
+    destination = tmp_path / "subgraph_with_walk.gfa"
+
+    with pytest.raises(OSError):
+        main_module.GenerateWalksMC(
+            no_walk, destination, _WalkDerivativeFailingAfter(fail_on_call=2), main_module.api_log
+        )
+
+    assert not destination.exists(), "a failed extraction left a subgraph behind"
+    assert not list(tmp_path.glob("*.partial-*")), "a failed extraction left its temporary behind"
+
+
+def test_a_finished_extraction_is_renamed_into_place(main_module, tmp_path):
+    """And the successful path still writes the file it is asked for."""
+    no_walk = tmp_path / "subgraph_no_walk.gfa"
+    no_walk.write_text("H\tVN:Z:1.1\nS\t1\tACGT\n")
+    destination = tmp_path / "subgraph_with_walk.gfa"
+
+    class OneWalk:
+        def fetch(self, *args, **kwargs):
+            return iter(["1\t1\t4\tHG1#1|chr8:0:+\t.\n"])
+
+    main_module.GenerateWalksMC(no_walk, destination, OneWalk(), main_module.api_log)
+
+    assert main_module.subgraph_has_walks(destination)
+    assert not list(tmp_path.glob("*.partial-*"))
+
+
+# --- a stage that fails says which stage it was ------------------------------
+
+
+def test_a_walkless_cache_entry_is_reported_not_served(client, cache, no_extraction):
+    """The live failure, end to end.
+
+    With extraction stubbed out, a walk-less entry cannot be repaired — which is
+    the position the server was in — so the request must fail. What is under test
+    is *how*: a 502 naming `subgraph_extract`, rather than a 500 from
+    `FileResponse` three stages later.
+    """
+    (cache / SUBGRAPH.name).write_text(_walkless_copy_of(SUBGRAPH))
+
+    response = client.get("/seqtubemap", params=REQUEST)
+
+    assert response.status_code == 502
+    detail = response.json()["detail"]
+    assert "subgraph_extract" in detail
+    assert "W lines" in detail
+    assert f"{CHROM}:{START}-{END}" in detail
+
+
+def test_a_walkless_cache_entry_is_re_extracted(client, cache, main_module, monkeypatch):
+    """And when extraction *can* run, the bad entry is replaced rather than served.
+
+    Without this the entry is permanent: `path.exists()` was true, so the region
+    stayed broken until somebody deleted the file by hand. Extraction is stood in
+    for by one that writes the good subgraph, which is what a working server's
+    would have done.
+    """
+    (cache / SUBGRAPH.name).write_text(_walkless_copy_of(SUBGRAPH))
+    extractions = []
+
+    def extract(no_walk, with_walk, *args, **kwargs):
+        extractions.append(Path(with_walk))
+        shutil.copy(SUBGRAPH, with_walk)
+
+    monkeypatch.setattr(main_module, "SubgraphMC", lambda *args, **kwargs: None)
+    monkeypatch.setattr(main_module, "GenerateWalksMC", extract)
+    # The stage after extraction, so the test stops at the question it is asking.
+    monkeypatch.setattr(main_module, "ConvertGfaToVg", lambda *args, **kwargs: False)
+
+    response = client.get("/seqtubemap", params=REQUEST)
+
+    assert extractions, "the walk-less entry was served as a cache hit"
+    assert response.status_code == 502
+    assert "gfa_to_vg" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "stage, stubbed",
+    [
+        ("gfa_to_vg", "ConvertGfaToVg"),
+        ("vg_to_json", "ConvertVgToJson"),
+        ("generate_svg", "GenerateSeqTubeMapSvg"),
+    ],
+)
+def test_a_failing_stage_names_itself(client, cache, main_module, monkeypatch, stage, stubbed):
+    """Each stage in turn, because each one used to fail the same anonymous way.
+
+    All three already returned a boolean nobody read. The response now carries
+    the name of the one that returned False, and the tool's own stderr goes to
+    the log next to it.
+    """
+    shutil.copy(SUBGRAPH, cache / SUBGRAPH.name)
+    for name in ("ConvertGfaToVg", "ConvertVgToJson", "GenerateSeqTubeMapSvg"):
+        monkeypatch.setattr(main_module, name, lambda *args, **kwargs: True)
+    monkeypatch.setattr(main_module, stubbed, lambda *args, **kwargs: False)
+
+    response = client.get("/seqtubemap", params=REQUEST)
+
+    assert response.status_code == 502
+    assert stage in response.json()["detail"]
+
+
+def test_a_render_that_writes_no_document_is_reported(client, cache, main_module, monkeypatch):
+    """A stage can also fail by succeeding quietly and writing nothing.
+
+    `FileResponse` on a file that is not there is the 500 this whole file exists
+    to replace, so the document's absence is checked before the response is
+    built rather than by it.
+    """
+    shutil.copy(SUBGRAPH, cache / SUBGRAPH.name)
+    for name in ("ConvertGfaToVg", "ConvertVgToJson", "GenerateSeqTubeMapSvg"):
+        monkeypatch.setattr(main_module, name, lambda *args, **kwargs: True)
+
+    response = client.get("/seqtubemap", params=REQUEST)
+
+    assert response.status_code == 502
+    assert "generate_svg" in response.json()["detail"]
+
+
+def test_a_stage_failure_carries_cors_headers(client, cache, no_extraction):
+    """Why the browser said "Failed to fetch" rather than showing the status.
+
+    Starlette renders an unhandled exception outside the CORS middleware, so a
+    bare 500 reaches a cross-origin caller with no `access-control-allow-origin`
+    on it and the fetch fails at the network layer, status and body unread. An
+    `HTTPException` is a response like any other and goes through the middleware,
+    which is what lets the tube map panel show the reason.
+    """
+    (cache / SUBGRAPH.name).write_text(_walkless_copy_of(SUBGRAPH))
+
+    response = client.get(
+        "/seqtubemap", params=REQUEST, headers={"Origin": "https://pgb.example"}
+    )
+
+    assert response.status_code == 502
+    # The middleware echoes the caller's origin when it is configured to allow
+    # any; what matters is that the header is on the response at all, which is
+    # what a bare 500 lacked.
+    assert response.headers["access-control-allow-origin"] in ("*", "https://pgb.example")

--- a/tests/python/test_walk_derivatives.py
+++ b/tests/python/test_walk_derivatives.py
@@ -66,7 +66,7 @@ def test_a_present_derivative_is_read(main_module, walk_stand_in):
     ]
 
 
-def test_a_derivative_is_opened_once_per_process(main_module, walk_stand_in, monkeypatch):
+def test_a_derivative_is_opened_once_per_thread(main_module, walk_stand_in, monkeypatch):
     """Not once per request: the tabix index is paid for the first time only."""
     import pysam
 
@@ -84,3 +84,55 @@ def test_a_derivative_is_opened_once_per_process(main_module, walk_stand_in, mon
     list(derivative.fetch("chr1", 0, 200))
 
     assert opens == [str(walk_stand_in)]
+
+
+def test_two_threads_never_share_a_handle(main_module, walk_stand_in):
+    """The invariant pysam requires, and the one the live server broke.
+
+    A `pysam.TabixFile` is one htslib handle with one seek position, and `fetch`
+    hands back a lazy iterator, so the handle stays in use for as long as the
+    caller takes to read it — in `GenerateWalksMC`, minutes. Endpoints run in
+    FastAPI's threadpool, so two requests genuinely overlap; sharing one handle
+    between them interleaved the seeks and left it broken for the life of the
+    process. Every later request that read a walk derivative then failed, while
+    cached requests, which read none, kept working — which is exactly how the
+    `increment-b` trial wedged, and why only a restart cleared it.
+
+    Asserted on the handles rather than on a race, because a race that has to be
+    provoked makes a flaky test: what is checked is that there is nothing to
+    race over.
+    """
+    import threading
+
+    derivative = main_module.WalkDerivative(walk_stand_in, "a test")
+    handles = {}
+
+    def read_in_this_thread(name):
+        rows = list(derivative.fetch("chr1", 0, 200))
+        handles[name] = (derivative._open(), rows)
+
+    threads = [
+        threading.Thread(target=read_in_this_thread, args=(name,))
+        for name in ("first", "second")
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    first, second = handles["first"], handles["second"]
+    assert first[0] is not second[0], "two threads were handed the same tabix handle"
+    # And each thread read the file correctly through its own handle.
+    assert [row.split("\t")[:2] for row in first[1]] == [["chr1", "0"], ["chr1", "100"]]
+    assert first[1] == second[1]
+
+
+def test_one_thread_keeps_its_own_handle(main_module, walk_stand_in):
+    """The other half of it: per-thread, not per-call.
+
+    Opening a multi-gigabyte tabix index per `fetch` would be its own defect —
+    `GenerateWalksMC` calls `fetch` once per `S` line.
+    """
+    derivative = main_module.WalkDerivative(walk_stand_in, "a test")
+
+    assert derivative._open() is derivative._open()


### PR DESCRIPTION
Found during the `increment-b` live trial. A 40 kb region was requested from the browser and abandoned mid-flight; from then on **every uncached region returned 500 in 0.3 s, while every cached region served normally.** Only a restart cleared it — and two regions stayed broken across the restart.

Three separate defects, each of which turned the next one into a mystery.

## 1. A shared `pysam` handle, read from the threadpool

`pysam.TabixFile` is one htslib handle with one seek position, and pysam does not support reading it from two threads at once. `fetch` makes that worse: it returns a *lazy iterator*, so the handle is in use for as long as the caller takes to consume it — `GenerateWalksMC` opens one per `S` line (`main.py:273`), which on a large region is minutes. `WalkDerivative` kept one handle for the whole process and its lock guarded only the open, which is the part that didn't need guarding.

Closing the browser panel cancels nothing — a `def` handler runs in the threadpool and can't be interrupted — so the abandoned request kept iterating that handle while new requests fetched from it. The interleaved seeks left it broken for the life of the process. Cached requests read no walk derivative, which is exactly why they were unaffected.

Now one handle per thread, via `threading.local`. That's the granularity pysam supports.

This was only reachable after the `async def` → `def` change in #22's sibling commit, which moved handlers off the event loop where every request had been serialized. That change was right — one slow request must not stop the server — and this is the edge it exposed.

## 2. A failed extraction cached itself

`GenerateWalksMC` writes the `W` lines *last*, after every `S` and `L` line. A run that dies partway therefore leaves a structurally valid GFA describing a graph with no paths in it — several KB of it, so "delete the empty ones" doesn't find it. `subgraph_cached` asked only `path.exists()` (`main.py:737`), so those entries were served as finished work and their regions failed identically **forever**, including across the restart that fixed everything else.

- extraction writes under a temporary name and `os.replace`s into place, so an interrupted run leaves nothing;
- a cache hit means a subgraph with at least one `W` line — which also clears the poisoned entries already on disk, without anyone deleting files by hand.

## 3. Nothing said which stage failed

`ConvertGfaToVg`, `ConvertVgToJson` and `GenerateSeqTubeMapSvg` all returned a boolean nobody read, and captured a stderr they threw away. The failure surfaced as `FileResponse` raising over a file no stage ever wrote. In the browser that's "Failed to fetch" and nothing more — an unhandled exception is rendered *outside* the CORS middleware, so it arrives with no `access-control-allow-origin` and the fetch fails at the network layer with the status unread.

A failing stage now raises a 502 naming itself and the region. It goes through the middleware like any other response, so the panel can show the reason, and the tool's own stderr goes to the log beside it.

## Tests

New `tests/python/test_pipeline_failures.py` (14 tests) plus two in `test_walk_derivatives.py`. None needs `vg`, Node, or a pangenome — each stands in for the stage it isn't about.

- two threads are never handed the same tabix handle; one thread keeps its own across calls
- a walk-less subgraph is not a cache hit; an empty one isn't; a 1.8 MB one with its walks at the end is (the check reads the tail, so size can't decide the answer)
- an interrupted extraction leaves neither a subgraph nor its temporary
- a walk-less entry is re-extracted rather than served, and reported rather than served when it can't be
- each of the three stages, failing in turn, names itself in the response
- a render that exits clean but writes nothing is caught before `FileResponse` sees it
- a stage failure carries CORS headers

`test_endpoints_do_not_block_the_event_loop.py`'s stage stubs now satisfy the contract they stand in for (a `W` line, a truthy return).

Full suite: 27 passed, 5 skipped (no local `vg`). Node suite unchanged at 79 passed.

Diagnosing this took an hour of probing the live server from outside. The 502 would have said it in one request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQLSZisy2XbiuZBWhddjnF