### PR TITLE
The segment style fields are strings, and the format doc says so

### DIFF
--- a/docs/band-format.md
+++ b/docs/band-format.md
@@ -99,8 +99,8 @@ Python.
   "segments": [
     { "id": "79337767",
       "box": { "left": 11, "top": 11, "right": 76, "bottom": 5564, "radius": 9 },
-      "sequence": "AGAGCCTGTCTT…", "fill": "#ffffff", "fillOpacity": 0.4,
-      "stroke": "#000000", "strokeWidth": 2 }
+      "sequence": "AGAGCCTGTCTT…", "fill": "#ffffff", "fillOpacity": "0.4",
+      "stroke": "#000000", "strokeWidth": "2px" }
   ],
   "overlays": [],
   "reversals": { "corners": [], "connectors": [] },
@@ -167,6 +167,14 @@ The alternative was to add `box` beside `outline` and bump nothing, which the
 rule does allow. That was rejected: it would have kept the string in the format
 forever and left that first reader with two ways to find the same rectangle, one
 of them the parser this change exists to delete.
+
+`fill`, `fillOpacity`, `stroke` and `strokeWidth` are the box's appearance as the
+document spells it — the attribute values verbatim, strings and all, which is why
+`strokeWidth` carries its CSS unit (`"2px"`) and `fillOpacity` its decimal as
+text. They are on their way back out as attributes on the SVG route, so they
+travel as written rather than as numbers this format would have to spell back.
+A client that wants a number out of a dimension parses one, exactly as it would
+from the document.
 
 **`overlays`** — the ruler and the per-segment labels, when the render drew any:
 an element name, its attributes as ordered pairs, and its text. **Empty in every


### PR DESCRIPTION
`docs/band-format.md` documented a segment's `fillOpacity` and `strokeWidth` as numbers — `0.4` and `2`. The payload sends `"0.4"` and `"2px"`, verified against the post-#66 fixture `subgraph_chr8_78771162_78771252_v2_with_walk.band.json.gz`. The four appearance fields come through `tubemap.js` as the document's own attribute values and go back out as attributes on the SVG route, so they travel as written.

The doc is what a client is written against, and pgb's reader is being written from it now ([pgb#151](https://github.com/CAST-genomics/pgb/issues/151)). Its `SegmentBox.stroke` is a number its overlay does arithmetic with, so a reader trusting the spec turns `"2px"` into `NaN` and lays a border of the wrong width — silently, since `NaN` in a CSS length is an ignored declaration rather than an error. Same class as `pclaiScore` in #67, caught the same way: by reading the spec instead of the encoder.

**The document moves, not the payload.** No encoder change, no bytes move, `version` stays 1 — this corrects what the format claims, not what it sends.

The new paragraph sits after the #66 discussion rather than directly under the `segments` description, so that "It travelled as a path command" keeps pointing at the box.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QQpjq82mqv6GS2GQyoUrm