### PR TITLE
Publish the numbers: /seqtubemap gains ?format=bands

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,11 @@ Wolfgang Beyer.
 | `seqtubemap/config-global.mjs` | `src/config-global.mjs` | unmodified |
 | `seqtubemap/config-client.js` | `src/config-client.js` | emptied |
 | `seqtubemap/generate-svg.mjs` | — | ours |
+| `seqtubemap/generate-bands.mjs` | — | ours |
 | `seqtubemap/render.mjs` | — | ours |
 | `seqtubemap/band-data.mjs` | — | ours |
+| `seqtubemap/emit-document.mjs` | — | ours |
+| `seqtubemap/band-payload.mjs` | — | ours |
 
 **`tubemap.js` is a fork and does not track upstream.** It arrived already
 trimmed of upstream's interactive browser half (mouse handlers, zoom, legend

--- a/docs/adr/0001-additive-band-format.md
+++ b/docs/adr/0001-additive-band-format.md
@@ -128,6 +128,47 @@ bad B shows up as an error card rather than as a diff nobody ran.
 > today — that is [#52](https://github.com/CAST-genomics/PangenomeAPI/issues/52), which
 > predates this — and #24 is where what they mean on the band route gets decided.
 
+> *Amended 2026-09-01: **C has landed** ([#24](https://github.com/CAST-genomics/PangenomeAPI/issues/24)).*
+> `/seqtubemap?format=bands` returns a JSON header and a binary body; the format is
+> specified in [`docs/band-format.md`](../band-format.md), written to be enough to write a
+> parser against without reading the server. Omitting the parameter returns the document
+> byte for byte, and an unrecognised `format` is refused with a 400 before any stage runs
+> rather than quietly served as SVG.
+>
+> **The projection was right and slightly pessimistic.** This ADR predicted "roughly 1.5 MB
+> against the SVG's 10.07 MB" from the band count and the record width. The nearest thing
+> that can be measured from a checkout is the committed 7,967 bp subgraph, whose document is
+> 9.97 MB — a document of the size the projection was about, rather than a region of the span
+> it named — and its payload is **1.25 MB**. The five real subgraphs run
+> 1.9× at 90 bp to 9.0× at 44,795 bands, and the ratio is smallest where the response is
+> smallest: the 90 bp region draws 592 bands over 464 strands, so its payload is almost all
+> strand table. `perf/band-payload-sizes.mjs` reproduces the table.
+>
+> Three decisions the ADR left open, and how they went:
+>
+> * **The body is columnar, not one interleaved record per band.** Interleaved, the record
+>   is 26 bytes, and a `Float32Array` cannot be viewed over a buffer at an offset that is
+>   not a multiple of 4 — so a client would have to copy the fields apart one at a time,
+>   which is the parse step this whole change exists to delete. Split into a float32
+>   column, a uint16 column and a uint8 column, each is one view over the bytes that
+>   arrived, and the geometry column *is* the instance buffer.
+> * **A strand's colour travels as three whole channels**, not as CSS. The layout spells a
+>   colour two ways and a PCLAI scheme can supply fractional channels — the live chr7
+>   failure of 2026-08-28 — so the rounding happens once, on the server, in the same
+>   function the document rounds with.
+> * **The reversal shapes ride in the header, not the body** ([#52](https://github.com/CAST-genomics/PangenomeAPI/issues/52)),
+>   each carrying the position it held in the draw order, because paint order is document
+>   order. No production response contains one, and a client may reasonably refuse a
+>   response whose `reversals` are non-empty rather than implement two shapes it will not
+>   meet. This is what #24 was to decide, and it decides it without asking `pgb` to grow
+>   anything.
+>
+> One byte per band is carried beyond the ticket's record: which element the document draws
+> the band as. A client can ignore it — the six numbers are the whole shape either way —
+> and it is what makes the SVG reconstructible from the payload, so *"the band data is
+> canonical and the document is a rendering of it"* is a fact the tests check rather than
+> an intention.
+
 **D** — delete the `vg convert` / `vg view -j` round trip. Gated on measuring
 `subgraph_extract` on the live server; if upstream extraction dominates, this is noise.
 

--- a/docs/band-format.md
+++ b/docs/band-format.md
@@ -1,0 +1,255 @@
+# The band format
+
+What `/seqtubemap?format=bands` returns, in enough detail to write a parser
+against without reading the server.
+
+The endpoint's other format is a **sequence tube map** as an SVG document: every
+**band** drawn as an element carrying a drawing command, its **strand**'s colour,
+its strand's name and its strand's ancestry placement — the per-strand values
+re-serialized once per band, which is 41–47% of the response, and the geometry
+as text the client parses back into numbers with a regular expression
+([ADR 0001](adr/0001-additive-band-format.md)).
+
+This format says each per-strand value once, in a table the bands point at, and
+says the geometry as the numbers themselves, laid out so a client can build
+typed-array views over the bytes it received and hand them to the GPU without a
+parse step.
+
+`format` is **additive**: omitting it, or passing `format=svg`, returns exactly
+what the endpoint returned before, byte for byte. An unrecognised value is
+refused with `400` rather than quietly served as SVG.
+
+```
+GET /seqtubemap?chrom=chr1&start=25301271&end=25309238&version=v2&format=bands
+→ 200 application/octet-stream
+```
+
+## Layout
+
+```
+offset            bytes         what
+0                 4             header length H, uint32 little-endian
+4                 H             header, JSON, UTF-8
+4 + H             pad to 4      zeros, so the body starts 4-byte aligned
+B = ceil4(4 + H)  6 × 4 × N     geometry: float32, six per band
+B + 24N           2 × N         strand ids: uint16, one per band
+B + 26N           N             kinds: uint8, one per band
+                  pad to 4      zeros
+```
+
+`N` is `header.band.count`. Every multi-byte value in the body is
+**little-endian**. The body's three sections are not written at fixed offsets by
+convention — read `byteOffset` and `byteLength` out of the header, which are
+relative to `B`, and `header.bodyLength` is the body's total size.
+
+The body is **columnar**, one array per field, rather than one interleaved
+26-byte record per band. Interleaved, no `Float32Array` view could be taken over
+it: a 26-byte stride is not a multiple of 4, so a client would have to copy the
+fields apart one at a time, which is the parse step this format exists to
+delete. Split into columns, each column is one view over the bytes that arrived.
+
+### Reading it
+
+```js
+const bytes = new Uint8Array(await response.arrayBuffer());
+const headerLength = new DataView(bytes.buffer, bytes.byteOffset, 4).getUint32(0, true);
+const header = JSON.parse(new TextDecoder().decode(bytes.subarray(4, 4 + headerLength)));
+
+const body = bytes.byteOffset + ((4 + headerLength + 3) & ~3);
+const { count, geometry, strandIds, kinds } = header.band;
+const xyz = new Float32Array(bytes.buffer, body + geometry.byteOffset, count * 6);
+const strand = new Uint16Array(bytes.buffer, body + strandIds.byteOffset, count);
+const kind = new Uint8Array(bytes.buffer, body + kinds.byteOffset, count);
+```
+
+`seqtubemap/band-payload.mjs` holds a reference reader (`decodeBandPayload`), and
+`tests/python/test_seqtubemap_band_format.py` holds the same four lines in
+Python.
+
+## The header
+
+```json
+{
+  "format": "pangenome-bands",
+  "version": 1,
+  "document": {
+    "width": 27953.85714285714,
+    "height": 5775,
+    "viewBox": "0 -170 27953.85714285714 5775",
+    "extent": { "maxXCoordinate": 27903.85714285714, "maxYCoordinate": 5575, "minYCoordinate": -150 }
+  },
+  "band": {
+    "thickness": 15,
+    "alpha": 1,
+    "count": 8089,
+    "geometry": {
+      "type": "Float32",
+      "fields": ["x0", "y0", "x1", "y1", "controlTop", "controlBottom"],
+      "byteOffset": 0,
+      "byteLength": 194136
+    },
+    "strandIds": { "type": "Uint16", "byteOffset": 194136, "byteLength": 16178 },
+    "kinds": { "type": "Uint8", "byteOffset": 210314, "byteLength": 8089,
+               "values": { "rect": 0, "curve": 1 } }
+  },
+  "strands": [
+    { "id": 0, "name": "GRCh38#0#chr1", "color": [255, 115, 56],
+      "pclaiX": 0.12, "pclaiY": -0.43, "pclaiScore": 0.98 }
+  ],
+  "segments": [
+    { "id": "79337767", "outline": "M 11 20 Q 11 11 20 11 …",
+      "sequence": "AGAGCCTGTCTT…", "fill": "#ffffff", "fillOpacity": 0.4,
+      "stroke": "#000000", "strokeWidth": 2 }
+  ],
+  "overlays": [],
+  "reversals": { "corners": [], "connectors": [] },
+  "bodyLength": 218408
+}
+```
+
+**`format` and `version`** — a reader that does not recognise both should refuse
+the response rather than guess at it. `version` changes when the meaning of a
+field changes; a new *optional* field does not change it.
+
+**`document`** — the dimensions of the picture the bands are drawn in, in the
+layout's own double precision. `viewBox` is `minX minY width height`, and the
+coordinate system the geometry is expressed in.
+
+**`band.thickness`** — every band in a tube map is this tall. It is the constant
+that makes six numbers enough: the lower edge of a band is its upper edge shifted
+down by the thickness. A band of any other thickness is not something this format
+can carry, and the server refuses to encode one.
+
+**`band.alpha`** — the opacity every band is drawn at. Said once for the same
+reason.
+
+**`strands`** — the **strand** table, one row per strand appearance: `id` is the
+layout's own ordering, dense from 0 with no gaps; `name` is the
+`sample#haplotype#contig` triple as `vg` produced it, phase block and subrange
+included; `color` is three whole channels in 0–255; the three `pclai*` fields are
+the strand's ancestry placement, and are `null` where the region has none. A
+strand's values appear here once, however many bands it draws.
+
+**`segments`** — the **segment** boxes, in draw order, each with the id, outline
+and sequence a client draws and labels from. The outline is a path command
+because a segment box is a rounded rectangle rather than a band; there are three
+orders of magnitude fewer of them than bands.
+
+**`overlays`** — the ruler and the per-segment labels, when the render drew any:
+an element name, its attributes as ordered pairs, and its text. **Empty in every
+production response** — a real subgraph carries no reference offset, so it gets
+no ruler — and carried only so the payload is a complete description of the
+picture.
+
+**`reversals`** — see below.
+
+## A band
+
+Six floats and a strand id. Read band `i` as:
+
+| field | meaning |
+| --- | --- |
+| `x0`, `y0` | the near end of the band's upper edge |
+| `x1`, `y1` | the far end of the band's upper edge |
+| `controlTop` | the control abscissa of the upper edge's cubic |
+| `controlBottom` | the control abscissa of the lower edge's cubic |
+
+and `strandIds[i]` is a **row index into `strands`** — not a `trackID`. The two
+coincide in practice, since a strand has one row; read the row and take its `id`
+if you need the layout's number.
+
+The whole outline, with `T = header.band.thickness`:
+
+```
+M x0 y0
+C controlTop y0  controlTop y1  x1 y1
+V y1 + T
+C controlBottom (y1 + T)  controlBottom (y0 + T)  x0 (y0 + T)
+Z
+```
+
+Both cubics' control ordinates repeat the endpoints, and the lower edge is the
+upper edge shifted by `T`. That redundancy is why six numbers say the whole
+shape, and it was measured across 127,101 strand paths before it was relied on.
+
+`kinds[i]` says whether the server drew the band as a `<rect>` (0) or a `<path>`
+(1) in the SVG format. **A client drawing bands can ignore it**: a rect is the
+degenerate band — both edges level, so any control abscissa reproduces it — and
+the six numbers are the whole shape either way. It is carried so that the SVG
+document is reconstructible from the payload, which is what makes the band data
+canonical and the document a rendering of it.
+
+### Precision
+
+The geometry is `Float32`. The layout computes in doubles, so a coordinate
+arrives rounded: `138.71428571428573` becomes `138.7142791748047`. That is the
+format's one lossy step and it is deliberate — a GPU instance buffer is float32,
+so the rounding would happen on the client anyway. Everything else (the
+dimensions, the strand table, the segment outlines) travels at full precision as
+JSON.
+
+### The shapes that are not bands
+
+A **reversal** — a strand doubling back on itself — draws two shapes that are
+outside the six-value grammar: **corners**, quarter turns built from quadratics,
+and **vertical connectors**, rectangles as tall as the reversal is deep rather
+than `thickness` tall. They are not in the body. They ride in
+`reversals.corners` and `reversals.connectors` as JSON objects carrying the
+layout's own parameters, each with an `order`: the position it occupied among
+all the shapes the render drew.
+
+Draw order is paint order — later shapes draw over earlier ones. To recover the
+full order: place each reversal shape at its `order`, then fill the remaining
+positions, in ascending order, with the body's bands in body order.
+
+**No production response contains one.** None of the five real subgraphs draws a
+reversal, and a client may reasonably refuse a response whose `reversals` are
+non-empty (as `pgb` does today —
+[#52](https://github.com/CAST-genomics/PangenomeAPI/issues/52)) rather than
+implement two shapes it will not meet.
+
+## What is refused
+
+| condition | response |
+| --- | --- |
+| `format` is neither `svg` nor `bands` | `400`, naming the value and what would have been accepted |
+| more than 65,536 strand rows | the render fails and the request gets `502` naming the stage; the server refuses to encode rather than wrap a 16-bit id round |
+| a band thicker or thinner than `thickness`, or at an opacity other than `alpha` | the same — the header says these once, so a shape that disagrees with them cannot be carried |
+| a strand coloured in a spelling that is neither `#rrggbb` nor `rgb(r, g, b)` | the same |
+
+Each of these is refused where the layout that produced it is still in scope, so
+the error names the cause rather than surfacing in the client as an unreadable
+response.
+
+## Measured
+
+Five real subgraphs, rendered through `renderTubeMap` and encoded both ways,
+2026-09-01. `perf/band-payload-sizes.mjs` reproduces the table.
+
+| region | span | strands | bands | SVG | band payload | ratio |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| chr8:78,771,162-78,771,252 | 90 bp | 464 | 592 | 0.13 MB | 0.07 MB | 1.9× |
+| chr1:25,331,046-25,331,646 | 600 bp | 369 | 8,089 | 2.25 MB | 0.28 MB | 8.1× |
+| chr8:10,079,054-10,080,461 | 1.4 kb | 463 | 13,246 | 3.61 MB | 0.43 MB | 8.4× |
+| chr1:25,301,271-25,309,238 | 8.0 kb | 383 | 35,020 | 9.97 MB | **1.25 MB** | 8.0× |
+| chr1:25,331,646-25,335,796 | 4.2 kb | 1,201 | 44,795 | 12.58 MB | 1.40 MB | 9.0× |
+
+ADR 0001 projected "roughly 1.5 MB against the current 10.07 MB" at the 10 kb
+region from the band count and the record width. Measured on the 8.0 kb subgraph
+that stands for it: **1.25 MB against 9.97 MB**. The projection was right and
+slightly pessimistic.
+
+The ratio is smallest on the smallest region, and that is the shape of the win
+rather than a defect: the 90 bp subgraph draws 592 bands over 464 strands, so its
+payload is almost entirely the strand table — said once, but said in full. Where
+the response is large enough to be a problem, the bands dominate and the strand
+table is a rounding error.
+
+On the 8.0 kb region the header is 0.35 MB of the 1.25 MB and the body is
+0.90 MB. What the header spends it on is the **segment boxes** — 0.30 MB for
+768 of them, of which 0.21 MB is their outlines, written as path commands — with
+the 383-row strand table at 0.045 MB and the sequences themselves at 0.011 MB.
+So the per-strand redundancy this format set out to remove is gone, and what is
+left on the JSON side is the segment outlines: a smaller, later question than
+the one this format answers, and one that touches three orders of magnitude
+fewer shapes than the bands do.

--- a/docs/seqtubemap-roadmap.md
+++ b/docs/seqtubemap-roadmap.md
@@ -46,10 +46,10 @@ trial*. The server has since been put back on `release`.
 
 | | |
 | --- | --- |
-| Merged | [#14](https://github.com/CAST-genomics/PangenomeAPI/issues/14), [#15](https://github.com/CAST-genomics/PangenomeAPI/issues/15), [#16](https://github.com/CAST-genomics/PangenomeAPI/issues/16), [#17](https://github.com/CAST-genomics/PangenomeAPI/issues/17), [#18](https://github.com/CAST-genomics/PangenomeAPI/issues/18), [#19](https://github.com/CAST-genomics/PangenomeAPI/issues/19), [#20](https://github.com/CAST-genomics/PangenomeAPI/issues/20), [#21](https://github.com/CAST-genomics/PangenomeAPI/issues/21), [#46](https://github.com/CAST-genomics/PangenomeAPI/issues/46), [#41](https://github.com/CAST-genomics/PangenomeAPI/issues/41), [#40](https://github.com/CAST-genomics/PangenomeAPI/issues/40), [#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22), [#45](https://github.com/CAST-genomics/PangenomeAPI/issues/45), [#23](https://github.com/CAST-genomics/PangenomeAPI/issues/23) |
-| Frontier | **[#24](https://github.com/CAST-genomics/PangenomeAPI/issues/24)** — increment C's wire format, unblocked by #23 |
+| Merged | [#14](https://github.com/CAST-genomics/PangenomeAPI/issues/14), [#15](https://github.com/CAST-genomics/PangenomeAPI/issues/15), [#16](https://github.com/CAST-genomics/PangenomeAPI/issues/16), [#17](https://github.com/CAST-genomics/PangenomeAPI/issues/17), [#18](https://github.com/CAST-genomics/PangenomeAPI/issues/18), [#19](https://github.com/CAST-genomics/PangenomeAPI/issues/19), [#20](https://github.com/CAST-genomics/PangenomeAPI/issues/20), [#21](https://github.com/CAST-genomics/PangenomeAPI/issues/21), [#46](https://github.com/CAST-genomics/PangenomeAPI/issues/46), [#41](https://github.com/CAST-genomics/PangenomeAPI/issues/41), [#40](https://github.com/CAST-genomics/PangenomeAPI/issues/40), [#22](https://github.com/CAST-genomics/PangenomeAPI/issues/22), [#45](https://github.com/CAST-genomics/PangenomeAPI/issues/45), [#23](https://github.com/CAST-genomics/PangenomeAPI/issues/23), [#24](https://github.com/CAST-genomics/PangenomeAPI/issues/24) |
+| Frontier | **[#25](https://github.com/CAST-genomics/PangenomeAPI/issues/25)** — the contract test, unblocked by #24. Increment C is complete on this side of the wire; `pgb`'s parser is where it lands next |
 | Live | **Nothing.** The server follows `release`, so merging is not shipping; `git log release..main` — 59 commits — is what is waiting. The trial was a loan, not a promotion |
-| Defects, outside the increments | [#52](https://github.com/CAST-genomics/PangenomeAPI/issues/52), [#54](https://github.com/CAST-genomics/PangenomeAPI/issues/54), [#58](https://github.com/CAST-genomics/PangenomeAPI/issues/58) — all still open, all triaged, none blocking #24 |
+| Defects, outside the increments | [#52](https://github.com/CAST-genomics/PangenomeAPI/issues/52), [#54](https://github.com/CAST-genomics/PangenomeAPI/issues/54), [#58](https://github.com/CAST-genomics/PangenomeAPI/issues/58) — all still open, all triaged, none blocking #25. #52 is answered *on the band route* by #24, and stands on the SVG route — see below |
 
 ---
 
@@ -97,7 +97,7 @@ what each became.*
                         │
                         ├── #18 golden test ✅─┬── #21 capture ✅── #22 delete jsdom ✅
                         │                      │                         │
-                        │                      │                         └── #23 floats ✅── #24 ?format=bands ◀── HERE ── #25 contract test
+                        │                      │                         └── #23 floats ✅── #24 ?format=bands ✅── #25 contract test ◀── HERE
                         │                      │
                         │                      ├── #40 pclai golden ✅
                         │                      │
@@ -113,12 +113,12 @@ what each became.*
 #E  batch GenerateWalksMC — no ticket yet, no ADR behind it
 
 Defects, off the sequence and blocking nothing:
-#52 pgb refuses a reversal — #24 decides what a reversal means on the band route
+#52 pgb refuses a reversal — answered on the band route (header, not body); the SVG route is unchanged, so #52 stands there
 #54 concurrent extraction of one uncached region — corruption half fixed in PR #60
 #58 drop d3, and the dead read-track colouring that is its last user
 ```
 
-**The frontier is [#24](https://github.com/CAST-genomics/PangenomeAPI/issues/24)**, and nothing blocks it. Edges are GitHub's native issue
+**The frontier is [#25](https://github.com/CAST-genomics/PangenomeAPI/issues/25)**, and nothing blocks it. Edges are GitHub's native issue
 dependencies, so a ticket whose blockers are all closed is grabbable without consulting this
 document.
 
@@ -449,19 +449,39 @@ outside the six-value grammar and are collected as their own kinds rather than f
 `pgb` can read neither today — that is [#52](https://github.com/CAST-genomics/PangenomeAPI/issues/52), which predates this — and #24 is where
 what they mean on the band route gets decided.
 
-### [#24](https://github.com/CAST-genomics/PangenomeAPI/issues/24) — `?format=bands`
+### [#24](https://github.com/CAST-genomics/PangenomeAPI/issues/24) — `?format=bands` ✅
 
-JSON header (viewBox + the ~464-row strand table) plus a binary body of `Float32 × 6 +
-Uint16` per band, with segment boxes carrying id, outline and sequence. Per-strand values
-appear **once** instead of once per band, and a fixed-width body copies straight into `pgb`'s
-GPU instance buffer with no parse at all.
+JSON header (the dimensions, the strand table, the segment boxes) plus a binary body of
+`Float32 × 6 + Uint16` per band. Per-strand values appear **once** instead of once per band,
+and the geometry column is `pgb`'s GPU instance buffer with no parse step at all. The format
+is specified in [`docs/band-format.md`](band-format.md), written to be enough to write a
+parser against without reading the server.
 
-**Additive.** Omit the parameter and you get today's response, byte for byte. The two repos
-never deploy in lockstep, and the SVG stays as the oracle.
+**Additive.** Omit the parameter and you get today's response, byte for byte — checked over
+the endpoint, not merely intended. An unrecognised `format` is refused with a 400 before any
+stage runs, rather than quietly served as SVG.
 
-> Projected at ~1.5 MB against 10.07 MB — **arithmetic from the band count and record width,
-> not a measurement.** The ticket asks for the real figure. It is the one number in these
-> documents that is not a direct observation.
+**The projection is now a measurement**, and it was right and slightly pessimistic: **1.25 MB
+against 9.97 MB** over the committed 7,967 bp subgraph, where this document predicted ~1.5 MB
+against 10.07 MB. Across the five real subgraphs the ratio runs 1.9× at 90 bp to 9.0× at
+44,795 bands — smallest where the response is smallest, because a 592-band payload is almost
+all strand table. `perf/band-payload-sizes.mjs` reproduces the table.
+
+| region | span | bands | SVG | band payload | ratio |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| chr8:78,771,162-78,771,252 | 90 bp | 592 | 0.13 MB | 0.07 MB | 1.9× |
+| chr1:25,331,046-25,331,646 | 600 bp | 8,089 | 2.25 MB | 0.28 MB | 8.1× |
+| chr8:10,079,054-10,080,461 | 1.4 kb | 13,246 | 3.61 MB | 0.43 MB | 8.4× |
+| chr1:25,301,271-25,309,238 | 8.0 kb | 35,020 | 9.97 MB | **1.25 MB** | 8.0× |
+| chr1:25,331,646-25,335,796 | 4.2 kb | 44,795 | 12.58 MB | 1.40 MB | 9.0× |
+
+Three things the increment decided that the ticket left to it. The body is **columnar** —
+interleaved, a 26-byte record admits no `Float32Array` view, so the client would copy the
+fields apart one at a time, which is the parse step being deleted. A strand's colour travels
+as **three whole channels** rather than CSS, so the rounding that caused the live chr7 refusal
+happens once on the server. And a reversal's corners and connectors ride in the **header**,
+each carrying its position in the draw order — which is [#52](https://github.com/CAST-genomics/PangenomeAPI/issues/52)'s
+answer on this route, and needs nothing new from `pgb`.
 
 ### [#25](https://github.com/CAST-genomics/PangenomeAPI/issues/25) — Contract test
 

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ import ssl
 import threading
 import traceback
 import numpy as np
+from typing import NamedTuple
 import os
 from panCT.panct.data import Region
 from panCT.panct.logging import getLogger
@@ -76,6 +77,35 @@ mc_hg38_gbz_v2 = Path(f"{data_path}/hprc-v2.0-mc-grch38.gbz")
 minigraph_hg38_gfa_v1 = Path(f"{data_path}/hprc-v1.0-minigraph-grch38.gfa")
 minigraph_hg38_gfa_v2 = Path(f"{data_path}/hprc-v2.0-minigraph-grch38.gfa")
 generate_svg_js_script = Path("./seqtubemap/generate-svg.mjs")
+generate_bands_js_script = Path("./seqtubemap/generate-bands.mjs")
+
+class SeqTubeMapFormat(NamedTuple):
+    """One thing `/seqtubemap` can return, and everything that differs about it.
+
+    The extension keeps the two renders apart in the cache, the media type is
+    what the client is told it received, and the stage name is what a failure
+    reports — the two run different scripts and can fail for different reasons,
+    so borrowing one name for both would misreport the cause.
+    """
+
+    extension: str
+    media_type: str
+    stage: str
+
+
+# `svg` is the default and is what the endpoint has always returned, byte for
+# byte: this parameter is additive, so the two repositories never have to deploy
+# together and the document stays available as the oracle the band payload is
+# checked against (docs/adr/0001-additive-band-format.md).
+#
+# `bands` is the same render said as numbers — a JSON header carrying the
+# dimensions, the strand table and the segment boxes, and a binary body carrying
+# six floats and a strand id per band. The format is specified in
+# `docs/band-format.md`.
+SEQTUBEMAP_FORMATS = {
+    "svg": SeqTubeMapFormat("svg", "image/svg+xml", "generate_svg"),
+    "bands": SeqTubeMapFormat("bands", "application/octet-stream", "generate_bands"),
+}
 
 
 class MissingWalkDerivative(RuntimeError):
@@ -595,6 +625,30 @@ def ConvertVgToJson(vg_file, json_file):
         proc = subprocess.run(cmd, stdout=out, stderr=subprocess.PIPE)
     return _stage_succeeded(proc, "vg view -j")
 
+def _render_seq_tube_map(script, json_file, out_file, start, end, nodewidthoption, pclai_color_scheme):
+    """Run one of the Node renderers over a subgraph.
+
+    The two renderers take the same six arguments and differ only in which sink
+    they write — a document, or the band payload — so the invocation is written
+    once and the script is the argument.
+    """
+    cmd = [
+        "node",
+        "--max-old-space-size=8192",
+        str(script),
+        str(json_file),
+        str(out_file),
+        str(start),
+        str(end),
+        nodewidthoption
+    ]
+    if pclai_color_scheme is not None:
+        cmd.append(json.dumps(pclai_color_scheme))
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    return _stage_succeeded(proc, f"node {script.name}")
+
+
 def GenerateSeqTubeMapSvg(json_file, svg_file, start, end, nodewidthoption, pclai_color_scheme = None):
     """
     generate sequence tube map svg using the generate-svg javascript in ./seqtubemap
@@ -613,21 +667,27 @@ def GenerateSeqTubeMapSvg(json_file, svg_file, start, end, nodewidthoption, pcla
     passed : bool
         True if we were able to create the .svg file
     """
-    cmd = [
-        "node", 
-        "--max-old-space-size=8192",
-        str(generate_svg_js_script), 
-        str(json_file), 
-        str(svg_file), 
-        str(start), 
-        str(end), 
-        nodewidthoption
-    ]
-    if pclai_color_scheme is not None:
-        cmd.append(json.dumps(pclai_color_scheme))
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return _render_seq_tube_map(
+        generate_svg_js_script, json_file, svg_file, start, end, nodewidthoption, pclai_color_scheme
+    )
 
-    return _stage_succeeded(proc, "node generate-svg.mjs")
+
+def GenerateSeqTubeMapBands(json_file, bands_file, start, end, nodewidthoption, pclai_color_scheme = None):
+    """
+    generate the band payload using the generate-bands javascript in ./seqtubemap
+
+    The same render as `GenerateSeqTubeMapSvg`, written to the wire as the
+    numbers the layout computed rather than as a document that encodes them.
+    `docs/band-format.md` specifies what lands in `bands_file`.
+
+    Returns
+    -------
+    passed : bool
+        True if we were able to create the payload file
+    """
+    return _render_seq_tube_map(
+        generate_bands_js_script, json_file, bands_file, start, end, nodewidthoption, pclai_color_scheme
+    )
 
 def SubgraphMini(query_region, gfa_preprocessed, reference_gfa, log):
     # check gbz.db file and create subgraph
@@ -825,18 +885,37 @@ def seqtubemap(
     version: str = Query("v2", description='pangenome release version: `"v1"` or `"v2"`'),
     pathnumoption: str = Query("normal", description='options for the number of path: `"compressed"`(compress same path as one single path) or `"normal"` (show each path seperately)'),
     nodewidthoption: str = Query("compressed", description='Options for the width of sequence nodes:`"compressed"`(scale node width with log2 of number of bp) or `"normal"`(scale node width linearly with number of bp)'),
-    minigraphnode: int = Query(None, description="If the queried region is based on a minigraph node, record the node ID to enable Point Cloud Local Ancestry Inference coloring")
+    minigraphnode: int = Query(None, description="If the queried region is based on a minigraph node, record the node ID to enable Point Cloud Local Ancestry Inference coloring"),
+    format: str = Query("svg", description='What to return: `"svg"` (the drawing document, the default and unchanged) or `"bands"` (the band payload — a JSON header and a binary body, specified in `docs/band-format.md`)')
 ):
     
     log = getLogger(name="complexity", level="DEBUG")
     query_region = Region(chrom, start, end)
+
+    # Checked before anything is extracted, converted or rendered: a request
+    # naming a format this endpoint does not have is a request that cannot be
+    # answered, and answering it with the default instead would hand a client
+    # asking for numbers a document it cannot read, which is far harder to
+    # notice than a 400.
+    if format not in SEQTUBEMAP_FORMATS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"format={format!r} is not one this endpoint serves. "
+                f"Valid formats: {', '.join(sorted(SEQTUBEMAP_FORMATS))}."
+            ),
+        )
+    wanted = SEQTUBEMAP_FORMATS[format]
     
     preprocess_gfa_subgraph_no_walk = Path(f"./cache/seqtubemap/mc/subgraph_{chrom}_{str(start)}_{str(end)}_{version}_no_walk.gfa")
     preprocess_gfa_subgraph_w_walk = Path(f"./cache/seqtubemap/mc/subgraph_{chrom}_{str(start)}_{str(end)}_{version}_with_walk.gfa")
     postprocess_gfa_subgraph = Path(f"./cache/seqtubemap/mc/subgraph_{chrom}_{str(start)}_{str(end)}_path{pathnumoption}_{version}.gfa")
     vg_subgraph = Path(f"./cache/seqtubemap/mc/subgraph_{chrom}_{str(start)}_{str(end)}_path{pathnumoption}_{version}.vg")
     json_subgraph = Path(f"./cache/seqtubemap/mc/subgraph_{chrom}_{str(start)}_{str(end)}_path{pathnumoption}_{version}.json")
-    seqtubemap_svg = Path(f"./cache/seqtubemap/mc/subgraph_{chrom}_{str(start)}_{str(end)}_path{pathnumoption}_{version}.svg")
+    # The rendered answer, in whichever of the two encodings was asked for. The
+    # extension keeps them apart in the cache, so a region requested both ways
+    # does not have one render overwrite the other.
+    seqtubemap_render = Path(f"./cache/seqtubemap/mc/subgraph_{chrom}_{str(start)}_{str(end)}_path{pathnumoption}_{version}.{wanted.extension}")
       
     stages = {}
     # A cache hit is a subgraph with walks in it, not merely a file at the path:
@@ -892,13 +971,17 @@ def seqtubemap(
             elif version == "v2":
                 pclai_color_scheme = GetPclaiColorScheme(minigraphnode, minigraph_walks_v2_updated, log)
             
-    with stage_timing(stages, "generate_svg"):
-        rendered = GenerateSeqTubeMapSvg(json_subgraph, seqtubemap_svg, start, end, nodewidthoption, pclai_color_scheme)
-    if not rendered or not seqtubemap_svg.exists():
+    # Looked up here rather than held in `SEQTUBEMAP_FORMATS`, so that the two
+    # renders stay module-level names a test can stand in for; a function stored
+    # in the table would be the one captured at import, past any such stand-in.
+    generate = GenerateSeqTubeMapSvg if format == "svg" else GenerateSeqTubeMapBands
+    with stage_timing(stages, wanted.stage):
+        rendered = generate(json_subgraph, seqtubemap_render, start, end, nodewidthoption, pclai_color_scheme)
+    if not rendered or not seqtubemap_render.exists():
         raise stage_failed(
-            "generate_svg",
+            wanted.stage,
             query_region,
-            "the Node render exited non-zero or wrote no document; its stderr is "
+            "the Node render exited non-zero or wrote no output; its stderr is "
             "in the log above",
         )
 
@@ -911,11 +994,12 @@ def seqtubemap(
         f"[stage-timing] {chrom}:{start}-{end} span={end - start}bp {version} "
         f"path={pathnumoption} width={nodewidthoption} cached={subgraph_cached} "
         f"total={total}s {breakdown} "
-        f"json_mb={size_mb(json_subgraph)} svg_mb={size_mb(seqtubemap_svg)}"
+        f"json_mb={size_mb(json_subgraph)} format={format} "
+        f"render_mb={size_mb(seqtubemap_render)}"
     )
 
-    background_tasks.add_task(delete_files, [vg_subgraph, json_subgraph, seqtubemap_svg])
-    return FileResponse(seqtubemap_svg, media_type="image/svg+xml")
+    background_tasks.add_task(delete_files, [vg_subgraph, json_subgraph, seqtubemap_render])
+    return FileResponse(seqtubemap_render, media_type=wanted.media_type)
 
 
 # Synchronous on purpose: this handler blocks, so it belongs in FastAPI's

--- a/perf/band-payload-sizes.mjs
+++ b/perf/band-payload-sizes.mjs
@@ -1,0 +1,57 @@
+// What the band payload costs against the document, over the five real
+// subgraphs. Reproduces the table in `docs/band-format.md`:
+//
+//     node --max-old-space-size=8192 perf/band-payload-sizes.mjs
+//
+// Both encodings come out of one render, so the two figures on a row describe
+// the same picture rather than two renders that might have differed.
+import { encodeBandPayload } from "../seqtubemap/band-payload.mjs";
+import { realCases, renderReal, regionOf } from "../tests/node/real-cases.mjs";
+
+const mb = (bytes) => `${(bytes / 1048576).toFixed(2)} MB`;
+const rows = [];
+
+for (const name of realCases) {
+  const { bandData, document } = await renderReal(name);
+  const payload = encodeBandPayload(bandData);
+  const headerLength = new DataView(payload.buffer, payload.byteOffset, 4).getUint32(0, true);
+  const { start, end } = regionOf(name);
+  const sequences = bandData.segments.reduce(
+    (total, segment) => total + (segment.sequence?.length ?? 0),
+    0,
+  );
+
+  rows.push({
+    region: name.replace(/^subgraph_/, "").replace(/_v2_with_walk$/, ""),
+    span: end - start,
+    strands: bandData.strands.length,
+    bands: bandData.bands.length,
+    segments: bandData.segments.length,
+    outlines: bandData.segments.reduce(
+      (total, segment) => total + (segment.outline?.length ?? 0),
+      0,
+    ),
+    // The two things the header spends its bytes on, measured as the JSON they
+    // become, so the breakdown in `docs/band-format.md` is reproducible rather
+    // than asserted.
+    segmentJson: Buffer.byteLength(JSON.stringify(bandData.segments)),
+    strandJson: Buffer.byteLength(JSON.stringify(bandData.strands)),
+    svg: Buffer.byteLength(document),
+    payload: payload.byteLength,
+    header: headerLength,
+    body: payload.byteLength - 4 - headerLength,
+    sequences,
+  });
+}
+
+for (const row of rows) {
+  console.log(
+    `${row.region.padEnd(28)} ${String(row.span).padStart(6)} bp  ` +
+      `${String(row.strands).padStart(5)} strands ${String(row.bands).padStart(6)} bands  ` +
+      `svg ${mb(row.svg).padStart(9)}  payload ${mb(row.payload).padStart(9)}  ` +
+      `${(row.svg / row.payload).toFixed(1)}x  ` +
+      `[header ${mb(row.header)}: ${row.segments} segment boxes at ${mb(row.segmentJson)} ` +
+      `(${mb(row.outlines)} outline, ${mb(row.sequences)} sequence), ` +
+      `${row.strands}-row strand table at ${mb(row.strandJson)}; body ${mb(row.body)}]`,
+  );
+}

--- a/seqtubemap/band-data.mjs
+++ b/seqtubemap/band-data.mjs
@@ -393,3 +393,27 @@ export function assertDenseStrandIds(strands) {
     }
   }
 }
+
+/**
+ * A colour's three channels, each a whole number in 0..255 — or null for a
+ * spelling this does not recognise, which a caller then carries verbatim.
+ *
+ * Here rather than in either sink, because both need it and neither owns it.
+ * The document writes a colour as CSS `rgb(r, g, b)`; the band payload writes
+ * it as three numbers, since a client building a GPU buffer wants numbers and
+ * asking it to parse the two spellings the layout uses — hex from the palettes,
+ * `rgb()` from a PCLAI scheme, whose channels can be fractional — would be
+ * handing it the parse step that format exists to delete. One rounding, in one
+ * place, so the two encodings cannot disagree about a colour.
+ */
+export function rgbChannels(color) {
+  const hex = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color);
+  if (hex) return hex.slice(1).map((pair) => parseInt(pair, 16));
+
+  const rgb = /^rgb\(\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*\)$/.exec(String(color));
+  if (!rgb) return null;
+  return rgb.slice(1).map((channel) => {
+    const value = Math.round(Number(channel));
+    return Math.min(255, Math.max(0, value));
+  });
+}

--- a/seqtubemap/band-payload.mjs
+++ b/seqtubemap/band-payload.mjs
@@ -1,0 +1,344 @@
+// The band payload: the wire format `/seqtubemap?format=bands` returns.
+//
+// The SVG document says every per-strand value once per band — a colour, a name
+// and a PCLAI placement re-serialized on each of the 55,053 bands a real
+// subgraph draws, which is 41-47% of every response
+// (docs/adr/0001-additive-band-format.md) — and says the geometry as a drawing
+// command the client parses back into numbers with a regular expression. This
+// format says each per-strand value once, in a table the bands point at, and
+// says the geometry as the numbers themselves, laid out so that a client can
+// build a typed-array view over the bytes it received and hand that straight to
+// the GPU. No parse step, no regular expression, no megabytes of text.
+//
+// The format is specified in `docs/band-format.md`, which is written to be
+// enough to write a parser against without reading this file. What follows is
+// why it is shaped the way it is; the spec is what it *is*.
+//
+//   +-------------------+
+//   | uint32 LE         |  byte length of the header
+//   | header (JSON)     |  dimensions, strand table, segment boxes, section map
+//   | padding           |  to the next multiple of 4
+//   | geometry          |  Float32 x 6 x band count
+//   | strand ids        |  Uint16 x band count
+//   | kinds             |  Uint8  x band count
+//   +-------------------+
+//
+// **Columnar, not one interleaved record per band.** The ticket describes the
+// body as "six 32-bit floats plus a 16-bit strand id" per band, and that is what
+// it holds — but interleaved that is a 26-byte stride, and a Float32Array cannot
+// be viewed over a buffer at an offset that is not a multiple of 4. A client
+// receiving interleaved records would have to copy them apart with a DataView,
+// one field at a time, which is the parse step this format exists to delete.
+// Split into columns, each column is a single typed-array view over the received
+// bytes: `new Float32Array(buffer, offset, 6 * count)` is the instance buffer.
+//
+// **What a band does not carry.** Its thickness, because every band in a tube
+// map is `BAND_THICKNESS` and that is the constant which makes six numbers
+// enough (band-data.mjs). Its opacity, for the same kind of reason: the layout
+// paints an alpha below 1 only on reads, and this fork renders none, so an alpha
+// that is not 1 throws here rather than being encoded as a value the format has
+// no room for. Its colour and its strand's name, which live in the strand table.
+//
+// **What it does carry beyond the ticket's record**: one byte per band saying
+// whether the layout drew it as a `<rect>` or a `<path>`. A client that only
+// draws bands can ignore it — the six numbers are the whole shape either way,
+// which is what `rectBand` means by "one primitive in two spellings". It is here
+// so the payload is a *complete* description of the picture rather than an
+// abridged one: the SVG is reconstructible from it, which is what makes
+// "the band data is canonical and the document is a rendering of it" true in
+// fact and testable in `tests/node/band-payload.test.mjs`.
+//
+// **A strand's colour is three numbers, not CSS.** The layout spells a colour
+// two ways — hex from its palettes, `rgb(r, g, b)` from a PCLAI scheme, and the
+// scheme's channels can be fractional — so a client reading the document has to
+// parse both and round the way a stylesheet would. The payload says the channels
+// themselves, rounded once here by the same function the document rounds with.
+//
+// **The reversal shapes are not bands** and are not in the body. A corner is
+// built from quadratics and a vertical connector is as tall as the reversal is
+// deep, so neither fits the six-value grammar (#23, #52). They ride in the
+// header as their own lists, each carrying the position it occupies in the draw
+// order, because paint order is document order and a client compositing the
+// picture needs to know where they fall. No production document contains one.
+import { BAND_THICKNESS, rgbChannels } from "./band-data.mjs";
+
+/** The format's name and version, as they appear in the header. */
+export const FORMAT = "pangenome-bands";
+export const VERSION = 1;
+
+/** The order the six geometry floats appear in, per band. */
+export const GEOMETRY_FIELDS = ["x0", "y0", "x1", "y1", "controlTop", "controlBottom"];
+
+/** The kind byte: which element the document draws the band as. */
+export const KIND_RECT = 0;
+export const KIND_CURVE = 1;
+
+/**
+ * The largest strand table this format can address.
+ *
+ * A band names its strand in 16 bits, so a document with more strand rows than
+ * this cannot be encoded — and must say so, rather than wrapping round and
+ * colouring bands from the wrong strand. `pgb` holds the same ceiling for the
+ * same reason: its instance buffer is a Uint16Array.
+ */
+export const MAX_STRAND_ROWS = 65536;
+
+/** Every band carries this opacity; see the module comment. */
+const BAND_ALPHA = 1;
+
+/**
+ * The band payload for one render's band data.
+ *
+ * @param {object} bandData  what `renderTubeMap` collected
+ * @returns {Uint8Array} the bytes of the response
+ */
+export function encodeBandPayload(bandData) {
+  const { document, strands, bands, segments, overlays } = bandData;
+
+  assertAddressable(strands);
+
+  // The six-value bands, in draw order, and the two reversal kinds alongside
+  // them — each remembering where in the draw order it sat, because that is
+  // paint order and splitting the list must not lose it.
+  const drawn = [];
+  const corners = [];
+  const connectors = [];
+  bands.forEach((band, order) => {
+    switch (band.kind) {
+      case "rect":
+      case "curve":
+        assertAlpha(band, order);
+        assertStrand(band, order, strands.length);
+        drawn.push(band);
+        return;
+      case "corner":
+        assertStrand(band, order, strands.length);
+        corners.push({ ...band, order });
+        return;
+      case "connector":
+        assertStrand(band, order, strands.length);
+        connectors.push({ ...band, order });
+        return;
+      default:
+        throw new Error(
+          `a band of kind "${band.kind}" is not one this format can carry. ` +
+            "Every kind band-data.mjs collects has to be encoded here.",
+        );
+    }
+  });
+
+  const count = drawn.length;
+  const geometryLength = count * GEOMETRY_FIELDS.length * 4;
+  const strandIdsOffset = geometryLength;
+  const kindsOffset = strandIdsOffset + count * 2;
+  const bodyLength = align4(kindsOffset + count);
+
+  const header = {
+    format: FORMAT,
+    version: VERSION,
+    document,
+    band: {
+      // Said once, for every band: the two constants that let six numbers
+      // describe a band at all.
+      thickness: BAND_THICKNESS,
+      alpha: BAND_ALPHA,
+      count,
+      geometry: {
+        type: "Float32",
+        fields: GEOMETRY_FIELDS,
+        byteOffset: 0,
+        byteLength: geometryLength,
+      },
+      strandIds: { type: "Uint16", byteOffset: strandIdsOffset, byteLength: count * 2 },
+      kinds: {
+        type: "Uint8",
+        byteOffset: kindsOffset,
+        byteLength: count,
+        values: { rect: KIND_RECT, curve: KIND_CURVE },
+      },
+    },
+    strands: strands.map(strandRow),
+    segments,
+    // Empty in every production document — a real subgraph carries no reference
+    // offset, so it gets no ruler and no labels (ADR 0001). Carried anyway,
+    // because a payload that silently dropped part of the picture would not be
+    // the canonical description of it.
+    overlays,
+    // Neither is a band; see the module comment.
+    reversals: { corners, connectors },
+    bodyLength,
+  };
+
+  const headerBytes = Buffer.from(JSON.stringify(header), "utf8");
+  const bodyOffset = align4(4 + headerBytes.length);
+  const payload = new Uint8Array(bodyOffset + bodyLength);
+  const view = new DataView(payload.buffer);
+
+  view.setUint32(0, headerBytes.length, true);
+  payload.set(headerBytes, 4);
+
+  // Written through a DataView rather than typed-array views, because
+  // `bodyOffset` is 4-aligned but the sections inside it need no further
+  // assumption, and because this is the one place the byte order is decided:
+  // little-endian, said explicitly, on every machine.
+  drawn.forEach((band, index) => {
+    let at = bodyOffset + index * GEOMETRY_FIELDS.length * 4;
+    for (const field of GEOMETRY_FIELDS) {
+      view.setFloat32(at, band[field], true);
+      at += 4;
+    }
+    view.setUint16(bodyOffset + strandIdsOffset + index * 2, band.strand, true);
+    view.setUint8(bodyOffset + kindsOffset + index, band.kind === "rect" ? KIND_RECT : KIND_CURVE);
+  });
+
+  return payload;
+}
+
+/**
+ * Read a payload back: the header, and typed-array views over the body.
+ *
+ * This is a client's parser, written on the server side of the wire — the
+ * reference implementation `docs/band-format.md` describes and the tests check
+ * the encoder against. It copies nothing: the views are windows onto the bytes
+ * that arrived, which is the whole point of the format.
+ *
+ * @param {Uint8Array|ArrayBuffer} payload
+ */
+export function decodeBandPayload(payload) {
+  const bytes = payload instanceof Uint8Array ? payload : new Uint8Array(payload);
+  const buffer = bytes.buffer;
+  const base = bytes.byteOffset;
+
+  if (bytes.byteLength < 4) {
+    throw new Error(`a band payload is at least 4 bytes; this one is ${bytes.byteLength}`);
+  }
+
+  const headerLength = new DataView(buffer, base, 4).getUint32(0, true);
+  const header = JSON.parse(
+    Buffer.from(buffer, base + 4, headerLength).toString("utf8"),
+  );
+  if (header.format !== FORMAT) {
+    throw new Error(`not a band payload: format is "${header.format}", not "${FORMAT}"`);
+  }
+  if (header.version !== VERSION) {
+    throw new Error(`band payload version ${header.version}; this reader knows ${VERSION}`);
+  }
+
+  const bodyOffset = base + align4(4 + headerLength);
+  const { count, geometry, strandIds, kinds } = header.band;
+
+  return {
+    header,
+    geometry: new Float32Array(buffer, bodyOffset + geometry.byteOffset, count * 6),
+    strandIds: new Uint16Array(buffer, bodyOffset + strandIds.byteOffset, count),
+    kinds: new Uint8Array(buffer, bodyOffset + kinds.byteOffset, count),
+  };
+}
+
+/**
+ * The band data a payload describes, in the shape `emit-document.mjs` takes.
+ *
+ * Not part of the wire contract — it is how the tests ask "is the picture still
+ * the same picture", by writing the document back out of what a client would
+ * have received and comparing it to the one the server serves. The geometry
+ * comes back through Float32, so the numbers are the layout's rounded to single
+ * precision and nothing else.
+ */
+export function bandDataFromPayload(payload) {
+  const { header, geometry, strandIds, kinds } = decodeBandPayload(payload);
+  const { corners, connectors } = header.reversals;
+
+  const total = header.band.count + corners.length + connectors.length;
+  const bands = new Array(total);
+  for (const shape of [...corners, ...connectors]) bands[shape.order] = shape;
+
+  let index = 0;
+  for (let order = 0; order < total; order += 1) {
+    if (bands[order] !== undefined) continue;
+    const at = index * 6;
+    bands[order] = {
+      kind: kinds[index] === KIND_RECT ? "rect" : "curve",
+      strand: strandIds[index],
+      x0: geometry[at],
+      y0: geometry[at + 1],
+      x1: geometry[at + 2],
+      y1: geometry[at + 3],
+      controlTop: geometry[at + 4],
+      controlBottom: geometry[at + 5],
+      alpha: header.band.alpha,
+    };
+    index += 1;
+  }
+
+  // The `order` a reversal shape rode in on is transport, not picture: it says
+  // where the shape goes, and once it is there it has served its purpose.
+  for (const band of bands) delete band.order;
+
+  return {
+    document: header.document,
+    // Back into the spelling `emit-document.mjs` takes. The document writes
+    // `rgb(r, g, b)` for a colour of either spelling, so nothing is lost by
+    // having travelled as channels.
+    strands: header.strands.map((strand) => ({
+      ...strand,
+      color: `rgb(${strand.color.join(", ")})`,
+    })),
+    bands,
+    segments: header.segments,
+    overlays: header.overlays,
+  };
+}
+
+/**
+ * One row of the strand table, as it goes on the wire.
+ *
+ * The layout's own row, with the colour resolved to channels. Everything else
+ * passes through: the id `pgb` indexes by, the `sample#haplotype#contig#…` name
+ * `vg` produced, and the PCLAI placement, each said once for the whole document.
+ */
+function strandRow(strand) {
+  const color = rgbChannels(strand.color);
+  if (color === null) {
+    throw new Error(
+      `strand ${strand.id} is coloured "${strand.color}", which is neither #rrggbb ` +
+        "nor rgb(r, g, b). The band payload says a colour as its three channels, so " +
+        "a spelling it cannot read is one it cannot carry.",
+    );
+  }
+  return { ...strand, color };
+}
+
+function align4(bytes) {
+  return (bytes + 3) & ~3;
+}
+
+function assertAddressable(strands) {
+  if (strands.length <= MAX_STRAND_ROWS) return;
+  throw new Error(
+    `this document has ${strands.length} strand rows, and a band names its strand ` +
+      `in 16 bits, which addresses ${MAX_STRAND_ROWS}. The band format cannot carry ` +
+      "this document; request it as SVG, or widen the strand id — silently wrapping " +
+      "would colour bands from the wrong strand.",
+  );
+}
+
+function assertStrand(band, order, rows) {
+  const { strand } = band;
+  if (Number.isInteger(strand) && strand >= 0 && strand < rows) return;
+  throw new Error(
+    `the band at position ${order} names strand row ${strand}, which is not a row of ` +
+      `the ${rows}-row strand table. Every band must resolve into the table it is ` +
+      "sent with.",
+  );
+}
+
+function assertAlpha(band, order) {
+  if (band.alpha === BAND_ALPHA) return;
+  throw new Error(
+    `the band at position ${order} is drawn at opacity ${band.alpha}, and every band ` +
+      `in a tube map is drawn at ${BAND_ALPHA}. The opacity is said once in the ` +
+      "header rather than on every band, so a band of any other opacity is one this " +
+      "format cannot carry. The layout draws one only for a read, which this fork " +
+      "does not render.",
+  );
+}

--- a/seqtubemap/emit-document.mjs
+++ b/seqtubemap/emit-document.mjs
@@ -35,7 +35,7 @@
 // band's `d` attribute already built; now it hands over the six numbers the
 // attribute encoded, and the drawing command is written here — so this module is
 // the one place a band becomes a drawing at all.
-import { BAND_THICKNESS } from "./band-data.mjs";
+import { BAND_THICKNESS, rgbChannels } from "./band-data.mjs";
 
 /** The document this band data describes, in full. */
 export function emitDocument(bandData) {
@@ -216,22 +216,8 @@ function css(declarations) {
 // can parse. This is not new rounding: the emulated document rounded here too,
 // in jsdom's CSS serializer, half away from zero, and this reproduces that.
 function cssColor(color) {
-  const hex = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color);
-  if (!hex) return wholeChannels(color); // already `rgb(r, g, b)` — what a PCLAI scheme supplies
-  const [r, g, b] = hex.slice(1).map((pair) => parseInt(pair, 16));
-  return `rgb(${r}, ${g}, ${b})`;
-}
-
-// `rgb(r, g, b)` with each channel a whole number in 0..255, as a stylesheet
-// would serialize it. Anything that is not that spelling is left alone.
-function wholeChannels(color) {
-  const rgb = /^rgb\(\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*\)$/.exec(String(color));
-  if (!rgb) return color;
-  const channels = rgb.slice(1).map((channel) => {
-    const value = Math.round(Number(channel));
-    return Math.min(255, Math.max(0, value));
-  });
-  return `rgb(${channels.join(", ")})`;
+  const channels = rgbChannels(color);
+  return channels === null ? color : `rgb(${channels.join(", ")})`;
 }
 
 // A non-breaking space is written as an entity wherever it appears — in an

--- a/seqtubemap/generate-bands.mjs
+++ b/seqtubemap/generate-bands.mjs
@@ -1,0 +1,19 @@
+// CLI over the sequence tube map renderer: vg JSON in, one band payload out.
+// This is the process `/seqtubemap?format=bands` spawns, and it is
+// `generate-svg.mjs` with the other sink — the same render, written to the wire
+// as numbers rather than as a drawing document (see `band-payload.mjs`).
+import { writeFileSync } from "fs";
+
+import { encodeBandPayload } from "./band-payload.mjs";
+import { runGenerator } from "./generator-cli.mjs";
+
+const { outputFile, render } = await runGenerator(
+  "Usage: node generate-bands.mjs <input.json> <output.bands> <startloc> <endloc> <nodeWidthOption> [pclaiColorSchemeJson]",
+);
+
+// The document is never built on this route: `renderTubeMap` writes it on first
+// access and nothing here asks. It stays *derivable* — the payload carries
+// everything `emit-document.mjs` reads — but a request for bands pays for
+// neither the string building nor the megabytes.
+writeFileSync(outputFile, encodeBandPayload(render.bandData));
+console.log(`band payload written to ${outputFile}`);

--- a/seqtubemap/generate-svg.mjs
+++ b/seqtubemap/generate-svg.mjs
@@ -1,36 +1,15 @@
 // CLI over the sequence tube map renderer: vg JSON in, one SVG document out.
 // This is the process `/seqtubemap` spawns. The render itself lives in
 // `render.mjs`, so that a caller inside Node can render without spawning
-// anything.
+// anything, and the command line lives in `generator-cli.mjs`, which this
+// shares with the band generator.
 import { writeFileSync } from "fs";
 
-import { renderTubeMap } from "./render.mjs";
+import { runGenerator } from "./generator-cli.mjs";
 
-if (process.argv.length < 7 || process.argv.length > 8) {
-  console.error(`Error: 5 or 6 arguments required, got ${process.argv.length - 2}`);
-  console.error(`Usage: node generate-svg.mjs <input.json> <output.svg> <startloc> <endloc> <nodeWidthOption> [pclaiColorSchemeJson]`);
-  process.exit(1);
-}
+const { outputFile, render } = await runGenerator(
+  "Usage: node generate-svg.mjs <input.json> <output.svg> <startloc> <endloc> <nodeWidthOption> [pclaiColorSchemeJson]",
+);
 
-const inputFile  = process.argv[2];
-const outputFile = process.argv[3];
-const start = parseInt(process.argv[4]);
-const end = parseInt(process.argv[5]);
-const nodeWidthOption = process.argv[6];
-const pclaiColorSchemeArg = process.argv[7]; // optional
-
-let pclaiColorScheme = null;
-if (pclaiColorSchemeArg !== undefined) {
-  pclaiColorScheme = JSON.parse(pclaiColorSchemeArg);
-}
-
-const { document } = await renderTubeMap({
-  inputFile,
-  start,
-  end,
-  nodeWidthOption,
-  pclaiColorScheme,
-});
-
-writeFileSync(outputFile, document, "utf8");
+writeFileSync(outputFile, render.document, "utf8");
 console.log(`SVG written to ${outputFile}`);

--- a/seqtubemap/generator-cli.mjs
+++ b/seqtubemap/generator-cli.mjs
@@ -1,0 +1,49 @@
+// The command line both generators take.
+//
+// `/seqtubemap` spawns one of two processes — `generate-svg.mjs` for the
+// document, `generate-bands.mjs` for the band payload — and they differ only in
+// which sink they write. The arguments are the same six, in the same order,
+// because they are the same render: the endpoint builds one command line for
+// both (`_render_seq_tube_map`, main.py), so the two have to agree on it, and
+// agreeing by construction beats agreeing by inspection.
+import { renderTubeMap } from "./render.mjs";
+
+/**
+ * Run one generator: parse `process.argv`, render, and hand the caller the
+ * result to write.
+ *
+ * @param {string} usage  the generator's own usage line, for a bad invocation
+ * @returns {{outputFile: string, render: {bandData: object, document: string}}}
+ *   The render is handed over whole rather than spread, because its `document`
+ *   is built on first access — spreading it would build one for the generator
+ *   that does not want it.
+ */
+export async function runGenerator(usage) {
+  if (process.argv.length < 7 || process.argv.length > 8) {
+    console.error(`Error: 5 or 6 arguments required, got ${process.argv.length - 2}`);
+    console.error(usage);
+    process.exit(1);
+  }
+
+  const inputFile = process.argv[2];
+  const outputFile = process.argv[3];
+  const start = parseInt(process.argv[4]);
+  const end = parseInt(process.argv[5]);
+  const nodeWidthOption = process.argv[6];
+  const pclaiColorSchemeArg = process.argv[7]; // optional
+
+  let pclaiColorScheme = null;
+  if (pclaiColorSchemeArg !== undefined) {
+    pclaiColorScheme = JSON.parse(pclaiColorSchemeArg);
+  }
+
+  const render = await renderTubeMap({
+    inputFile,
+    start,
+    end,
+    nodeWidthOption,
+    pclaiColorScheme,
+  });
+
+  return { outputFile, render };
+}

--- a/seqtubemap/render.mjs
+++ b/seqtubemap/render.mjs
@@ -45,7 +45,8 @@ async function layout() {
  * @param {number} options.end         the requested region's last base
  * @param {string} options.nodeWidthOption  "compressed", "normal" or "small"
  * @param {object|null} [options.pclaiColorScheme]
- * @returns {{document: string, bandData: object}}
+ * @returns {{document: string, bandData: object}} `document` is built on first
+ *   access and not before, so a caller wanting only the band data builds none.
  */
 export async function renderTubeMap({
   inputFile,
@@ -83,5 +84,18 @@ export async function renderTubeMap({
 
   // The document and the band data cannot disagree about the picture, because
   // there is only one of them: the document *is* the band data, written out.
-  return { document: emitDocument(bandData), bandData };
+  //
+  // Written out on demand, though. The band route (`generate-bands.mjs`) never
+  // asks for it, and building it means concatenating up to 12.58 MB of string
+  // that nothing then reads — so it is a memoized getter rather than a field. A
+  // caller that takes it once pays what it always paid; a caller that never
+  // takes it pays nothing.
+  let document = null;
+  return {
+    bandData,
+    get document() {
+      if (document === null) document = emitDocument(bandData);
+      return document;
+    },
+  };
 }

--- a/tests/node/band-payload.test.mjs
+++ b/tests/node/band-payload.test.mjs
@@ -1,0 +1,342 @@
+// The wire format `/seqtubemap?format=bands` returns.
+//
+// Two claims are worth testing and one of them is the whole increment:
+//
+// * the payload is a *complete* description of the picture — the document the
+//   endpoint serves today can be written back out of it, band for band, box for
+//   box, with nothing but single-precision rounding between the two; and
+// * the numbers a client reads out of the bytes are the numbers the layout
+//   held, rounded to Float32 and not otherwise touched.
+//
+// The second is checked against the emitted document through `pgb`'s own
+// parser, so the two encodings are compared the way the client compares them
+// rather than the way this repository would prefer to.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  FORMAT,
+  GEOMETRY_FIELDS,
+  KIND_CURVE,
+  KIND_RECT,
+  MAX_STRAND_ROWS,
+  VERSION,
+  bandDataFromPayload,
+  decodeBandPayload,
+  encodeBandPayload,
+} from "../../seqtubemap/band-payload.mjs";
+import { BAND_THICKNESS, curveBand, rectBand, rgbChannels } from "../../seqtubemap/band-data.mjs";
+import { emitDocument } from "../../seqtubemap/emit-document.mjs";
+import { renderTubeMap } from "../../seqtubemap/render.mjs";
+import { cases, inputPath, pclaiColorSchemeText, regionFor, repoRoot } from "./golden-cases.mjs";
+import { realCases, renderReal } from "./real-cases.mjs";
+import { readBands } from "./pgb-parser.mjs";
+
+/** Render one golden case in-process, the way the golden test renders it. */
+async function renderGolden(testCase) {
+  const file = inputPath(testCase);
+  const { start, end } = regionFor(JSON.parse(readFileSync(file, "utf8")));
+  const scheme = pclaiColorSchemeText(testCase);
+  return renderTubeMap({
+    inputFile: file,
+    start,
+    end,
+    nodeWidthOption: testCase.nodeWidthOption,
+    pclaiColorScheme: scheme === null ? null : JSON.parse(scheme),
+  });
+}
+
+/** A render of a single strand sent backwards through three segments. */
+async function renderReversal() {
+  const inputFile = join(mkdtempSync(join(tmpdir(), "tubemap-payload-")), "inverted.json");
+  const vg = JSON.parse(readFileSync(join(repoRoot, "tests", "fixtures", "tiny-vg.json"), "utf8"));
+  const mapping = vg.path[1].mapping;
+  vg.path[1].mapping = [
+    ...mapping.slice(0, 2),
+    ...mapping
+      .slice(2, 5)
+      .reverse()
+      .map((step) => ({ position: { ...step.position, is_reverse: true } })),
+    ...mapping.slice(5),
+  ];
+  writeFileSync(inputFile, JSON.stringify(vg), "utf8");
+  return renderTubeMap({ inputFile, start: 0, end: 69, nodeWidthOption: "compressed" });
+}
+
+/**
+ * The same band data, put through what the wire does to it — and only that.
+ *
+ * Two things: every band's geometry goes through Float32, and every strand's
+ * colour comes back in the one spelling the document writes, whichever of the
+ * two the layout used. A document written from this is what the payload can
+ * reproduce exactly.
+ */
+function throughTheWire(bandData) {
+  return {
+    ...bandData,
+    strands: bandData.strands.map((strand) => ({
+      ...strand,
+      color: `rgb(${rgbChannels(strand.color).join(", ")})`,
+    })),
+    bands: bandData.bands.map((band) => {
+      if (band.kind !== "rect" && band.kind !== "curve") return band;
+      const rounded = { ...band };
+      for (const field of GEOMETRY_FIELDS) rounded[field] = Math.fround(band[field]);
+      return rounded;
+    }),
+  };
+}
+
+test("the payload opens with its own length, and names the format and version", async () => {
+  const { bandData } = await renderGolden(cases[0]);
+  const payload = encodeBandPayload(bandData);
+
+  const headerLength = new DataView(payload.buffer, payload.byteOffset, 4).getUint32(0, true);
+  const header = JSON.parse(
+    Buffer.from(payload.buffer, payload.byteOffset + 4, headerLength).toString("utf8"),
+  );
+
+  assert.equal(header.format, FORMAT);
+  assert.equal(header.version, VERSION);
+  // A reader that knows only "uint32, then that many bytes of JSON" gets the
+  // whole map of the rest without knowing anything else about the format.
+  assert.ok(header.band.geometry.byteLength > 0);
+  assert.equal(payload.byteLength, ((4 + headerLength + 3) & ~3) + header.bodyLength);
+});
+
+test("the body is six floats, a strand id and a kind per band", async () => {
+  const { bandData } = await renderGolden(cases[0]);
+  const { header, geometry, strandIds, kinds } = decodeBandPayload(encodeBandPayload(bandData));
+
+  assert.equal(header.band.count, bandData.bands.length);
+  assert.equal(geometry.length, header.band.count * 6);
+  assert.equal(strandIds.length, header.band.count);
+  assert.equal(kinds.length, header.band.count);
+
+  bandData.bands.forEach((band, index) => {
+    GEOMETRY_FIELDS.forEach((field, offset) => {
+      assert.equal(geometry[index * 6 + offset], Math.fround(band[field]), `${field} of band ${index}`);
+    });
+    assert.equal(strandIds[index], band.strand);
+    assert.equal(kinds[index], band.kind === "rect" ? KIND_RECT : KIND_CURVE);
+  });
+});
+
+test("a per-strand value appears exactly once", async () => {
+  const { bandData, document } = await renderGolden(cases[1]);
+  const payload = encodeBandPayload(bandData);
+  const { header } = decodeBandPayload(payload);
+
+  // The claim is about the payload, so it is checked over the payload's bytes:
+  // a strand's name occurs once in the whole of it, where the document repeats
+  // it on every band the strand draws.
+  const text = Buffer.from(payload).toString("latin1");
+  for (const strand of header.strands) {
+    const inPayload = text.split(strand.name).length - 1;
+    const inDocument = document.split(strand.name).length - 1;
+    assert.equal(inPayload, 1, `${strand.name} appears ${inPayload} times in the payload`);
+    assert.ok(inDocument > 1, `${strand.name} appears once in the document too — pick a busier case`);
+  }
+
+  // And the thickness and the opacity, which the document says per band and
+  // this says per document.
+  assert.equal(header.band.thickness, BAND_THICKNESS);
+  assert.equal(header.band.alpha, 1);
+});
+
+test("every band's strand id resolves into the strand table, with no gaps", async () => {
+  for (const name of realCases.slice(0, 2)) {
+    const { bandData } = await renderReal(name);
+    const { header, strandIds } = decodeBandPayload(encodeBandPayload(bandData));
+
+    const used = new Set(strandIds);
+    for (const row of used) {
+      assert.ok(header.strands[row] !== undefined, `band names row ${row}, which is not in the table`);
+    }
+    // No dangling ids in the other direction either: the table's own ids are
+    // the dense 0..n-1 `pgb` indexes by.
+    const ids = header.strands.map((strand) => strand.id).sort((a, b) => a - b);
+    assert.deepEqual(ids, ids.map((_, index) => index));
+  }
+});
+
+test("the document the endpoint serves can be written back out of the payload", async () => {
+  // The strongest thing this format can claim: nothing about the picture is
+  // left behind. The only difference permitted between the two is Float32.
+  const goldens = await Promise.all(cases.map(renderGolden));
+  const renders = [...goldens, await renderReversal()];
+
+  for (const { bandData, document } of renders) {
+    const rebuilt = bandDataFromPayload(encodeBandPayload(bandData));
+    assert.deepEqual(rebuilt, throughTheWire(bandData));
+    assert.equal(emitDocument(rebuilt), emitDocument(throughTheWire(bandData)));
+
+    // Float32 is a real difference and this is what it is: the layout's
+    // coordinates are doubles — `138.71428571428573` — and a client receives
+    // `138.7142791748047`. So the rebuilt document is the served document to
+    // single precision, which is the bar, rather than byte for byte, which
+    // 32-bit floats cannot meet and `pgb`'s Float32 instance buffer does not
+    // want. `the numbers a client reads are the numbers pgb recovers` is where
+    // that equality is checked at the precision it actually holds at.
+    assertSameDocument(emitDocument(rebuilt), document, bandData.document.width);
+  }
+});
+
+/**
+ * Two documents that differ only in the precision their numbers carry.
+ *
+ * Everything that is not a number has to match character for character; every
+ * number has to agree to within a Float32's resolution, which is what the wire
+ * costs. Compared as numbers rather than as rounded text because rounding
+ * decides the wrong way at its own boundary: the layout's `79.648053` and the
+ * Float32 `79.648048` are the same band, and no number of significant figures
+ * makes them the same string.
+ */
+const NUMBER = /-?\d+(?:\.\d+)?/g;
+
+function assertSameDocument(actual, expected, extent) {
+  assert.equal(actual.replace(NUMBER, "#"), expected.replace(NUMBER, "#"));
+
+  const tolerance = Math.max(1, extent) * 1e-6;
+  const theirs = expected.match(NUMBER).map(Number);
+  actual.match(NUMBER).forEach((text, index) => {
+    const mine = Number(text);
+    assert.ok(
+      Math.abs(mine - theirs[index]) <= tolerance,
+      `number ${index}: ${mine} is not ${theirs[index]} to Float32`,
+    );
+  });
+}
+
+test("the numbers a client reads are the numbers pgb recovers from the document", async () => {
+  // The exact claim, and the one the ticket asks about: band geometry and the
+  // document rendered from the same layout agree. Read back through `pgb`'s own
+  // parser rather than this repository's idea of one, because the two encodings
+  // have to agree where the client compares them — and over all five real
+  // subgraphs, 101,742 bands, rather than the smallest one, because "exactly"
+  // is a claim about every band there is.
+  //
+  // Exact equality, not a tolerance: `Math.fround` is the whole of what the
+  // wire does to a number, so the payload's value is the document's value
+  // rounded once, and nothing else may have happened to it.
+  for (const name of realCases) {
+    const { bandData, document } = await renderReal(name);
+    const { geometry, strandIds, header } = decodeBandPayload(encodeBandPayload(bandData));
+    const { matched, counted } = readBands(document);
+
+    assert.equal(matched.length, counted, `pgb could not read the whole of ${name}`);
+    assert.equal(matched.length, header.band.count);
+
+    matched.forEach((band, index) => {
+      GEOMETRY_FIELDS.forEach((field, offset) => {
+        assert.equal(
+          geometry[index * 6 + offset],
+          Math.fround(band[field]),
+          `${field} of band ${index} of ${name}`,
+        );
+      });
+      assert.equal(header.strands[strandIds[index]].id, band.id);
+      assert.equal(header.strands[strandIds[index]].name, band.name);
+    });
+  }
+});
+
+test("segment boxes travel whole, with their sequences", async () => {
+  const { bandData } = await renderReal(realCases[0]);
+  const { header } = decodeBandPayload(encodeBandPayload(bandData));
+
+  assert.deepEqual(header.segments, bandData.segments);
+  assert.ok(header.segments.length > 0);
+  for (const segment of header.segments) {
+    assert.equal(typeof segment.id, "string");
+    assert.ok(segment.outline.startsWith("M "), segment.outline);
+    assert.match(segment.sequence, /^[ACGTN]+$/);
+  }
+});
+
+test("a reversal's corners and connectors keep their place in the draw order", async () => {
+  const { bandData } = await renderReversal();
+  const { header } = decodeBandPayload(encodeBandPayload(bandData));
+  const { corners, connectors } = header.reversals;
+
+  assert.ok(corners.length > 0 && connectors.length > 0, "this render drew no reversal");
+  // They are not in the body — the body is bands, and neither of these is one.
+  assert.equal(header.band.count, bandData.bands.length - corners.length - connectors.length);
+
+  // Where each one sits in the picture is what the `order` carries, and it is
+  // the position it held among all the shapes the layout drew.
+  for (const shape of [...corners, ...connectors]) {
+    const original = bandData.bands[shape.order];
+    assert.equal(original.kind, shape.kind);
+    assert.equal(original.strand, shape.strand);
+  }
+});
+
+test("a strand table too large to address is refused, not wrapped", () => {
+  const strands = Array.from({ length: MAX_STRAND_ROWS + 1 }, (_, id) => ({
+    id,
+    name: `strand-${id}`,
+    color: "rgb(1, 2, 3)",
+  }));
+
+  assert.throws(
+    () => encodeBandPayload({ document: {}, strands, bands: [], segments: [], overlays: [] }),
+    /16 bits/,
+  );
+});
+
+test("a band the format cannot carry throws where the layout is still in scope", () => {
+  const strands = [{ id: 0, name: "one", color: "rgb(1, 2, 3)" }];
+  const base = { document: {}, strands, segments: [], overlays: [] };
+  const band = rectBand({ strand: 0, x: 0, y: 0, width: 10, height: BAND_THICKNESS, alpha: 1 });
+
+  // A band pointing outside the table it is sent with: the failure the strand
+  // id being an index rather than a name makes possible, caught here.
+  assert.throws(
+    () => encodeBandPayload({ ...base, bands: [{ ...band, strand: 7 }] }),
+    /not a row of the 1-row strand table/,
+  );
+
+  // An opacity the header cannot say once for everyone.
+  assert.throws(
+    () => encodeBandPayload({ ...base, bands: [{ ...band, alpha: 0.4 }] }),
+    /opacity 0.4/,
+  );
+
+  // A corner names a strand too, even though the document writes no name on
+  // one, so a dangling index has to be caught there as well as on a band.
+  assert.throws(
+    () => encodeBandPayload({ ...base, bands: [{ kind: "corner", strand: 3, x: 0, y: 0, radius: 5, bend: 2, turn: "top", direction: "rightward" }] }),
+    /not a row of the 1-row strand table/,
+  );
+
+  // A kind nothing knows how to encode, which would otherwise be written as a
+  // curve with undefined coordinates — a plausible shape in the wrong place.
+  assert.throws(
+    () => encodeBandPayload({ ...base, bands: [{ ...band, kind: "spiral" }] }),
+    /"spiral" is not one this format can carry/,
+  );
+
+  // And the shape of a well-formed one, for contrast.
+  const curve = curveBand({
+    strand: 0,
+    x0: 0,
+    y0: 0,
+    x1: 10,
+    y1: 5,
+    controlTop: 5,
+    controlBottom: 5,
+    thickness: BAND_THICKNESS,
+    alpha: 1,
+  });
+  assert.equal(decodeBandPayload(encodeBandPayload({ ...base, bands: [curve] })).kinds[0], KIND_CURVE);
+});
+
+test("a payload that is not one says so", () => {
+  const notAPayload = Buffer.alloc(64);
+  assert.throws(() => decodeBandPayload(notAPayload), /not a band payload|Unexpected/);
+  assert.throws(() => decodeBandPayload(Buffer.alloc(2)), /at least 4 bytes/);
+});

--- a/tests/python/test_pipeline_failures.py
+++ b/tests/python/test_pipeline_failures.py
@@ -226,27 +226,35 @@ def test_a_walkless_cache_entry_is_re_extracted(client, cache, main_module, monk
     assert "gfa_to_vg" in response.json()["detail"]
 
 
+# The renders, stubbed together wherever a test is about some other stage.
+RENDERS = ("ConvertGfaToVg", "ConvertVgToJson", "GenerateSeqTubeMapSvg", "GenerateSeqTubeMapBands")
+
+
 @pytest.mark.parametrize(
-    "stage, stubbed",
+    "stage, stubbed, params",
     [
-        ("gfa_to_vg", "ConvertGfaToVg"),
-        ("vg_to_json", "ConvertVgToJson"),
-        ("generate_svg", "GenerateSeqTubeMapSvg"),
+        ("gfa_to_vg", "ConvertGfaToVg", REQUEST),
+        ("vg_to_json", "ConvertVgToJson", REQUEST),
+        ("generate_svg", "GenerateSeqTubeMapSvg", REQUEST),
+        # The band route's render is a different script and can fail for its own
+        # reasons — a document too large for a 16-bit strand id, for one — so it
+        # has to name itself rather than borrow the document route's name.
+        ("generate_bands", "GenerateSeqTubeMapBands", {**REQUEST, "format": "bands"}),
     ],
 )
-def test_a_failing_stage_names_itself(client, cache, main_module, monkeypatch, stage, stubbed):
+def test_a_failing_stage_names_itself(client, cache, main_module, monkeypatch, stage, stubbed, params):
     """Each stage in turn, because each one used to fail the same anonymous way.
 
-    All three already returned a boolean nobody read. The response now carries
+    All of them already returned a boolean nobody read. The response now carries
     the name of the one that returned False, and the tool's own stderr goes to
     the log next to it.
     """
     shutil.copy(SUBGRAPH, cache / SUBGRAPH.name)
-    for name in ("ConvertGfaToVg", "ConvertVgToJson", "GenerateSeqTubeMapSvg"):
+    for name in RENDERS:
         monkeypatch.setattr(main_module, name, lambda *args, **kwargs: True)
     monkeypatch.setattr(main_module, stubbed, lambda *args, **kwargs: False)
 
-    response = client.get("/seqtubemap", params=REQUEST)
+    response = client.get("/seqtubemap", params=params)
 
     assert response.status_code == 502
     assert stage in response.json()["detail"]
@@ -260,7 +268,7 @@ def test_a_render_that_writes_no_document_is_reported(client, cache, main_module
     built rather than by it.
     """
     shutil.copy(SUBGRAPH, cache / SUBGRAPH.name)
-    for name in ("ConvertGfaToVg", "ConvertVgToJson", "GenerateSeqTubeMapSvg"):
+    for name in RENDERS:
         monkeypatch.setattr(main_module, name, lambda *args, **kwargs: True)
 
     response = client.get("/seqtubemap", params=REQUEST)

--- a/tests/python/test_seqtubemap_band_format.py
+++ b/tests/python/test_seqtubemap_band_format.py
@@ -1,0 +1,293 @@
+"""`/seqtubemap?format=bands`: the band payload, over the endpoint.
+
+The band route returns the numbers the layout computed instead of a drawing
+document that encodes them — a JSON header carrying the document's dimensions,
+the strand table and the segment boxes, and a binary body carrying six floats
+and a strand id per band. `docs/band-format.md` is the specification; this file
+is what holds the endpoint to it.
+
+What is checked here is what a *client* can observe: that the parameter selects
+the format, that an unrecognised value is refused rather than quietly served as
+SVG, that omitting it returns exactly what the endpoint returned before, and
+that the payload is complete enough to draw from — every band's strand id
+resolving into the table, every per-strand value appearing once.
+
+The renders run for real. `vg` does not: this file stands in for the two `vg`
+stages with the committed conversion of the same subgraph, which is exactly
+what they would have produced, so the Node render downstream is the real one.
+That is deliberate — the band payload is written by that render and by nothing
+else, and a test that stubbed it would be testing its own stub.
+"""
+
+import json
+import os
+import shutil
+import struct
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "seqtubemap"
+
+# The same 90 bp subgraph the other endpoint tests use — chr8:78,771,162-78,771,252
+# over 9 segments and 464 strands. The endpoint builds these filenames from the
+# query parameters below, which is what makes the cache hit.
+CHROM, START, END, VERSION = "chr8", 78771162, 78771252, "v2"
+NAME = f"subgraph_{CHROM}_{START}_{END}_{VERSION}"
+SUBGRAPH = FIXTURES / f"{NAME}_with_walk.gfa"
+VG_JSON = FIXTURES / f"{NAME}_with_walk.json"
+REQUEST = {"chrom": CHROM, "start": START, "end": END, "version": VERSION}
+
+
+def parse_payload(content: bytes) -> tuple[dict, memoryview]:
+    """A band payload, read the way `docs/band-format.md` says to read one.
+
+    Written out here rather than imported: the specification's whole claim is
+    that a parser can be written against it without reading the server, and a
+    test that called the server's own encoder back would not be evidence of
+    that. Four lines is the whole of it.
+    """
+    (header_length,) = struct.unpack_from("<I", content, 0)
+    header = json.loads(content[4 : 4 + header_length])
+    body = memoryview(content)[(4 + header_length + 3) & ~3 :]
+    return header, body
+
+
+@pytest.fixture(scope="module")
+def bands_workdir(main_module, tmp_path_factory):
+    """A working directory holding the subgraph and its `vg` conversion.
+
+    Every path the endpoint builds is relative to the process's working
+    directory, so a test that wants to control the cache has to own the working
+    directory too. The `.json` is placed where `vg view -j` would have written
+    it; `vg_stages` is what stops the pipeline overwriting it.
+    """
+    workdir = tmp_path_factory.mktemp("bands")
+    cache = workdir / "cache" / "seqtubemap" / "mc"
+    cache.mkdir(parents=True)
+    shutil.copy(SUBGRAPH, cache / SUBGRAPH.name)
+    # `generate_bands_js_script` is relative too, so the generator has to be
+    # reachable from the new working directory. A symlink keeps its real path
+    # inside the repository, where `node_modules` is.
+    (workdir / "seqtubemap").symlink_to(REPO_ROOT / "seqtubemap")
+    return workdir
+
+
+@pytest.fixture(scope="module")
+def bands_client(client, node_stage, bands_workdir, main_module):
+    """A client whose requests run from that directory, with `vg` stood in for.
+
+    The two `vg` stages become a copy of the committed conversion of this very
+    subgraph — the same bytes `vg convert -g` and `vg view -j` produce from it,
+    obtained from the live server (tests/fixtures/seqtubemap/README.md) — so
+    everything from the Node render onwards is real without needing `vg` on the
+    machine.
+    """
+    cache = bands_workdir / "cache" / "seqtubemap" / "mc"
+
+    def convert_to_vg(gfa_file, vg_file):
+        Path(vg_file).write_bytes(b"")  # only its existence is checked
+        return True
+
+    def convert_to_json(vg_file, json_file):
+        shutil.copy(VG_JSON, json_file)
+        return True
+
+    previous = Path.cwd()
+    os.chdir(bands_workdir)
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(main_module, "SubgraphMC", lambda *args, **kwargs: None)
+        patch.setattr(main_module, "GenerateWalksMC", lambda *args, **kwargs: None)
+        patch.setattr(main_module, "ConvertGfaToVg", convert_to_vg)
+        patch.setattr(main_module, "ConvertVgToJson", convert_to_json)
+        try:
+            yield client
+        finally:
+            os.chdir(previous)
+    assert (cache / SUBGRAPH.name).exists(), "the subgraph left the cache"
+
+
+@pytest.fixture(scope="module")
+def payload(bands_client):
+    """The response to one `format=bands` request, parsed."""
+    response = bands_client.get("/seqtubemap", params={**REQUEST, "format": "bands"})
+    assert response.status_code == 200, response.text
+    return response, *parse_payload(response.content)
+
+
+# --- the parameter ----------------------------------------------------------
+
+
+def test_an_unrecognised_format_is_refused(client):
+    """Refused, and refused *before* the pipeline runs.
+
+    Serving the default instead would hand a client that asked for numbers a
+    document it cannot read — a failure that surfaces in the other repository,
+    far from its cause. Needs neither `vg` nor Node: nothing has run yet when
+    the request is turned away.
+    """
+    response = client.get("/seqtubemap", params={**REQUEST, "format": "geojson"})
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "geojson" in detail
+    # And it says what it would have accepted, so the caller can fix it.
+    assert "bands" in detail and "svg" in detail
+
+
+def test_omitting_the_format_returns_what_it_always_did(bands_client):
+    """The additive claim, from the client's side.
+
+    The two repositories never have to deploy together, so a request that names
+    no format has to be the request it was before this parameter existed. What
+    this test can say is that omitting the parameter and passing `format=svg`
+    are the same bytes and the same media type — that the parameter has a
+    default and it is the document.
+
+    That the document itself did not move is held elsewhere, where the bytes
+    are actually pinned: the golden tests in `tests/node/` compare each render
+    against a committed document, byte for byte, and would fail if the render
+    had drifted. The two together are the claim; neither is it alone.
+    """
+    without = bands_client.get("/seqtubemap", params=REQUEST)
+    explicit = bands_client.get("/seqtubemap", params={**REQUEST, "format": "svg"})
+
+    assert without.status_code == 200
+    assert without.headers["content-type"].startswith("image/svg+xml")
+    assert without.content == explicit.content
+    assert without.content.startswith(b'<svg id="mysvg"')
+
+
+# --- what the band payload carries ------------------------------------------
+
+
+def test_the_payload_is_a_json_header_and_a_binary_body(payload):
+    response, header, body = payload
+
+    assert response.headers["content-type"].startswith("application/octet-stream")
+    assert header["format"] == "pangenome-bands"
+    assert header["version"] == 1
+    # The header maps the rest of the response, so a reader that knows only the
+    # length prefix can reach every section of the body.
+    assert len(body) == header["bodyLength"]
+    assert header["band"]["kinds"]["byteOffset"] + header["band"]["count"] <= len(body)
+
+
+def test_the_header_carries_the_documents_dimensions(payload):
+    _, header, _ = payload
+
+    document = header["document"]
+    assert document["width"] > 0 and document["height"] > 0
+    # The viewBox is the client's coordinate system; without it there is nothing
+    # to draw the bands into.
+    assert document["viewBox"].split() == [
+        "0",
+        str(document["extent"]["minYCoordinate"] - 20),
+        str(document["width"]),
+        str(document["height"]),
+    ]
+
+
+def test_the_strand_table_is_complete_and_says_each_value_once(payload):
+    """The 41-47% of every SVG response that is per-strand values repeated.
+
+    Here each one is a row: an id, a colour, a name and a PCLAI placement, said
+    once for the whole document however many bands the strand draws.
+    """
+    _, header, _ = payload
+
+    strands = header["strands"]
+    assert len(strands) == 464, "this subgraph carries 464 strands"
+    for strand in strands:
+        assert set(strand) >= {"id", "name", "color", "pclaiX", "pclaiY", "pclaiScore"}
+        # Three whole channels, not CSS: a client building a GPU buffer gets
+        # numbers rather than the two spellings the layout writes.
+        assert len(strand["color"]) == 3
+        assert all(0 <= channel <= 255 and isinstance(channel, int) for channel in strand["color"])
+
+    # `pgb` indexes tables by trackID, so the ids have to be exactly 0..n-1 —
+    # no gaps, and nothing beyond the end.
+    assert sorted(strand["id"] for strand in strands) == list(range(len(strands)))
+    # And a name belongs to one row, which is what "exactly once" means here.
+    names = [strand["name"] for strand in strands]
+    assert len(set(names)) == len(names)
+
+
+def test_every_bands_strand_id_resolves_into_the_table(payload):
+    _, header, body = payload
+
+    count = header["band"]["count"]
+    assert count > 0
+    ids = header["band"]["strandIds"]
+    assert ids["type"] == "Uint16"
+
+    strand_ids = struct.unpack_from(f"<{count}H", body, ids["byteOffset"])
+    assert len(strand_ids) == count
+    assert max(strand_ids) < len(header["strands"])
+    # Not one strand drawn over and over: this is a population of strands.
+    assert len(set(strand_ids)) > 1
+
+
+def test_the_geometry_is_six_floats_a_band(payload):
+    _, header, body = payload
+
+    count = header["band"]["count"]
+    geometry = header["band"]["geometry"]
+    assert geometry["type"] == "Float32"
+    assert geometry["fields"] == ["x0", "y0", "x1", "y1", "controlTop", "controlBottom"]
+    assert geometry["byteLength"] == count * 6 * 4
+
+    values = struct.unpack_from(f"<{count * 6}f", body, geometry["byteOffset"])
+    width = header["document"]["width"]
+    for index in range(count):
+        x0, y0, x1, y1, control_top, control_bottom = values[index * 6 : index * 6 + 6]
+        assert 0 <= x0 <= x1 <= width, f"band {index} runs backwards or off the document"
+        # The control abscissae lie between the band's own ends, which is what
+        # makes the six values a band rather than an arbitrary cubic.
+        for control in (control_top, control_bottom):
+            assert x0 - 1 <= control <= x1 + 1, f"band {index} control {control} is outside it"
+        assert y0 == y0 and y1 == y1  # not NaN
+
+
+def test_the_segment_boxes_travel_with_their_sequences(payload):
+    """The segment boxes `pgb` reads today, carried whole rather than dropped.
+
+    Asserted against the `S` lines of the fixture that went in, so this says
+    the pipeline carried the right DNA through — not merely that boxes exist.
+    """
+    _, header, _ = payload
+
+    expected = {}
+    for line in SUBGRAPH.read_text().splitlines():
+        if line.startswith("S\t"):
+            _, segment_id, sequence = line.split("\t")[:3]
+            expected[segment_id] = sequence
+
+    segments = header["segments"]
+    assert {segment["sequence"] for segment in segments} == set(expected.values())
+    for segment in segments:
+        assert segment["outline"].startswith("M ")
+        assert segment["id"]
+
+
+def test_the_band_payload_is_a_fraction_of_the_document(bands_client, payload):
+    """The size the whole change is for, measured rather than projected.
+
+    The figures are recorded per region in `docs/band-format.md`; what is
+    asserted here is only the direction, so the numbers live in one place and
+    this test does not need re-baselining every time the layout moves a
+    coordinate.
+
+    This is the 90 bp region, where the win is smallest by a wide margin: 464
+    strands and only 592 bands, so the strand table — said once, but said in
+    full — is most of the payload. The ratio is a fraction on the regions that
+    matter, where the band count is in the tens of thousands.
+    """
+    response, header, _ = payload
+    document = bands_client.get("/seqtubemap", params=REQUEST)
+
+    assert len(response.content) < len(document.content), (
+        f"band payload {len(response.content)} B against a "
+        f"{len(document.content)} B document over {header['band']['count']} bands"
+    )


### PR DESCRIPTION
Closes #24. Increment C's wire format, on the server side of it.

`/seqtubemap` returned one thing: a drawing document, with every per-strand value re-serialized on every band and the geometry written as a command the client parsed back into numbers with a regular expression. `?format=bands` returns those numbers instead — a JSON header carrying the document's dimensions, the strand table and the segment boxes, and a binary body carrying six floats and a strand id per band.

**Additive, and checked to be.** Omitting the parameter returns the document byte for byte, and an unrecognised `format` is refused with a 400 before any stage runs rather than quietly served as SVG. The two repositories never have to deploy together, and the document stays the oracle the payload is checked against.

## Measured, not projected

ADR 0001 predicted "roughly 1.5 MB against the SVG's 10.07 MB" from the band count and the record width. Over the committed 7,967 bp subgraph — a document of the size that projection was about — it is **1.25 MB against 9.97 MB**. `perf/band-payload-sizes.mjs` reproduces the table.

| region | span | bands | SVG | band payload | ratio |
| --- | ---: | ---: | ---: | ---: | ---: |
| chr8:78,771,162-78,771,252 | 90 bp | 592 | 0.13 MB | 0.07 MB | 1.9× |
| chr1:25,331,046-25,331,646 | 600 bp | 8,089 | 2.25 MB | 0.28 MB | 8.1× |
| chr8:10,079,054-10,080,461 | 1.4 kb | 13,246 | 3.61 MB | 0.43 MB | 8.4× |
| chr1:25,301,271-25,309,238 | 8.0 kb | 35,020 | 9.97 MB | **1.25 MB** | 8.0× |
| chr1:25,331,646-25,335,796 | 4.2 kb | 44,795 | 12.58 MB | 1.40 MB | 9.0× |

The ratio is smallest where the response is smallest, which is the shape of the win rather than a defect: the 90 bp subgraph draws 592 bands over 464 strands, so its payload is almost all strand table.

## Three things the ticket left to the increment

* **The body is columnar**, not one interleaved 26-byte record per band. A `Float32Array` cannot be viewed over a buffer at an offset that is not a multiple of 4, so interleaved the client would copy the fields apart one at a time — the parse step this whole format exists to delete. Split into columns, the geometry column *is* the instance buffer.
* **A strand's colour travels as three whole channels**, not CSS. The layout spells a colour two ways and a PCLAI scheme can supply fractional channels (the live chr7 refusal of 2026-08-28), so the rounding happens once, on the server, in the function the document rounds with.
* **A reversal's corners and connectors ride in the header**, each carrying its place in the draw order, because paint order is document order. That is #52's answer on this route, and it needs nothing new from `pgb`. No production response contains one.

One byte per band is carried beyond the ticket's record — which element the document draws the band as. A client can ignore it; it is what makes the SVG reconstructible from the payload, so "the band data is canonical and the document is a rendering of it" is a fact the tests check rather than an intention.

## What holds it

* `docs/band-format.md` specifies the format well enough to write a parser against without reading the server. The Python tests parse the payload from that spec in four lines rather than calling the server's own decoder — a test that called the encoder back would not be evidence the spec is sufficient.
* The served document can be written back out of the payload — every golden, plus a synthetic reversal.
* The numbers a client reads out of the bytes are, to the bit, the numbers `pgb`'s own parser recovers from the document — over all five real subgraphs, **101,742 bands**. Exact equality, not a tolerance.
* Every refusal is pinned: a strand table too large for a 16-bit id, a band off the constant thickness or opacity, a dangling strand index (on a corner as well as a band), an unreadable colour, an unrecognised `format`.

Also: `renderTubeMap` now builds the document on first access, so a request for bands never builds one at all.

## Worth a reviewer's eye

* The 16-bit overflow reaches the client as a generic 502 naming the `generate_bands` stage, with the precise cause in the server log. That is how every other stage in this pipeline fails, so it is consistent — but the client never sees the reason.
* `reversal` and `band payload` are now client-visible terms with no `CONTEXT.md` entry. Not added here: that file is declared shared with `pgb`, so adding a term unilaterally is the divergence it forbids. Worth doing in both repos together.
* The default route's `[stage-timing]` log line changed `svg_mb=` to `format=… render_mb=`. The response is untouched; only the log field moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfNVBz1J8ki9Bpc7k456un