### PR TITLE
pclaiScore is an opaque string, not a number

### DIFF
--- a/docs/band-format.md
+++ b/docs/band-format.md
@@ -94,7 +94,7 @@ Python.
   },
   "strands": [
     { "id": 0, "name": "GRCh38#0#chr1", "color": [255, 115, 56],
-      "pclaiX": 0.12, "pclaiY": -0.43, "pclaiScore": 0.98 }
+      "pclaiX": 0.396, "pclaiY": -1.353, "pclaiScore": "993" }
   ],
   "segments": [
     { "id": "79337767", "outline": "M 11 20 Q 11 11 20 11 …",
@@ -129,6 +129,15 @@ layout's own ordering, dense from 0 with no gaps; `name` is the
 included; `color` is three whole channels in 0–255; the three `pclai*` fields are
 the strand's ancestry placement, and are `null` where the region has none. A
 strand's values appear here once, however many bands it draws.
+
+`pclaiX` and `pclaiY` are numbers, and they are coordinates in the ancestry
+cloud's own plane — nothing in this payload's geometry touches them.
+**`pclaiScore` is an opaque string**, not a number: it is usually an integer
+spelled as text (`"993"`), but real schemes also spell it `"impainted"`, on
+strands that *are* placed. That is a different kind of answer rather than a
+number with a bad value, so it travels verbatim and whoever displays it decides
+what the categories mean. A reader that parses it as a number either refuses
+real documents or turns a category into `NaN`.
 
 **`segments`** — the **segment** boxes, in draw order, each with the id, outline
 and sequence a client draws and labels from. The outline is a path command

--- a/tests/node/band-payload.test.mjs
+++ b/tests/node/band-payload.test.mjs
@@ -275,6 +275,31 @@ test("a reversal's corners and connectors keep their place in the draw order", a
   }
 });
 
+test("a strand's ancestry score travels verbatim, whatever it says", () => {
+  // `pclaiScore` looks like a number and is not one. Real schemes spell it
+  // `impainted` on strands that are placed — a different kind of answer, not a
+  // number with a bad value — and `pgb` carries it as an opaque string for
+  // exactly that reason (`parseBands.ts`). A payload that coerced it would
+  // either refuse those strands or turn a category into NaN, so this pins that
+  // the header carries what the layout handed over and nothing else.
+  const strands = [
+    { id: 0, name: "placed", color: "#ff0000", pclaiX: 0.396, pclaiY: -1.353, pclaiScore: "993" },
+    { id: 1, name: "impainted", color: "#00ff00", pclaiX: 0.1, pclaiY: 0.2, pclaiScore: "impainted" },
+    { id: 2, name: "nowhere", color: "#0000ff", pclaiX: null, pclaiY: null, pclaiScore: null },
+  ];
+
+  const { header } = decodeBandPayload(
+    encodeBandPayload({ document: {}, strands, bands: [], segments: [], overlays: [] }),
+  );
+
+  assert.deepEqual(
+    header.strands.map((strand) => strand.pclaiScore),
+    ["993", "impainted", null],
+  );
+  // The placement is numbers, and stays numbers.
+  assert.deepEqual(header.strands.map((strand) => strand.pclaiX), [0.396, 0.1, null]);
+});
+
 test("a strand table too large to address is refused, not wrapped", () => {
   const strands = Array.from({ length: MAX_STRAND_ROWS + 1 }, (_, id) => ({
     id,


### PR DESCRIPTION
Follow-up to #65, which merged before this commit was pushed — the fix was on the branch, not in the merge.

`docs/band-format.md` wrote a strand's score as `0.98`. It is not a number and never was: the band data carries it as text (`"993"`), and real schemes also spell it `"impainted"`, on strands that *are* placed. That is a different kind of answer rather than a number with a bad value, so it travels verbatim and whoever displays it decides what the categories mean. A reader that took the spec at its word would either refuse real documents or turn a category into `NaN`.

`pgb`'s `parseBands.ts` already carries it opaque, for exactly that reason, and says so.

The example now shows a real row, the `strands` paragraph says what each `pclai*` field is, and a test pins the contract — including the `impainted` spelling and the `null` a strand the inference placed nowhere carries.

Found while designing `pgb`'s reader against this spec, which is what a spec written to be read without the server is for. It is the first thing that spec was used for and it caught an error on the first pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfNVBz1J8ki9Bpc7k456un