### PR TITLE
CONTEXT.md: band payload, and reversal

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,27 @@ x-interval. A strand is made of many bands, so a band count counts shapes, not
 haplotypes.
 _Avoid_: ribbon, which reads as the whole strand.
 
+**band payload**:
+What `/seqtubemap?format=bands` returns: the same picture as the SVG document, said as
+the numbers themselves — a JSON header carrying the frame, the **strand** table and the
+segment boxes, then a columnar body of six `Float32`s, a `Uint16` and a `Uint8` per
+**band**. Specified in [`docs/band-format.md`](./docs/band-format.md). Additive: omitting
+`format` returns the document byte for byte. The band data is canonical and the document
+is a rendering of it.
+_Avoid_: "the binary format", which names how it is spelled rather than what it carries —
+the header is JSON.
+
+**reversal**:
+The shape a **strand** doubling back on itself draws: a pair of **corners** — quarter
+turns built from quadratics — and a **vertical connector**, a rectangle as tall as the
+reversal is deep rather than `thickness` tall. Outside the six-value **band** grammar, so
+they ride in the header's `reversals` rather than in the body, each with the `order` it
+occupied among the shapes the render drew. No production response contains one, and a
+client may reasonably refuse a response whose `reversals` are non-empty.
+_Avoid_: using it for an inverted haplotype. A reversal is a fact about the drawing; an
+inversion is a fact about the biology, and the haplotypes that traverse an inversion are
+drawn out of ordinary bands.
+
 **sequence tube map**:
 A base-resolution picture of what is inside one **node** — its **segments** laid
 along an axis with every **strand** threaded through them.


### PR DESCRIPTION
The two words `pgb`'s `CONTEXT.md` gains at [CAST-genomics/pgb#145](https://github.com/CAST-genomics/pgb/issues/145) ([pgb#149](https://github.com/CAST-genomics/pgb/pull/149)), landing here in the same window because the two files are shared and must not diverge.

**reversal** is the one worth the entry. It is *not* an inverted haplotype — it is the drawn shape a strand doubling back makes, of which a **corner** and a **vertical connector** are the parts, and the haplotypes that traverse an inversion are drawn out of ordinary bands. Two words a letter apart for different things, in two repos where both are live.

**band payload** names what `?format=bands` returns, with the `_Avoid_` line this repo's entries carry: not "the binary format", which names how it is spelled rather than what it carries — the header is JSON.

Docs only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZJpDT9SNDBPfmqrsLh8ZV
